### PR TITLE
feat: secret 관리를 위한 git submodule 설정

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "config/secret"]
+	path = config/secret
+	url = https://github.com/suker80/18th-team2-server-secret.git

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,6 +47,13 @@ allOpen {
     annotation("jakarta.persistence.Embeddable")
 }
 
+tasks.processResources {
+    from("config/secret") {
+        include("*.yml", "*.yaml")
+        into("")
+    }
+}
+
 tasks.withType<Test> {
     useJUnitPlatform()
 }

--- a/docs/secret-management.md
+++ b/docs/secret-management.md
@@ -1,0 +1,59 @@
+# Secret 관리 가이드
+
+이 프로젝트는 [suker80/18th-team2-server-secret](https://github.com/suker80/18th-team2-server-secret) 레포지토리를 git submodule로 사용하여 비밀 설정 파일을 관리합니다.
+
+## 구조
+
+```
+config/
+└── secret/          # git submodule (depromeet/18th-team2-server-secret)
+    └── application-secret.yml
+```
+
+`application.yml`에서 `spring.profiles.include: secret`으로 자동 로드됩니다.
+
+## 최초 설정
+
+### 방법 1: 클론 시 함께 가져오기
+
+```bash
+git clone --recurse-submodules https://github.com/depromeet/18th-team2-server.git
+```
+
+### 방법 2: 이미 클론한 경우
+
+```bash
+./scripts/init-secrets.sh
+```
+
+이 스크립트는 submodule 초기화 + secret 파일 심볼릭 링크 생성을 자동으로 수행합니다.
+
+### 방법 3: 수동
+
+```bash
+git submodule update --init --recursive
+```
+
+Gradle 빌드 시 `config/secret/` 디렉터리의 yml 파일이 자동으로 리소스에 포함됩니다.
+
+## Secret 파일 업데이트
+
+secret 레포지토리에 변경사항이 있을 때:
+
+```bash
+cd config/secret
+git pull origin main
+cd ../..
+git add config/secret
+git commit -m "chore: update secret submodule"
+```
+
+## 빌드
+
+Gradle `processResources` 태스크가 `config/secret/*.yml` 파일을 빌드 리소스에 자동 복사합니다. 별도 설정 없이 `./gradlew build`만 실행하면 됩니다.
+
+## 주의사항
+
+- `application-secret.yml`은 `.gitignore`에 등록되어 있어 메인 레포에 커밋되지 않습니다
+- secret 레포 접근 권한이 필요합니다 (suker80/18th-team2-server-secret 접근 권한)
+- CI/CD에서는 deploy key 또는 PAT를 사용하여 submodule을 체크아웃해야 합니다

--- a/scripts/init-secrets.sh
+++ b/scripts/init-secrets.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+SECRET_DIR="$PROJECT_ROOT/config/secret"
+RESOURCES_DIR="$PROJECT_ROOT/src/main/resources"
+
+echo "==> Initializing secret submodule..."
+
+cd "$PROJECT_ROOT"
+git submodule update --init --recursive
+
+if [ ! -d "$SECRET_DIR" ] || [ -z "$(ls -A "$SECRET_DIR" 2>/dev/null)" ]; then
+    echo "ERROR: Secret submodule is empty. Check your access to depromeet/18th-team2-server-secret."
+    exit 1
+fi
+
+echo "==> Creating symlinks for secret config files..."
+
+for file in "$SECRET_DIR"/*.yml "$SECRET_DIR"/*.yaml; do
+    [ -f "$file" ] || continue
+    filename="$(basename "$file")"
+    target="$RESOURCES_DIR/$filename"
+
+    if [ -L "$target" ]; then
+        echo "  Symlink already exists: $filename"
+    elif [ -f "$target" ]; then
+        echo "  WARNING: $filename already exists as a regular file, skipping"
+    else
+        ln -s "../../../config/secret/$filename" "$target"
+        echo "  Created symlink: $filename"
+    fi
+done
+
+echo "==> Done! Secret configuration is ready."


### PR DESCRIPTION
## 🔗 Issue
- closes #6

## 💬 Context
Secret 설정 파일(application-secret.yml 등)을 메인 레포에 직접 포함하지 않고, 별도 private 레포를 git submodule로 연결하여 관리합니다.
`application.yml`에 이미 `spring.profiles.include: secret`이 설정되어 있으므로, submodule의 `application-secret.yml`이 빌드 시 자동으로 포함됩니다.

## 🛠 Changes
- `suker80/18th-team2-server-secret` 레포를 `config/secret/` 경로에 git submodule로 추가
- `build.gradle.kts`에 `processResources` 태스크 추가 — `config/secret/*.yml` 파일을 빌드 리소스에 자동 복사
- `scripts/init-secrets.sh` — submodule 초기화 + 심볼릭 링크 생성 자동화 스크립트
- `docs/secret-management.md` — 팀원용 secret 관리 가이드 문서

## 👀 Review Focus
- `build.gradle.kts`의 `processResources` 설정이 빌드 시 정상 동작하는지
- submodule URL(HTTPS)이 팀원들 환경에서 접근 가능한지

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [ ] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견