### PR TITLE
[Chore] application yml 및 docker-compose 프로파일 정리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,18 @@
 # Spring
 .env
-application-secret.yml
+.env.*
+application-secret*.yml
+application-secret*.yaml
 HELP.md
+
+# Secrets / Credentials
+*.pem
+*.key
+*.p12
+*.jks
+*.keystore
+secrets.json
+*credential*
 
 # IntelliJ IDEA
 .idea/

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: Dockerfile
     environment:
-      - SPRING_PROFILES_ACTIVE=secret-dev
+      - SPRING_PROFILES_ACTIVE=dev,secret-dev
       - DB_HOST=db-dev
     depends_on:
       db-dev:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: Dockerfile
     environment:
-      - SPRING_PROFILES_ACTIVE=secret-prod
+      - SPRING_PROFILES_ACTIVE=prod,secret-prod
       - DB_HOST=db-prod
     depends_on:
       db-prod:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,8 +1,4 @@
 spring:
-  datasource:
-    url: jdbc:mysql://localhost:3306/team2
-    username: root
-    password: 1234
   jpa:
     hibernate:
       ddl-auto: update

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,16 @@
+spring:
+  application:
+    name: team2-backend-test
+  profiles:
+    active: test
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: ""
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
## 🔗 Issue
- closes #27

## 💬 Context
운영 환경에서 `application-prod.yml`이 활성화되지 않아 `ddl-auto: validate` / `swagger-ui.enabled: false` 같은 프로덕션 안전 설정이 미적용되는 상태였습니다. 또한 `.gitignore`의 시크릿 패턴이 단일 파일명만 매칭해 환경별 secret 파일과 인증서/키 파일이 보호되지 않을 위험이 있었습니다. 테스트는 메인 application.yml의 `profiles.include: secret` 때문에 MySQL 시크릿을 끌어와 컨텍스트 로딩 시 실패하던 문제도 함께 정리합니다.

## 🛠 Changes
- `.gitignore`: `application-secret*.yml/yaml`, `.env.*`, `*.pem`, `*.key`, `*.p12`, `*.jks`, `*.keystore`, `secrets.json`, `*credential*` 패턴 추가
- `docker-compose.dev.yml`: `SPRING_PROFILES_ACTIVE` → `dev,secret-dev` (이제 `application-dev.yml`이 적용됨)
- `docker-compose.prod.yml`: `SPRING_PROFILES_ACTIVE` → `prod,secret-prod` (운영 안전 설정 적용)
- `application-dev.yml`: secret-dev와 중복되는 datasource 블록 제거, JPA 설정만 유지
- `src/test/resources/application.yml` 신규: 테스트 시 secret include 우회하고 H2 인메모리 사용

## 👀 Review Focus
- prod 컨테이너 환경 변수에 `prod,secret-prod` 두 프로파일이 모두 활성화되는 것이 의도된 동작인지
- 테스트 전용 `src/test/resources/application.yml`이 메인 application.yml의 `profiles.include: secret`을 적절히 차단하는지 (테스트 통과로 검증됨)
- `.gitignore` 패턴이 기존 추적 파일을 의도치 않게 무시하지 않는지

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견