### PR TITLE
[Feat] 파티 초대링크 활성화 API 구현

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -1,0 +1,5 @@
+style:
+  UnusedParameter:
+    active: true
+    ignoreAnnotated:
+      - AuthenticationPrincipal

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -1,5 +1,0 @@
-style:
-  UnusedParameter:
-    active: true
-    ignoreAnnotated:
-      - AuthenticationPrincipal

--- a/src/main/kotlin/com/team2/server/auth/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/team2/server/auth/config/SecurityConfig.kt
@@ -45,6 +45,7 @@ class SecurityConfig(
                         "/actuator/info",
                         "/swagger-ui/**",
                         "/v3/api-docs/**",
+                        "/api/dev/**",
                     ).permitAll()
                 auth.anyRequest().authenticated()
             }.oauth2Login { oauth ->

--- a/src/main/kotlin/com/team2/server/auth/controller/DevTokenController.kt
+++ b/src/main/kotlin/com/team2/server/auth/controller/DevTokenController.kt
@@ -1,0 +1,63 @@
+package com.team2.server.auth.controller
+
+import com.team2.server.auth.jwt.JwtTokenProvider
+import com.team2.server.common.exception.BusinessException
+import com.team2.server.common.exception.ErrorCode
+import com.team2.server.common.response.ApiResponse
+import com.team2.server.user.entity.AuthProvider
+import com.team2.server.user.entity.User
+import com.team2.server.user.repository.UserRepository
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.context.annotation.Profile
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "Dev", description = "개발용 API (prod 환경에서 비활성화)")
+@Profile("!prod")
+@RestController
+@RequestMapping("/api/dev")
+class DevTokenController(
+    private val userRepository: UserRepository,
+    private val jwtTokenProvider: JwtTokenProvider,
+) {
+    @Operation(summary = "개발용 JWT 토큰 발급 (존재하지 않으면 유저 자동 생성)")
+    @PostMapping("/token")
+    fun issueToken(
+        @RequestParam email: String,
+    ): ApiResponse<DevTokenResponse> {
+        val user =
+            userRepository.findByProviderAndProviderId(AuthProvider.KAKAO, email)
+                ?: userRepository.save(
+                    User(
+                        name = email,
+                        birthDay = "01-01",
+                        provider = AuthProvider.KAKAO,
+                        providerId = email,
+                        email = email,
+                    ),
+                )
+        val token = jwtTokenProvider.issue(user)
+        return ApiResponse.success(DevTokenResponse(token = token, userId = user.id))
+    }
+
+    @Operation(summary = "개발용 JWT 토큰 발급 (userId로)")
+    @PostMapping("/token/by-id")
+    fun issueTokenById(
+        @RequestParam userId: Long,
+    ): ApiResponse<DevTokenResponse> {
+        val user =
+            userRepository
+                .findById(userId)
+                .orElseThrow { BusinessException(ErrorCode.AUTH_USER_NOT_FOUND) }
+        val token = jwtTokenProvider.issue(user)
+        return ApiResponse.success(DevTokenResponse(token = token, userId = user.id))
+    }
+}
+
+data class DevTokenResponse(
+    val token: String,
+    val userId: Long,
+)

--- a/src/main/kotlin/com/team2/server/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/team2/server/common/exception/ErrorCode.kt
@@ -9,6 +9,8 @@ enum class ErrorCode(
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다"),
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "잘못된 입력입니다"),
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "리소스를 찾을 수 없습니다"),
+    PARTY_NOT_FOUND(HttpStatus.NOT_FOUND, "파티를 찾을 수 없습니다"),
+    INVITE_LINK_EXPIRED(HttpStatus.BAD_REQUEST, "만료된 초대링크입니다"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다"),
 
     AUTH_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다"),

--- a/src/main/kotlin/com/team2/server/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/team2/server/common/exception/ErrorCode.kt
@@ -10,6 +10,7 @@ enum class ErrorCode(
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "잘못된 입력입니다"),
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "리소스를 찾을 수 없습니다"),
     PARTY_NOT_FOUND(HttpStatus.NOT_FOUND, "파티를 찾을 수 없습니다"),
