### PR TITLE
[Chore] Self-hosted Runner 배포 전환 및 인프라 설정 개선

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: Dockerfile
     environment:
-      - SPRING_PROFILES_ACTIVE=dev,secret
+      - SPRING_PROFILES_ACTIVE=secret-dev
       - DB_HOST=db-dev
     depends_on:
       db-dev:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: Dockerfile
     environment:
-      - SPRING_PROFILES_ACTIVE=prod,secret
+      - SPRING_PROFILES_ACTIVE=secret-prod
       - DB_HOST=db-prod
     depends_on:
       db-prod:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,3 +13,9 @@ services:
     networks:
       - dev-network
       - prod-network
+
+networks:
+  dev-network:
+    external: true
+  prod-network:
+    external: true

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -3,13 +3,7 @@ events {
 }
 
 http {
-    upstream app-dev {
-        server app-dev:8080;
-    }
-
-    upstream app-prod {
-        server app-prod:8080;
-    }
+    resolver 127.0.0.11 valid=30s;
 
     # dev - 8081 포트로 접근
     server {
@@ -17,7 +11,8 @@ http {
         server_name _;
 
         location / {
-            proxy_pass http://app-dev;
+            set $dev_upstream http://app-dev:8080;
+            proxy_pass $dev_upstream;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -34,7 +29,8 @@ http {
         server_name _;
 
         location / {
-            proxy_pass http://app-prod;
+            set $prod_upstream http://app-prod:8080;
+            proxy_pass $prod_upstream;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## 🔗 Issue
- closes #

## 💬 Context
PR #19 머지 후 배포 시 네트워크 에러가 발생하여 수정 및 반영했습니다.

## 🛠 Changes
- **Self-hosted Runner 전환**: SSH 배포 방식에서 Self-hosted Runner로 변경 (포트포워딩 불필요)
- **dev 포트 변경**: 8080 → 8081 (홈서버 기존 프로세스 충돌 방지)
- **네트워크 에러 수정**: 베이스 compose에 dev-network, prod-network external 선언 추가
- **deploy.sh 개선**: 중복 git pull 제거, yq `-e` 플래그 누락 수정
- **CI 개선**: cache-read-only 조건 우선순위 수정, Docker 빌드에 GHA 레이어 캐시 적용
- **nginx**: 프록시 타임아웃 설정 추가
- **서브모듈 업데이트**: DB URL에 DB_HOST 환경변수 적용

## 👀 Review Focus
- Self-hosted Runner 워크플로우 구조
- docker-compose 네트워크 external 선언 방식

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 설정 서브모듈 참조를 업데이트했습니다.
  * Docker Compose에서 개발 및 프로덕션 네트워크 구성을 외부 네트워크로 변경했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->