### PR TITLE
fix: MySQL 예약어 충돌로 인한 DDL 오류 수정

### DIFF
--- a/src/main/kotlin/com/team2/server/party/entity/Character.kt
+++ b/src/main/kotlin/com/team2/server/party/entity/Character.kt
@@ -6,7 +6,7 @@ import jakarta.persistence.Entity
 import jakarta.persistence.Table
 
 @Entity
-@Table(name = "character")
+@Table(name = "avatar")
 class Character(
     @Column(nullable = false)
     var name: String,

--- a/src/main/kotlin/com/team2/server/party/entity/Party.kt
+++ b/src/main/kotlin/com/team2/server/party/entity/Party.kt
@@ -28,7 +28,7 @@ class Party(
     @Column(name = "paper_opened_at")
     var paperOpenedAt: LocalDateTime? = null,
     @Enumerated(EnumType.STRING)
-    @Column(name = "option")
+    @Column(name = "party_type")
     var option: PartyOption? = null,
     @Enumerated(EnumType.STRING)
     @Column(name = "purpose")


### PR DESCRIPTION
## 🔗 Issue
- closes #

## 💬 Context
`character`(테이블명)와 `option`(컬럼명)이 MySQL 예약어와 충돌하여 Hibernate DDL 자동 생성 시 `party` 테이블 생성이 실패하고, 연관 FK도 전부 실패하는 문제가 있었습니다.

## 🛠 Changes
- `character` 테이블명 → `avatar`로 변경 (`Character.kt`)
- `option` 컬럼명 → `party_type`으로 변경 (`Party.kt`)

## 👀 Review Focus
- 예약어 회피를 위해 백틱 대신 이름 자체를 변경한 방식이 적절한지

## ✅ Check List
- [ ] Assignees 등록
- [ ] Label 등록
- [ ] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 데이터베이스 내부 매핑 구조를 업데이트했습니다. 시스템의 기능적 변화는 없으며, 백엔드 인프라 개선 작업입니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->