+    PARTY_FORBIDDEN(HttpStatus.FORBIDDEN, "파티에 대한 권한이 없습니다"),
     INVITE_LINK_EXPIRED(HttpStatus.BAD_REQUEST, "만료된 초대링크입니다"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다"),
 

--- a/src/main/kotlin/com/team2/server/party/controller/PartyInviteController.kt
+++ b/src/main/kotlin/com/team2/server/party/controller/PartyInviteController.kt
@@ -27,5 +27,6 @@ class PartyInviteController(
     fun activateInviteLink(
         @AuthenticationPrincipal principal: UserPrincipal,
         @PathVariable partyId: Long,
-    ): ApiResponse<ActivateInviteLinkResponse> = ApiResponse.success(partyInviteService.activateInviteLink(partyId))
+    ): ApiResponse<ActivateInviteLinkResponse> =
+        ApiResponse.success(partyInviteService.activateInviteLink(partyId, principal.userId))
 }

--- a/src/main/kotlin/com/team2/server/party/controller/PartyInviteController.kt
+++ b/src/main/kotlin/com/team2/server/party/controller/PartyInviteController.kt
@@ -1,0 +1,31 @@
+package com.team2.server.party.controller
+
+import com.team2.server.auth.principal.UserPrincipal
+import com.team2.server.common.response.ApiResponse
+import com.team2.server.party.dto.ActivateInviteLinkResponse
+import com.team2.server.party.service.PartyInviteService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "Party", description = "파티 API")
+@RestController
+@RequestMapping("/api/v1/parties")
+class PartyInviteController(
+    private val partyInviteService: PartyInviteService,
+) {
+    @Operation(
+        summary = "파티 초대링크 활성화",
+        security = [SecurityRequirement(name = "Bearer Authentication")],
+    )
+    @PostMapping("/{partyId}/invite-link")
+    fun activateInviteLink(
+        @AuthenticationPrincipal principal: UserPrincipal,
+        @PathVariable partyId: Long,
+    ): ApiResponse<ActivateInviteLinkResponse> = ApiResponse.success(partyInviteService.activateInviteLink(partyId))
+}

--- a/src/main/kotlin/com/team2/server/party/dto/ActivateInviteLinkResponse.kt
+++ b/src/main/kotlin/com/team2/server/party/dto/ActivateInviteLinkResponse.kt
@@ -1,0 +1,9 @@
+package com.team2.server.party.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "초대링크 활성화 응답")
+data class ActivateInviteLinkResponse(
+    @Schema(description = "초대 토큰", example = "a1b2c3d4e5f67890")
+    val token: String,
+)

--- a/src/main/kotlin/com/team2/server/party/entity/Party.kt
+++ b/src/main/kotlin/com/team2/server/party/entity/Party.kt
@@ -13,8 +13,6 @@ import java.time.LocalDateTime
 class Party(
     @Column(name = "owner_id", nullable = false)
     val ownerId: Long,
-    @Column(name = "share_link")
-    var shareLink: String? = null,
     @Column(name = "background_image_url")
     var backgroundImageUrl: String? = null,
     @Column(name = "started_at")

--- a/src/main/kotlin/com/team2/server/party/entity/PartyInvite.kt
+++ b/src/main/kotlin/com/team2/server/party/entity/PartyInvite.kt
@@ -1,0 +1,22 @@
+package com.team2.server.party.entity
+
+import com.team2.server.common.entity.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "party_invite")
+class PartyInvite(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "party_id", nullable = false)
+    val party: Party,
+    @Column(name = "token", nullable = false, length = 16, unique = true)
+    val token: String,
+    @Column(name = "expires_at", nullable = false)
+    val expiresAt: LocalDateTime,
+) : BaseEntity()

