### PR TITLE
feat: 로컬 개발용 통합 docker-compose 추가

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - "3306:3306"
     environment:
-      - MYSQL_DATABASE=team2
+      - MYSQL_DATABASE=team2-local-db
       - MYSQL_USER=team2
       - MYSQL_PASSWORD=team2
       - MYSQL_ROOT_PASSWORD=root

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,72 @@
+services:
+  db:
+    image: mysql:8.0
+    container_name: team2-local-db
+    ports:
+      - "3306:3306"
+    environment:
+      - MYSQL_DATABASE=team2
+      - MYSQL_USER=team2
+      - MYSQL_PASSWORD=team2
+      - MYSQL_ROOT_PASSWORD=root
+    volumes:
+      - db-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: team2-local-prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
+      - '--web.console.templates=/usr/share/prometheus/consoles'
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    restart: unless-stopped
+
+  loki:
+    image: grafana/loki:latest
+    container_name: team2-local-loki
+    user: root
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./monitoring/loki/loki-config.yml:/etc/loki/local-config.yaml
+      - loki_data:/tmp/loki
+    command: -config.file=/etc/loki/local-config.yaml
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: team2-local-grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+      - GF_USERS_ALLOW_SIGN_UP=false
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning
+      - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards
+    depends_on:
+      - prometheus
+      - loki
+    restart: unless-stopped
+
+volumes:
+  db-data:
+  prometheus_data:
+  loki_data:
+  grafana_data:


### PR DESCRIPTION
## 🔗 Issue
- N/A

## 💬 Context
로컬 개발 시 DB, Prometheus, Loki, Grafana를 각각 띄우는 게 번거로워서 하나의 docker-compose 파일로 통합했습니다.

## 🛠 Changes
- `docker-compose.local.yml` 추가: MySQL, Prometheus, Loki, Grafana를 한 번에 실행

## 📋 실행 방법
```bash
# 전부 띄우기
docker compose -f docker-compose.local.yml up -d

# 전부 내리기
docker compose -f docker-compose.local.yml down
```

| 서비스 | 포트 | 접속 정보 |
|--------|------|-----------|
| MySQL | 3306 | - |
| Prometheus | 9090 | - |
| Loki | 3100 | - |
| Grafana | 3000 | admin / admin |

## 👀 Review Focus
- 로컬 전용이라 네트워크 설정 없이 단순하게 구성했는데 괜찮은지

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [ ] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 로컬 개발 및 모니터링을 위한 완전한 스택 환경 추가: MySQL 데이터베이스, Prometheus 메트릭 수집, Loki 로그 집계, Grafana 대시보드 시각화를 포함하는 Docker Compose 구성 제공

* **Chores**
  * 내부 의존성 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->