### PR TITLE
[Chore] CI 워크플로우 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          cache-read-only: ${{ github.event_name == 'pull_request' && github.base_ref != 'main' || github.ref != 'refs/heads/main' }}
 
       # ── Lint ──
       - name: Run ktlint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          token: ${{ secrets.SUBMODULE_TOKEN }}
+          token: ${{ secrets.SUBMODULE_TOKEN != '' && secrets.SUBMODULE_TOKEN || github.token }}
 
       - name: Set up JDK 25
         uses: actions/setup-java@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write  # JaCoCo 커버리지 코멘트용
 
 jobs:
   build:
@@ -24,11 +25,38 @@ jobs:
           java-version: '25'
           distribution: 'temurin'
 
+      # ── Gradle Setup (Build Cache 포함) ──
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
+      # ── Lint ──
       - name: Run ktlint
         run: ./gradlew ktlintCheck
 
+      # ── Detekt (정적 분석) ──
+      - name: Run Detekt
+        run: ./gradlew detekt
+
+      # ── Build & Test + JaCoCo 리포트 생성 ──
       - name: Build and Test
-        run: ./gradlew build
+        run: ./gradlew build jacocoTestReport
+
+      # ── JaCoCo 커버리지 PR 코멘트 ──
+      - name: JaCoCo Coverage Report
+        if: github.event_name == 'pull_request'
+        uses: madrapps/jacoco-report@v1.7.1
+        with:
+          paths: '**/build/reports/jacoco/test/jacocoTestReport.xml'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 50
+          min-coverage-changed-files: 70
+          title: '📊 테스트 커버리지 리포트'
+          update-comment: true
+
+      # ── Docker 이미지 빌드 검증 ──
+      - name: Docker Build (verification only)
+        if: hashFiles('Dockerfile') != ''
+        run: |
+          docker build -t ${{ github.repository }}:pr-${{ github.event.pull_request.number }} .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ develop, main ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          token: ${{ secrets.SUBMODULE_TOKEN }}
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run ktlint
+        run: ./gradlew ktlintCheck
+
+      - name: Build and Test
+        run: ./gradlew build

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,7 +61,6 @@ tasks.processResources {
     }
 }
 
-
 ktlint {
     version.set("1.6.0")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("io.spring.dependency-management") version "1.1.7"
     kotlin("plugin.jpa") version "2.2.21"
     id("org.jlleitschuh.gradle.ktlint") version "12.3.0"
-    id("io.gitlab.arturbosch.detekt") version "1.23.7"
+    id("io.gitlab.arturbosch.detekt") version "1.23.8"
     jacoco
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
     id("io.spring.dependency-management") version "1.1.7"
     kotlin("plugin.jpa") version "2.2.21"
     id("org.jlleitschuh.gradle.ktlint") version "12.3.0"
+    id("io.gitlab.arturbosch.detekt") version "1.23.7"
+    jacoco
 }
 
 group = "com.team2"
@@ -65,4 +67,12 @@ ktlint {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+    finalizedBy(tasks.jacocoTestReport)
+}
+
+tasks.jacocoTestReport {
+    reports {
+        xml.required = true
+        html.required = true
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,11 @@
 plugins {
-    kotlin("jvm") version "2.3.10"
-    kotlin("plugin.spring") version "2.3.10"
+    kotlin("jvm") version "2.3.0"
+    kotlin("plugin.spring") version "2.3.0"
     id("org.springframework.boot") version "4.0.5"
     id("io.spring.dependency-management") version "1.1.7"
-    kotlin("plugin.jpa") version "2.2.21"
+    kotlin("plugin.jpa") version "2.3.0"
     id("org.jlleitschuh.gradle.ktlint") version "12.3.0"
-    id("io.gitlab.arturbosch.detekt") version "1.23.8"
+    id("dev.detekt") version "2.0.0-alpha.2"
     jacoco
 }
 
@@ -60,6 +60,7 @@ tasks.processResources {
         into("")
     }
 }
+
 
 ktlint {
     version.set("1.6.0")

--- a/src/main/kotlin/com/team2/server/common/filter/MdcLoggingFilter.kt
+++ b/src/main/kotlin/com/team2/server/common/filter/MdcLoggingFilter.kt
@@ -10,7 +10,6 @@ import java.util.UUID
 
 @Component
 class MdcLoggingFilter : OncePerRequestFilter() {
-
     override fun doFilterInternal(
         request: HttpServletRequest,
         response: HttpServletResponse,

--- a/src/test/kotlin/com/team2/server/ServerApplicationTests.kt
+++ b/src/test/kotlin/com/team2/server/ServerApplicationTests.kt
@@ -6,6 +6,7 @@ import org.springframework.boot.test.context.SpringBootTest
 @SpringBootTest
 class ServerApplicationTests {
     @Test
+    @Suppress("EmptyFunctionBlock")
     fun contextLoads() {
     }
 }


### PR DESCRIPTION
## 🔗 Issue
closes #14

## 💬 Context
PR 시 자동으로 빌드·테스트를 수행하는 GitHub Actions CI 워크플로우를 추가합니다.
`develop`, `main` 브랜치 대상 PR이 생성되면 ktlint 검사 및 Gradle 빌드·테스트가 자동 실행됩니다.

## 🛠 Changes
- `.github/workflows/ci.yml` — GitHub Actions CI 워크플로우 추가
- ktlint 검사 (`./gradlew ktlintCheck`)
- 빌드 및 테스트 (`./gradlew build`)

## 👀 Review Focus
- CI 워크플로우 스텝 구성이 적절한지
- ktlint 플러그인 설정은 별도 브랜치(chore/ktlint)에서 추가 예정이므로, 해당 브랜치에서 추가하지 않았습니다.
- SUBMODULE_TOKEN 시크릿은 submodule 레포 접근 권한 확보 후 등록 예정입니다.

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [ ] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 풀 리퀘스트 대상 자동 CI 파이프라인 추가(Checkout·JDK 25 설정·Gradle 캐시 포함)
  * 정적분석(ktlint·detekt)·빌드·테스트·코버리지 리포트 실행 및 PR 코멘트 게시(전체 50%, 변경 파일 70%)
  * Dockerfile 존재 시 PR 기반 이미지 빌드 검증 자동화

* **Chores**
  * 빌드 설정에 JaCoCo 및 관련 Gradle 태스크 통합
  * Kotlin 플러그인 버전 정리

* **Tests**
  * 기존 로드 테스트에 불필요 경고 억제 주석 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->