### PR TITLE
feat: 다형성 Image 엔티티 추가 및 기존 imageUrl 필드 제거

### DIFF
--- a/src/main/kotlin/com/team2/server/common/entity/Image.kt
+++ b/src/main/kotlin/com/team2/server/common/entity/Image.kt
@@ -1,0 +1,21 @@
+package com.team2.server.common.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "image")
+class Image(
+    @Column(name = "image_url", nullable = false)
+    var imageUrl: String,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "target_type", nullable = false, length = 50)
+    var targetType: ImageTargetType,
+    @Column(name = "target_id", nullable = false)
+    var targetId: Long,
+    @Column(name = "sort_order", nullable = false)
+    var sortOrder: Int = 0,
+) : BaseEntity()

--- a/src/main/kotlin/com/team2/server/common/entity/ImageTargetType.kt
+++ b/src/main/kotlin/com/team2/server/common/entity/ImageTargetType.kt
@@ -1,0 +1,6 @@
+package com.team2.server.common.entity
+
+enum class ImageTargetType {
+    ROLLING_PAPER_WRAPPER,
+    CHARACTER,
+}

--- a/src/main/kotlin/com/team2/server/party/entity/Character.kt
+++ b/src/main/kotlin/com/team2/server/party/entity/Character.kt
@@ -10,6 +10,4 @@ import jakarta.persistence.Table
 class Character(
     @Column(nullable = false)
     var name: String,
-    @Column(name = "image_url", nullable = false)
-    var imageUrl: String,
 ) : BaseEntity()

--- a/src/main/kotlin/com/team2/server/rollingpaper/entity/RollingPaper.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/entity/RollingPaper.kt
@@ -20,9 +20,6 @@ class RollingPaper(
     @JoinColumn(name = "writer_participant_id", nullable = false)
     var writer: Participant,
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "recipient_participant_id", nullable = false)
-    var recipient: Participant,
-    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "party_id", nullable = false)
     var party: Party,
     @Column(nullable = false, length = 1000)

--- a/src/main/kotlin/com/team2/server/rollingpaper/entity/RollingPaperWrapper.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/entity/RollingPaperWrapper.kt
@@ -10,6 +10,4 @@ import jakarta.persistence.Table
 class RollingPaperWrapper(
     @Column(nullable = false)
     var name: String,
-    @Column(name = "image_url", nullable = false)
-    var imageUrl: String,
 ) : BaseEntity()


### PR DESCRIPTION
## 🔗 Issue
- closes #35 

## 💬 Context
여러 엔티티(RollingPaperWrapper, Character 등)에 분산된 image_url을 하나의 Image 테이블로 통합 관리하기 위해 다형성(Polymorphic) 방식의 Image 엔티티를 추가합니다. 추후 Party.backgroundImageUrl도 이관 가능하도록 확장성을 고려했습니다.

## 🛠 Changes
- `Image` 엔티티 생성 (target_type + target_id 다형성 방식, sort_order로 1:N 지원)
- `ImageTargetType` enum 생성 (ROLLING_PAPER_WRAPPER, CHARACTER)
- `RollingPaperWrapper`에서 `imageUrl` 필드 제거
- `Character`에서 `imageUrl` 필드 제거

## 👀 Review Focus
- 다형성 방식(FK 없이 target_type + target_id) 설계가 적절한지
- Image 엔티티의 패키지 위치 (common/entity)가 적절한지

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견