### PR TITLE
[Feat] DDL 기반 도메인별 JPA 엔티티 추가

### DIFF
--- a/src/main/kotlin/com/team2/server/chat/entity/ChatMessage.kt
+++ b/src/main/kotlin/com/team2/server/chat/entity/ChatMessage.kt
@@ -1,0 +1,24 @@
+package com.team2.server.chat.entity
+
+import com.team2.server.common.entity.BaseEntity
+import com.team2.server.party.entity.Participant
+import com.team2.server.party.entity.Party
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "chat_message")
+class ChatMessage(
+    @Column(nullable = false, length = 1000)
+    var content: String,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "party_id", nullable = false)
+    var party: Party,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "participant_id", nullable = false)
+    var participant: Participant,
+) : BaseEntity()

--- a/src/main/kotlin/com/team2/server/party/entity/Character.kt
+++ b/src/main/kotlin/com/team2/server/party/entity/Character.kt
@@ -1,0 +1,15 @@
+package com.team2.server.party.entity
+
+import com.team2.server.common.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "character")
+class Character(
+    @Column(nullable = false)
+    var name: String,
+    @Column(name = "image_url", nullable = false)
+    var imageUrl: String,
+) : BaseEntity()

--- a/src/main/kotlin/com/team2/server/party/entity/Participant.kt
+++ b/src/main/kotlin/com/team2/server/party/entity/Participant.kt
@@ -1,0 +1,30 @@
+package com.team2.server.party.entity
+
+import com.team2.server.common.entity.BaseEntity
+import com.team2.server.user.entity.User
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "participant")
+class Participant(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "party_id", nullable = false)
+    var party: Party,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "character_id", nullable = false)
+    var character: Character,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    var user: User? = null,
+    @Column(name = "nickname")
+    var nickname: String? = null,
+    @Column(name = "is_celebrant", nullable = false)
+    var isCelebrant: Boolean = false,
+    @Column(name = "has_written_paper", nullable = false)
+    var hasWrittenPaper: Boolean = false,
+) : BaseEntity()

--- a/src/main/kotlin/com/team2/server/party/entity/Party.kt
+++ b/src/main/kotlin/com/team2/server/party/entity/Party.kt
@@ -1,0 +1,47 @@
+package com.team2.server.party.entity
+
+import com.team2.server.common.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "party")
+class Party(
+    @Column(name = "share_link")
+    var shareLink: String? = null,
+    @Column(name = "background_image_url")
+    var backgroundImageUrl: String? = null,
+    @Column(name = "started_at")
+    var startedAt: LocalDateTime? = null,
+    @Column(name = "ended_at")
+    var endedAt: LocalDateTime? = null,
+    @Column(name = "name")
+    var name: String? = null,
+    @Column(name = "celebrant_nickname")
+    var celebrantNickname: String? = null,
+    @Column(name = "is_chatting_allow")
+    var isChattingAllow: Boolean = false,
+    @Column(name = "paper_opened_at")
+    var paperOpenedAt: LocalDateTime? = null,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "option")
+    var option: PartyOption? = null,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "purpose")
+    var purpose: PartyPurpose? = null,
+) : BaseEntity()
+
+enum class PartyOption {
+    REALTIME,
+    PAPER_ONLY,
+}
+
+enum class PartyPurpose {
+    BIRTHDAY,
+    JOB_CHANGE,
+    WEDDING,
+}

--- a/src/main/kotlin/com/team2/server/rollingpaper/entity/RollingPaper.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/entity/RollingPaper.kt
@@ -1,0 +1,34 @@
+package com.team2.server.rollingpaper.entity
+
+import com.team2.server.common.entity.BaseEntity
+import com.team2.server.party.entity.Participant
+import com.team2.server.party.entity.Party
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "rolling_paper")
+class RollingPaper(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "theme_id", nullable = false)
+    var theme: RollingPaperWrapper,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "writer_participant_id", nullable = false)
+    var writer: Participant,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recipient_participant_id", nullable = false)
+    var recipient: Participant,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "party_id", nullable = false)
+    var party: Party,
+    @Column(nullable = false, length = 1000)
+    var content: String,
+    @Column(nullable = false, length = 32)
+    var color: String,
+    @Column(name = "is_read", nullable = false)
+    var isRead: Boolean = false,
+) : BaseEntity()

