### PR TITLE
[Feat] ktlint 코드 스타일 검사 적용

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{kt,kts}]
+ktlint_code_style = ktlint_official
+max_line_length = 120

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("org.springframework.boot") version "4.0.5"
     id("io.spring.dependency-management") version "1.1.7"
     kotlin("plugin.jpa") version "2.2.21"
+    id("org.jlleitschuh.gradle.ktlint") version "12.3.0"
 }
 
 group = "com.team2"
@@ -45,6 +46,10 @@ allOpen {
     annotation("jakarta.persistence.Entity")
     annotation("jakarta.persistence.MappedSuperclass")
     annotation("jakarta.persistence.Embeddable")
+}
+
+ktlint {
+    version.set("1.6.0")
 }
 
 tasks.withType<Test> {

--- a/src/test/kotlin/com/team2/server/ServerApplicationTests.kt
+++ b/src/test/kotlin/com/team2/server/ServerApplicationTests.kt
@@ -5,9 +5,7 @@ import org.springframework.boot.test.context.SpringBootTest
 
 @SpringBootTest
 class ServerApplicationTests {
-
     @Test
     fun contextLoads() {
     }
-
 }


### PR DESCRIPTION
## 🔗 Issue
- closes #5

## 💬 Context
프로젝트에 ktlint를 적용하여 팀 전체가 일관된 Kotlin 코드 스타일을 유지할 수 있도록 합니다.

## 🛠 Changes
- ktlint Gradle 플러그인 (v12.3.0) 및 ktlint 엔진 v1.6.0 추가
- `.editorconfig` 생성 (`ktlint_official` 스타일, max line length 120)
- 기존 코드 ktlint 자동 포맷팅 적용
- `./gradlew ktlintCheck` — 코드 스타일 검사
- `./gradlew ktlintFormat` — 자동 포맷팅

## 👀 Review Focus
- `.editorconfig`의 ktlint 설정 값이 팀 컨벤션에 적합한지

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [ ] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견