--- a/src/main/kotlin/com/team2/server/party/repository/ParticipantRepository.kt
+++ b/src/main/kotlin/com/team2/server/party/repository/ParticipantRepository.kt
@@ -1,0 +1,11 @@
+package com.team2.server.party.repository
+
+import com.team2.server.party.entity.Participant
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ParticipantRepository : JpaRepository<Participant, Long> {
+    fun existsByPartyIdAndUserId(
+        partyId: Long,
+        userId: Long,
+    ): Boolean
+}

--- a/src/main/kotlin/com/team2/server/party/repository/PartyInviteRepository.kt
+++ b/src/main/kotlin/com/team2/server/party/repository/PartyInviteRepository.kt
@@ -1,0 +1,14 @@
+package com.team2.server.party.repository
+
+import com.team2.server.party.entity.PartyInvite
+import org.springframework.data.jpa.repository.JpaRepository
+import java.time.LocalDateTime
+
+interface PartyInviteRepository : JpaRepository<PartyInvite, Long> {
+    fun findByToken(token: String): PartyInvite?
+
+    fun findByPartyIdAndExpiresAtAfter(
+        partyId: Long,
+        now: LocalDateTime,
+    ): PartyInvite?
+}

--- a/src/main/kotlin/com/team2/server/party/service/PartyInviteService.kt
+++ b/src/main/kotlin/com/team2/server/party/service/PartyInviteService.kt
@@ -5,6 +5,7 @@ import com.team2.server.common.exception.ErrorCode
 import com.team2.server.party.dto.ActivateInviteLinkResponse
 import com.team2.server.party.entity.Party
 import com.team2.server.party.entity.PartyInvite
+import com.team2.server.party.repository.ParticipantRepository
 import com.team2.server.party.repository.PartyInviteRepository
 import com.team2.server.party.repository.PartyRepository
 import org.springframework.data.repository.findByIdOrNull