--- a/src/main/kotlin/com/team2/server/rollingpaper/entity/RollingPaperWrapper.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/entity/RollingPaperWrapper.kt
@@ -1,0 +1,15 @@
+package com.team2.server.rollingpaper.entity
+
+import com.team2.server.common.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "rolling_paper_wrapper")
+class RollingPaperWrapper(
+    @Column(nullable = false)
+    var name: String,
+    @Column(name = "image_url", nullable = false)
+    var imageUrl: String,
+) : BaseEntity()

--- a/src/main/kotlin/com/team2/server/user/entity/User.kt
+++ b/src/main/kotlin/com/team2/server/user/entity/User.kt
@@ -1,0 +1,29 @@
+package com.team2.server.user.entity
+
+import com.team2.server.common.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "users")
+class User(
+    @Column(nullable = false)
+    var name: String,
+    @Column(name = "birth_day", nullable = false, length = 5)
+    var birthDay: String,
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 100)
+    var provider: AuthProvider,
+    @Column(nullable = false)
+    var email: String,
+) : BaseEntity()
+
+enum class AuthProvider {
+    KAKAO,
+    GOOGLE,
+    APPLE,
+    NAVER,
+}


### PR DESCRIPTION
## 🔗 Issue
- closes #25

## 💬 Context
파티 / 롤링페이퍼 / 사용자 / 채팅 도메인의 DDL을 바탕으로 JPA 엔티티 레이어를 정리합니다. DDL은 모든 컬럼이 `VARCHAR(255)`로 표현되어 있지만 주석에 의도된 실제 타입(LocalDateTime, Boolean, Enum)이 명시되어 있어 이를 반영해 매핑했습니다. 또한 ID 전략은 기존 `BaseEntity`(Long + IDENTITY + Auditing)와 일관성을 맞추기 위해 String UUID 대신 BaseEntity 상속 방식으로 통일했습니다.

## 🛠 Changes
- 도메인별 패키지 분리: `user`, `party`, `rollingpaper`, `chat`
- `User` + `AuthProvider` enum (KAKAO / GOOGLE / APPLE / NAVER)
- `Party` + `PartyOption`(REALTIME / PAPER_ONLY) / `PartyPurpose`(BIRTHDAY / JOB_CHANGE / WEDDING) enum
- `Participant`: `Party`, `Character` `@ManyToOne`, `User`는 nullable (비회원 참여 허용), `hasWrittenPaper` 플래그 추가
- `Character`: 캐릭터 메타 정보
- `RollingPaper`: `writer` / `recipient` 두 개의 `Participant` 관계 + `theme`(`RollingPaperWrapper`) + `party`
- `RollingPaperWrapper`: 롤링페이퍼 포장지(테마)
- `ChatMessage`: `Party`, `Participant` `@ManyToOne`
- 모든 연관관계는 `FetchType.LAZY`
- 모든 엔티티 `BaseEntity` 상속 (Long ID + IDENTITY + createdAt/updatedAt)

## 👀 Review Focus
- DDL의 `VARCHAR` → `LocalDateTime` / `Boolean` / `Enum` 매핑 의도가 적절한지
- `RollingPaper.writer` / `recipient` 두 관계 분리가 도메인 의미에 맞는지 (DDL은 `participant_id` 1개)
- `Participant.user`가 nullable 인 게 비회원 참여 시나리오를 커버하는지
- `Party.option` / `purpose` enum 값 후보가 실제 기획과 일치하는지
- 한글 테이블/컬럼명을 영문 스네이크 케이스(`@Table(name = "...")`)로 매핑한 컨벤션이 OK 인지

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견