### PR TITLE
[Feat] 파티 생성 API 구현

### DIFF
--- a/src/main/kotlin/com/team2/server/common/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/team2/server/common/config/SwaggerConfig.kt
@@ -1,11 +1,19 @@
 package com.team2.server.common.config
 
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType
+import io.swagger.v3.oas.annotations.security.SecurityScheme
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
+@SecurityScheme(
+    name = "Bearer Authentication",
+    type = SecuritySchemeType.HTTP,
+    scheme = "bearer",
+    bearerFormat = "JWT",
+)
 class SwaggerConfig {
     @Bean
     fun openAPI(): OpenAPI =

--- a/src/main/kotlin/com/team2/server/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/team2/server/common/exception/ErrorCode.kt
@@ -6,6 +6,7 @@ enum class ErrorCode(
     val httpStatus: HttpStatus,
     val message: String,
 ) {
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다"),
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "잘못된 입력입니다"),
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "리소스를 찾을 수 없습니다"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다"),

--- a/src/main/kotlin/com/team2/server/party/controller/PartyController.kt
+++ b/src/main/kotlin/com/team2/server/party/controller/PartyController.kt
@@ -1,7 +1,6 @@
 package com.team2.server.party.controller
 
-import com.team2.server.common.exception.BusinessException
-import com.team2.server.common.exception.ErrorCode
+import com.team2.server.auth.principal.UserPrincipal
 import com.team2.server.common.response.ApiResponse
 import com.team2.server.party.dto.CreatePartyRequest
 import com.team2.server.party.dto.CreatePartyResponse
@@ -10,9 +9,9 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
@@ -30,12 +29,7 @@ class PartyController(
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
     fun createParty(
-        @RequestHeader(value = "Authorization", required = false) authorization: String?,
+        @AuthenticationPrincipal principal: UserPrincipal,
         @RequestBody request: CreatePartyRequest,
-    ): ApiResponse<CreatePartyResponse> {
-        if (authorization.isNullOrBlank() || !authorization.startsWith("Bearer ")) {
-            throw BusinessException(ErrorCode.UNAUTHORIZED)
-        }
-        return ApiResponse.success(partyService.createParty(request))
-    }
+    ): ApiResponse<CreatePartyResponse> = ApiResponse.success(partyService.createParty(principal.userId, request))
 }

--- a/src/main/kotlin/com/team2/server/party/controller/PartyController.kt
+++ b/src/main/kotlin/com/team2/server/party/controller/PartyController.kt
@@ -1,0 +1,41 @@
+package com.team2.server.party.controller
+
+import com.team2.server.common.exception.BusinessException
+import com.team2.server.common.exception.ErrorCode
+import com.team2.server.common.response.ApiResponse
+import com.team2.server.party.dto.CreatePartyRequest
+import com.team2.server.party.dto.CreatePartyResponse
+import com.team2.server.party.service.PartyService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "Party", description = "파티 API")
+@RestController
+@RequestMapping("/api/v1/parties")
+class PartyController(
+    private val partyService: PartyService,
+) {
+    @Operation(
+        summary = "파티 생성",
+        security = [SecurityRequirement(name = "Bearer Authentication")],
+    )
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping
+    fun createParty(
+        @RequestHeader(value = "Authorization", required = false) authorization: String?,
+        @RequestBody request: CreatePartyRequest,
+    ): ApiResponse<CreatePartyResponse> {
+        if (authorization.isNullOrBlank() || !authorization.startsWith("Bearer ")) {
+            throw BusinessException(ErrorCode.UNAUTHORIZED)
+        }
+        return ApiResponse.success(partyService.createParty(request))
+    }
+}

--- a/src/main/kotlin/com/team2/server/party/dto/CreatePartyRequest.kt
+++ b/src/main/kotlin/com/team2/server/party/dto/CreatePartyRequest.kt
@@ -1,0 +1,17 @@
+package com.team2.server.party.dto
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+import java.time.LocalTime
+
+@Schema(description = "파티 생성 요청")
+data class CreatePartyRequest(
+    @Schema(description = "파티 주인공 이름", example = "홍길동")
+    val celebrantNickname: String,
+    @Schema(description = "파티 시작일", example = "2024-11-26")
+    val startedDate: LocalDate,
+    @Schema(description = "파티 시작 시간 (HH:mm)", example = "14:30")
+    @JsonFormat(pattern = "HH:mm")
+    val startTime: LocalTime,
+)