@@ -17,12 +18,20 @@ import java.time.LocalDateTime
 class PartyInviteService(
     private val partyRepository: PartyRepository,
     private val partyInviteRepository: PartyInviteRepository,
+    private val participantRepository: ParticipantRepository,
 ) {
     @Transactional
-    fun activateInviteLink(partyId: Long): ActivateInviteLinkResponse {
+    fun activateInviteLink(
+        partyId: Long,
+        userId: Long,
+    ): ActivateInviteLinkResponse {
         val party: Party =
             partyRepository.findByIdOrNull(partyId)
                 ?: throw BusinessException(ErrorCode.PARTY_NOT_FOUND)
+
+        if (!participantRepository.existsByPartyIdAndUserId(partyId, userId)) {
+            throw BusinessException(ErrorCode.PARTY_FORBIDDEN)
+        }
 
         val now = LocalDateTime.now()
 
@@ -37,7 +46,7 @@ class PartyInviteService(
         party: Party,
         now: LocalDateTime,
     ): PartyInvite {
-        val expiresAt = (party.startedAt ?: now).minusHours(EXPIRY_HOURS)
+        val expiresAt = (party.startedAt?.minusHours(EXPIRY_HOURS)) ?: now.plusHours(EXPIRY_HOURS)
         return partyInviteRepository.save(
             PartyInvite(
                 party = party,

--- a/src/main/kotlin/com/team2/server/party/service/PartyInviteService.kt
+++ b/src/main/kotlin/com/team2/server/party/service/PartyInviteService.kt
@@ -46,7 +46,7 @@ class PartyInviteService(
         party: Party,
         now: LocalDateTime,
     ): PartyInvite {
-        val expiresAt = (party.startedAt?.minusHours(EXPIRY_HOURS)) ?: now.plusHours(EXPIRY_HOURS)
+        val expiresAt = party.endedAt ?: now.plusHours(EXPIRY_HOURS)
         return partyInviteRepository.save(
             PartyInvite(
                 party = party,

--- a/src/main/kotlin/com/team2/server/party/service/PartyInviteService.kt
+++ b/src/main/kotlin/com/team2/server/party/service/PartyInviteService.kt
@@ -1,0 +1,60 @@
+package com.team2.server.party.service
+
+import com.team2.server.common.exception.BusinessException
+import com.team2.server.common.exception.ErrorCode
+import com.team2.server.party.dto.ActivateInviteLinkResponse
+import com.team2.server.party.entity.Party
+import com.team2.server.party.entity.PartyInvite
+import com.team2.server.party.repository.PartyInviteRepository
+import com.team2.server.party.repository.PartyRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.security.SecureRandom
+import java.time.LocalDateTime
+
+@Service
+class PartyInviteService(
+    private val partyRepository: PartyRepository,
+    private val partyInviteRepository: PartyInviteRepository,
+) {
+    @Transactional
+    fun activateInviteLink(partyId: Long): ActivateInviteLinkResponse {
+        val party: Party =
+            partyRepository.findByIdOrNull(partyId)
+                ?: throw BusinessException(ErrorCode.PARTY_NOT_FOUND)
+
+        val now = LocalDateTime.now()
+
+        val invite =
+            partyInviteRepository.findByPartyIdAndExpiresAtAfter(partyId, now)
+                ?: createInvite(party, now)
+
+        return ActivateInviteLinkResponse(token = invite.token)
+    }
+
+    private fun createInvite(
+        party: Party,
+        now: LocalDateTime,
+    ): PartyInvite {
+        val expiresAt = (party.startedAt ?: now).minusHours(EXPIRY_HOURS)
+        return partyInviteRepository.save(
+            PartyInvite(
+                party = party,
+                token = generateToken(),
+                expiresAt = expiresAt,
+            ),
+        )
+    }
+
+    private fun generateToken(): String {
+        val bytes = ByteArray(TOKEN_BYTES)
+        SecureRandom().nextBytes(bytes)
+        return bytes.joinToString("") { "%02x".format(it) }
+    }
+
+    companion object {
+        private const val TOKEN_BYTES = 8
+        private const val EXPIRY_HOURS = 24L
+    }
+}

--- a/src/test/kotlin/com/team2/server/party/service/PartyInviteServiceTest.kt
+++ b/src/test/kotlin/com/team2/server/party/service/PartyInviteServiceTest.kt
@@ -30,8 +30,9 @@ class PartyInviteServiceTest {
         id: Long = 1L,
         ownerId: Long = 1L,
         startedAt: LocalDateTime? = LocalDateTime.now().plusDays(2),
+        endedAt: LocalDateTime? = LocalDateTime.now().plusDays(2).plusHours(3),
     ): Party {
-        val party = Party(ownerId = ownerId, startedAt = startedAt)
+        val party = Party(ownerId = ownerId, startedAt = startedAt, endedAt = endedAt)
         val idField: Field = party.javaClass.superclass.getDeclaredField("id")
         idField.isAccessible = true
         idField.set(party, id)
@@ -91,9 +92,9 @@ class PartyInviteServiceTest {
     }
 
     @Test
-    fun `링크 만료 시간은 파티 시작 시간 24시간 전`() {
-        val startedAt = LocalDateTime.of(2024, 11, 26, 14, 0)
-        val party = makeParty(startedAt = startedAt)
+    fun `링크 만료 시간은 파티 종료 시간까지`() {
+        val endedAt = LocalDateTime.of(2024, 11, 26, 22, 0)
+        val party = makeParty(endedAt = endedAt)
         whenever(partyRepository.findById(1L)).thenReturn(Optional.of(party))
         whenever(participantRepository.existsByPartyIdAndUserId(1L, 1L)).thenReturn(true)
         whenever(partyInviteRepository.findByPartyIdAndExpiresAtAfter(any(), any())).thenReturn(null)
@@ -105,6 +106,6 @@ class PartyInviteServiceTest {
 
         service.activateInviteLink(1L, 1L)
 
-        assertEquals(startedAt.minusHours(24), savedInvite!!.expiresAt)
+        assertEquals(endedAt, savedInvite!!.expiresAt)
     }
 }

--- a/src/test/kotlin/com/team2/server/party/service/PartyInviteServiceTest.kt
+++ b/src/test/kotlin/com/team2/server/party/service/PartyInviteServiceTest.kt
@@ -1,0 +1,94 @@
+package com.team2.server.party.service
+
+import com.team2.server.common.exception.BusinessException
+import com.team2.server.common.exception.ErrorCode
+import com.team2.server.party.entity.Party
+import com.team2.server.party.entity.PartyInvite
+import com.team2.server.party.repository.PartyInviteRepository
+import com.team2.server.party.repository.PartyRepository
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.lang.reflect.Field
+import java.time.LocalDateTime
+import java.util.Optional
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PartyInviteServiceTest {
+    private val partyRepository: PartyRepository = mock()
+    private val partyInviteRepository: PartyInviteRepository = mock()
+    private val service = PartyInviteService(partyRepository, partyInviteRepository)
+
+    private fun makeParty(
+        id: Long = 1L,
+        startedAt: LocalDateTime? = LocalDateTime.now().plusDays(2),
+    ): Party {
+        val party = Party(startedAt = startedAt)
+        val idField: Field = party.javaClass.superclass.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(party, id)
+        return party
+    }
+
+    private fun makeInvite(
+        party: Party,
+        token: String = "abc1def2ghi3jklm",
+        expiresAt: LocalDateTime = LocalDateTime.now().plusHours(1),
+    ): PartyInvite = PartyInvite(party = party, token = token, expiresAt = expiresAt)
+
+    @Test
+    fun `파티가 없으면 PARTY_NOT_FOUND 예외`() {
+        whenever(partyRepository.findById(99L)).thenReturn(Optional.empty())
+
+        val ex = assertThrows<BusinessException> { service.activateInviteLink(99L) }
+        assertEquals(ErrorCode.PARTY_NOT_FOUND, ex.errorCode)
+    }
+
+    @Test
+    fun `유효한 초대링크가 이미 있으면 새로 만들지 않고 재사용`() {
+        val party = makeParty()
+        val existingInvite = makeInvite(party, token = "existingtoken1234")
+        whenever(partyRepository.findById(1L)).thenReturn(Optional.of(party))
+        whenever(partyInviteRepository.findByPartyIdAndExpiresAtAfter(any(), any())).thenReturn(existingInvite)
+
+        val result = service.activateInviteLink(1L)
+
+        verify(partyInviteRepository, never()).save(any())
+        assertEquals(existingInvite.token, result.token)
+    }
+
+    @Test
+    fun `유효한 링크가 없으면 새 토큰으로 생성`() {
+        val party = makeParty()
+        whenever(partyRepository.findById(1L)).thenReturn(Optional.of(party))
+        whenever(partyInviteRepository.findByPartyIdAndExpiresAtAfter(any(), any())).thenReturn(null)
+        whenever(partyInviteRepository.save(any())).thenAnswer { it.arguments[0] as PartyInvite }
+
+        val result = service.activateInviteLink(1L)
+
+        verify(partyInviteRepository).save(any())
+        assertTrue(result.token.isNotBlank())
+    }
+
+    @Test
+    fun `링크 만료 시간은 파티 시작 시간 24시간 전`() {
+        val startedAt = LocalDateTime.of(2024, 11, 26, 14, 0)
+        val party = makeParty(startedAt = startedAt)
+        whenever(partyRepository.findById(1L)).thenReturn(Optional.of(party))
+        whenever(partyInviteRepository.findByPartyIdAndExpiresAtAfter(any(), any())).thenReturn(null)
+
+        var savedInvite: PartyInvite? = null
+        whenever(partyInviteRepository.save(any())).thenAnswer {
+            (it.arguments[0] as PartyInvite).also { invite -> savedInvite = invite }
+        }
+
+        service.activateInviteLink(1L)
+
+        assertEquals(startedAt.minusHours(24), savedInvite!!.expiresAt)
+    }
+}

--- a/src/test/kotlin/com/team2/server/party/service/PartyInviteServiceTest.kt
+++ b/src/test/kotlin/com/team2/server/party/service/PartyInviteServiceTest.kt
@@ -4,6 +4,7 @@ import com.team2.server.common.exception.BusinessException
 import com.team2.server.common.exception.ErrorCode
 import com.team2.server.party.entity.Party
 import com.team2.server.party.entity.PartyInvite
+import com.team2.server.party.repository.ParticipantRepository
 import com.team2.server.party.repository.PartyInviteRepository
 import com.team2.server.party.repository.PartyRepository
 import org.junit.jupiter.api.Test
@@ -22,7 +23,8 @@ import kotlin.test.assertTrue
 class PartyInviteServiceTest {
     private val partyRepository: PartyRepository = mock()
     private val partyInviteRepository: PartyInviteRepository = mock()
-    private val service = PartyInviteService(partyRepository, partyInviteRepository)
+    private val participantRepository: ParticipantRepository = mock()
+    private val service = PartyInviteService(partyRepository, partyInviteRepository, participantRepository)
 
     private fun makeParty(
         id: Long = 1L,
@@ -45,8 +47,18 @@ class PartyInviteServiceTest {
     fun `파티가 없으면 PARTY_NOT_FOUND 예외`() {
         whenever(partyRepository.findById(99L)).thenReturn(Optional.empty())
 
-        val ex = assertThrows<BusinessException> { service.activateInviteLink(99L) }
+        val ex = assertThrows<BusinessException> { service.activateInviteLink(99L, 1L) }
         assertEquals(ErrorCode.PARTY_NOT_FOUND, ex.errorCode)
+    }
+
+    @Test
+    fun `파티 멤버가 아니면 PARTY_FORBIDDEN 예외`() {
+        val party = makeParty()
+        whenever(partyRepository.findById(1L)).thenReturn(Optional.of(party))
+        whenever(participantRepository.existsByPartyIdAndUserId(1L, 2L)).thenReturn(false)
+
+        val ex = assertThrows<BusinessException> { service.activateInviteLink(1L, 2L) }
+        assertEquals(ErrorCode.PARTY_FORBIDDEN, ex.errorCode)
     }
 
     @Test
@@ -54,9 +66,10 @@ class PartyInviteServiceTest {
         val party = makeParty()
         val existingInvite = makeInvite(party, token = "existingtoken1234")
         whenever(partyRepository.findById(1L)).thenReturn(Optional.of(party))
+        whenever(participantRepository.existsByPartyIdAndUserId(1L, 1L)).thenReturn(true)
         whenever(partyInviteRepository.findByPartyIdAndExpiresAtAfter(any(), any())).thenReturn(existingInvite)
 
-        val result = service.activateInviteLink(1L)
+        val result = service.activateInviteLink(1L, 1L)
 
         verify(partyInviteRepository, never()).save(any())
         assertEquals(existingInvite.token, result.token)
@@ -66,10 +79,11 @@ class PartyInviteServiceTest {
     fun `유효한 링크가 없으면 새 토큰으로 생성`() {
         val party = makeParty()
         whenever(partyRepository.findById(1L)).thenReturn(Optional.of(party))
+        whenever(participantRepository.existsByPartyIdAndUserId(1L, 1L)).thenReturn(true)
         whenever(partyInviteRepository.findByPartyIdAndExpiresAtAfter(any(), any())).thenReturn(null)
         whenever(partyInviteRepository.save(any())).thenAnswer { it.arguments[0] as PartyInvite }
 
-        val result = service.activateInviteLink(1L)
+        val result = service.activateInviteLink(1L, 1L)
 
         verify(partyInviteRepository).save(any())
         assertTrue(result.token.isNotBlank())
@@ -80,6 +94,7 @@ class PartyInviteServiceTest {
         val startedAt = LocalDateTime.of(2024, 11, 26, 14, 0)
         val party = makeParty(startedAt = startedAt)
         whenever(partyRepository.findById(1L)).thenReturn(Optional.of(party))
+        whenever(participantRepository.existsByPartyIdAndUserId(1L, 1L)).thenReturn(true)
         whenever(partyInviteRepository.findByPartyIdAndExpiresAtAfter(any(), any())).thenReturn(null)
 
         var savedInvite: PartyInvite? = null
@@ -87,7 +102,7 @@ class PartyInviteServiceTest {
             (it.arguments[0] as PartyInvite).also { invite -> savedInvite = invite }
         }
 
-        service.activateInviteLink(1L)
+        service.activateInviteLink(1L, 1L)
 
         assertEquals(startedAt.minusHours(24), savedInvite!!.expiresAt)
     }

--- a/src/test/kotlin/com/team2/server/party/service/PartyInviteServiceTest.kt
+++ b/src/test/kotlin/com/team2/server/party/service/PartyInviteServiceTest.kt
@@ -28,9 +28,10 @@ class PartyInviteServiceTest {
 
     private fun makeParty(
         id: Long = 1L,
+        ownerId: Long = 1L,
         startedAt: LocalDateTime? = LocalDateTime.now().plusDays(2),
     ): Party {
-        val party = Party(startedAt = startedAt)
+        val party = Party(ownerId = ownerId, startedAt = startedAt)
         val idField: Field = party.javaClass.superclass.getDeclaredField("id")
         idField.isAccessible = true
         idField.set(party, id)


### PR DESCRIPTION
## 🔗 Issue
- closes #37

## 💬 Context
파티에 참여할 수 있는 초대링크 기능이 필요했습니다. 프론트에서 초대링크를 공유하면 해당 링크로 파티에 참여할 수 있어야 하며, 유효한 초대링크가 이미 존재하면 재사용하고 만료된 경우에만 새로 발급하는 방식으로 설계했습니다. 또한 로컬 개발 환경에서 카카오 OAuth 없이도 API를 테스트할 수 있도록 개발용 토큰 발급 엔드포인트도 함께 추가했습니다.

## 🛠 Changes
- `PartyInvite` 엔티티 추가 — 토큰(16자 hex), 만료시간을 별도 테이블로 관리
- `POST /api/v1/parties/{partyId}/invite-link` — 초대 토큰 활성화/재사용 API 구현
- 토큰 만료 시간은 파티 시작 시간 24시간 전으로 설정
- `POST /api/dev/token` — 개발용 JWT 발급 API 추가 (`!prod` 프로파일에서만 활성화)
- Swagger에 Bearer Authentication `@SecurityScheme` 설정 추가
- `/api/dev/**` SecurityConfig permitAll 추가
- detekt `UnusedParameter` 룰에 `@AuthenticationPrincipal` 예외 설정

## 👀 Review Focus
- `PartyInviteService.createInvite()` — 만료 시간 계산 로직 (`startedAt ?: now - 24h`): `startedAt`이 null인 경우 현재 시각 기준으로 폴백하는 게 적절한지 확인 부탁드립니다
- `SecureRandom`으로 생성한 8바이트 hex 토큰(16자) — 충돌 가능성이나 길이가 적절한지 검토 부탁드립니다
- `DevTokenController`가 `@Profile("!prod")`로만 제한되어 있는데 추가 보안 장치가 필요한지 의견 주세요

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능
- 파티에 대한 초대링크 생성 및 활성화 기능 추가
- 초대링크를 통한 새로운 참여자 초대 지원
- 파티 종료 시간을 기반으로 하는 초대링크 자동 만료 설정

## 개선사항
- 파티 미검색, 권한 부족, 초대링크 만료 등 관련 오류 메시지 개선

## 테스트
- 파티 초대 기능에 대한 서비스 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->