### PR TITLE
[CHORE] PR 생성 시 assignee, reviewer, label 자동 지정 워크플로우 추가

### DIFF
--- a/.github/auto-assign.yml
+++ b/.github/auto-assign.yml
@@ -1,0 +1,12 @@
+addAssignees: author
+
+addReviewers: true
+reviewers:
+  - lydbsdud
+  - suker80
+  - eundeang
+
+numberOfReviewers: 2  # 작성자 제외 나머지 전원 리뷰어 지정 (3명 중 2명)
+skipKeywords:
+  - wip
+  - draft

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -17,5 +17,4 @@
   - head-branch: ['^test/', 'test/']
 
 ⚙️ SETTING:
-  - changed-files:
-    - any-glob-to-any-file: 'monitoring/**'
+  - head-branch: ['^setting/', 'setting/']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,21 @@
+✨ FEATURE:
+  - head-branch: ['^feat/', 'feat/']
+
+🔧 FIX:
+  - head-branch: ['^fix/', 'fix/']
+
+🗑️ CHORE:
+  - head-branch: ['^chore/', 'chore/']
+
+♻️ REFACTOR:
+  - head-branch: ['^refactor/', 'refactor/']
+
+📝 DOCS:
+  - head-branch: ['^docs/', 'docs/']
+
+🧪 TEST:
+  - head-branch: ['^test/', 'test/']
+
+⚙️ SETTING:
+  - changed-files:
+    - any-glob-to-any-file: 'monitoring/**'

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,13 @@
+name: Auto Assign
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v2.0.0
+        with:
+          configuration-path: '.github/auto-assign.yml'

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,18 @@
+name: Auto Label
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+
+jobs:
+  auto-label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml


### PR DESCRIPTION
## 🔗 Issue
  - closes #11

  ## 💬 Context
  PR 생성 시 assignee, reviewer, label을 수동으로 지정하는 번거로움을 없애기 위해 자동화했습니다.

  ## 🛠 Changes
  - `.github/workflows/auto-assign.yml`: PR 오픈 시 `kentaro-m/auto-assign-action` 으로 assignee, reviewer 자동 지정
  - `.github/auto-assign.yml`: assignee, reviewer 지정 규칙 설정
  - `.github/workflows/auto-label.yml`: PR 오픈 시 `actions/labeler` 로 라벨 자동 지정
  - `.github/labeler.yml`: 브랜치명 및 변경 파일 경로 기준 라벨 매핑 규칙 설정

  ## 🚀 사용 방법

  PR을 열면 자동으로 동작합니다. 별도 설정 불필요.

  **Auto Assign**

  | 항목 | 동작 |
  |------|------|
  | Assignee | PR 작성자 본인 자동 지정 |
  | Reviewer | 나머지 팀원 전원 자동 지정 |
  | 스킵 조건 | PR 제목에 `wip` 또는 `draft` 포함 시 미지정 |

  **Auto Label**

  | 브랜치명 | 라벨 |
  |----------|------|
  | `feat/*` | ✨ FEATURE |
  | `fix/*` | 🔧 FIX |
  | `chore/*` | 🗑️CHORE |
  | `refactor/*` | ♻️ REFACTOR |
  | `docs/*` | 📝 DOCS |
  | `test/*` | 🧪 TEST |
  | `setting/**` 파일 변경 | ⚙️ SETTING |

  ## 👀 Review Focus
  - 라벨 이름이 레포에 등록된 이름과 정확히 일치해야 동작함

  ## ✅ Check List
  - [x] Assignees 등록
  - [x] Label 등록
  - [ ] CI 통과 확인

  ---
  > **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견