--- a/src/main/kotlin/com/team2/server/party/dto/CreatePartyResponse.kt
+++ b/src/main/kotlin/com/team2/server/party/dto/CreatePartyResponse.kt
@@ -1,0 +1,5 @@
+package com.team2.server.party.dto
+
+data class CreatePartyResponse(
+    val partyId: Long,
+)

--- a/src/main/kotlin/com/team2/server/party/entity/Party.kt
+++ b/src/main/kotlin/com/team2/server/party/entity/Party.kt
@@ -11,6 +11,8 @@ import java.time.LocalDateTime
 @Entity
 @Table(name = "party")
 class Party(
+    @Column(name = "owner_id", nullable = false)
+    val ownerId: Long,
     @Column(name = "share_link")
     var shareLink: String? = null,
     @Column(name = "background_image_url")

--- a/src/main/kotlin/com/team2/server/party/repository/PartyRepository.kt
+++ b/src/main/kotlin/com/team2/server/party/repository/PartyRepository.kt
@@ -1,0 +1,6 @@
+package com.team2.server.party.repository
+
+import com.team2.server.party.entity.Party
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PartyRepository : JpaRepository<Party, Long>

--- a/src/main/kotlin/com/team2/server/party/service/PartyService.kt
+++ b/src/main/kotlin/com/team2/server/party/service/PartyService.kt
@@ -13,10 +13,14 @@ class PartyService(
     private val partyRepository: PartyRepository,
 ) {
     @Transactional
-    fun createParty(request: CreatePartyRequest): CreatePartyResponse {
+    fun createParty(
+        userId: Long,
+        request: CreatePartyRequest,
+    ): CreatePartyResponse {
         val startedAt = LocalDateTime.of(request.startedDate, request.startTime)
         val party =
             Party(
+                ownerId = userId,
                 celebrantNickname = request.celebrantNickname,
                 startedAt = startedAt,
             )

--- a/src/main/kotlin/com/team2/server/party/service/PartyService.kt
+++ b/src/main/kotlin/com/team2/server/party/service/PartyService.kt
@@ -1,0 +1,26 @@
+package com.team2.server.party.service
+
+import com.team2.server.party.dto.CreatePartyRequest
+import com.team2.server.party.dto.CreatePartyResponse
+import com.team2.server.party.entity.Party
+import com.team2.server.party.repository.PartyRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service
+class PartyService(
+    private val partyRepository: PartyRepository,
+) {
+    @Transactional
+    fun createParty(request: CreatePartyRequest): CreatePartyResponse {
+        val startedAt = LocalDateTime.of(request.startedDate, request.startTime)
+        val party =
+            Party(
+                celebrantNickname = request.celebrantNickname,
+                startedAt = startedAt,
+            )
+        val saved = partyRepository.save(party)
+        return CreatePartyResponse(partyId = saved.id)
+    }
+}


### PR DESCRIPTION
## 🔗 Issue
- closes #31

## 💬 Context
파티 생성 기능은 서비스의 핵심 기능으로, 사용자가 롤링페이퍼 파티를 만들 수 있어야 합니다. OAuth 로그인한 사용자만 파티를 생성할 수 있어야 하며, Swagger를 통해 API를 문서화하고 테스트할 수 있어야 합니다. OAuth 구현은 별도 작업으로 진행되므로, 현재는 Authorization 헤더의 Bearer 토큰 존재 여부로 인증 여부를 판단합니다.

## 🛠 Changes
- `POST /api/v1/parties` 파티 생성 엔드포인트 추가
- Bearer 토큰 없을 시 `UNAUTHORIZED(401)` 에러 반환
- 파티 주인공 이름, 시작일, 시작 시간을 요청값으로 받아 Party 엔티티 저장
- Swagger Bearer Authentication 스키마 등록 및 API 문서화
- `UNAUTHORIZED` 에러코드 추가

## 👀 Review Focus
- Bearer 토큰 존재 여부로 인증을 판단하는 임시 방식 — OAuth 구현 시 `@AuthenticationPrincipal`로 교체 필요
- `startedDate(LocalDate)` + `startTime(LocalTime)` 을 분리해서 받고 서비스에서 `LocalDateTime`으로 합산하는 방식의 적절성
- `CreatePartyRequest`에서 `@JsonFormat(pattern = "HH:mm")`으로 시간 포맷을 제한하는 방식

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 파티 생성 기능 추가
  * Bearer 토큰 기반 인증 처리 추가
  * 파티 정보(주인공 닉네임, 시작 날짜, 시작 시간) 입력 및 파티 ID 반환 지원
  * Swagger 문서에 인증 스킴 메타데이터 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->