### PR TITLE
[Feat] 파티 유형별 생성 엔드포인트 분리

### DIFF
--- a/src/main/kotlin/com/team2/server/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/team2/server/common/exception/GlobalExceptionHandler.kt
@@ -2,10 +2,12 @@ package com.team2.server.common.exception
 
 import com.team2.server.common.response.ErrorResponse
 import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 
 @RestControllerAdvice
 class GlobalExceptionHandler {
@@ -25,6 +27,12 @@ class GlobalExceptionHandler {
                 .joinToString(", ") { "${it.field}: ${it.defaultMessage}" }
         val response = ErrorResponse.of(e.statusCode, "VALIDATION_ERROR", message)
         return ResponseEntity.status(e.statusCode).body(response)
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException::class)
+    fun handleTypeMismatchException(e: MethodArgumentTypeMismatchException): ResponseEntity<ErrorResponse> {
+        val response = ErrorResponse.of(HttpStatus.BAD_REQUEST, "INVALID_INPUT", "잘못된 요청 값입니다: ${e.value}")
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response)
     }
 
     @ExceptionHandler(Exception::class)

--- a/src/main/kotlin/com/team2/server/party/controller/PartyController.kt
+++ b/src/main/kotlin/com/team2/server/party/controller/PartyController.kt
@@ -8,6 +8,7 @@ import com.team2.server.party.dto.CreatePartyResponse
 import com.team2.server.party.dto.JoinPartyRequest
 import com.team2.server.party.dto.ParticipantResponse
 import com.team2.server.party.dto.PartyInfoResponse
+import com.team2.server.party.entity.PartyOption
 import com.team2.server.party.service.PartyParticipationService
 import com.team2.server.party.service.PartyService
 import io.swagger.v3.oas.annotations.Operation
@@ -36,15 +37,28 @@ class PartyController(
     private val partyParticipationService: PartyParticipationService,
 ) {
     @Operation(
-        summary = "파티 생성",
+        summary = "실시간 파티 생성",
         security = [SecurityRequirement(name = "Bearer Authentication")],
     )
     @ResponseStatus(HttpStatus.CREATED)
-    @PostMapping()
-    fun createParty(
+    @PostMapping("/realtime")
+    fun createRealtimeParty(
         @AuthenticationPrincipal principal: UserPrincipal,
         @RequestBody request: CreatePartyRequest,
-    ): ApiResponse<CreatePartyResponse> = ApiResponse.success(partyService.createParty(principal.userId, request))
+    ): ApiResponse<CreatePartyResponse> =
+        ApiResponse.success(partyService.createParty(principal.userId, request, PartyOption.REALTIME))
+
+    @Operation(
+        summary = "롤링페이퍼 파티 생성",
+        security = [SecurityRequirement(name = "Bearer Authentication")],
+    )
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping("/paper")
+    fun createPaperOnlyParty(
+        @AuthenticationPrincipal principal: UserPrincipal,
+        @RequestBody request: CreatePartyRequest,
+    ): ApiResponse<CreatePartyResponse> =
+        ApiResponse.success(partyService.createParty(principal.userId, request, PartyOption.PAPER_ONLY))
 
     @Operation(summary = "파티 정보 조회", description = "초대 토큰으로 파티 정보를 조회한다.")
     @ApiResponses(

--- a/src/main/kotlin/com/team2/server/party/controller/PartyController.kt
+++ b/src/main/kotlin/com/team2/server/party/controller/PartyController.kt
@@ -37,28 +37,17 @@ class PartyController(
     private val partyParticipationService: PartyParticipationService,
 ) {
     @Operation(
-        summary = "실시간 파티 생성",
+        summary = "파티 생성 (REALTIME | PAPER_ONLY)",
         security = [SecurityRequirement(name = "Bearer Authentication")],
     )
     @ResponseStatus(HttpStatus.CREATED)
-    @PostMapping("/realtime")
-    fun createRealtimeParty(
+    @PostMapping("/{partyOption}")
+    fun createParty(
         @AuthenticationPrincipal principal: UserPrincipal,
+        @PathVariable partyOption: PartyOption,
         @RequestBody request: CreatePartyRequest,
     ): ApiResponse<CreatePartyResponse> =
-        ApiResponse.success(partyService.createParty(principal.userId, request, PartyOption.REALTIME))
-
-    @Operation(
-        summary = "롤링페이퍼 파티 생성",
-        security = [SecurityRequirement(name = "Bearer Authentication")],
-    )
-    @ResponseStatus(HttpStatus.CREATED)
-    @PostMapping("/paper")
-    fun createPaperOnlyParty(
-        @AuthenticationPrincipal principal: UserPrincipal,
-        @RequestBody request: CreatePartyRequest,
-    ): ApiResponse<CreatePartyResponse> =
-        ApiResponse.success(partyService.createParty(principal.userId, request, PartyOption.PAPER_ONLY))
+        ApiResponse.success(partyService.createParty(principal.userId, request, partyOption))
 
     @Operation(summary = "파티 정보 조회", description = "초대 토큰으로 파티 정보를 조회한다.")
     @ApiResponses(

--- a/src/main/kotlin/com/team2/server/party/dto/CreatePartyRequest.kt
+++ b/src/main/kotlin/com/team2/server/party/dto/CreatePartyRequest.kt
@@ -11,7 +11,7 @@ data class CreatePartyRequest(
     val celebrantNickname: String,
     @Schema(description = "파티 시작일", example = "2024-11-26")
     val startedDate: LocalDate,
-    @Schema(description = "파티 시작 시간 (HH:mm)", example = "14:30")
+    @Schema(description = "파티 시작 시간 (HH:mm). 미전송 시 00:00으로 설정됩니다.", example = "14:30")
     @JsonFormat(pattern = "HH:mm")
-    val startTime: LocalTime,
+    val startTime: LocalTime? = null,
 )

--- a/src/main/kotlin/com/team2/server/party/entity/Party.kt
+++ b/src/main/kotlin/com/team2/server/party/entity/Party.kt
@@ -29,10 +29,10 @@ class Party(
     var paperOpenedAt: LocalDateTime? = null,
     @Enumerated(EnumType.STRING)
     @Column(name = "party_type")
-    var option: PartyOption? = null,
+    var option: PartyOption,
     @Enumerated(EnumType.STRING)
     @Column(name = "purpose")
-    var purpose: PartyPurpose? = null,
+    var purpose: PartyPurpose = PartyPurpose.BIRTHDAY,
 ) : BaseEntity()
 
 enum class PartyOption {

--- a/src/main/kotlin/com/team2/server/party/service/PartyService.kt
+++ b/src/main/kotlin/com/team2/server/party/service/PartyService.kt
@@ -35,7 +35,16 @@ class PartyService(
         partyOption: PartyOption,
     ): CreatePartyResponse {
         val user = findUser(userId)
-        val startedAt = LocalDateTime.of(request.startedDate, request.startTime ?: LocalTime.MIDNIGHT)
+        val startedAt =
+            when (partyOption) {
+                PartyOption.PAPER_ONLY ->
+                    LocalDateTime.of(request.startedDate, request.startTime ?: LocalTime.MIDNIGHT)
+                PartyOption.REALTIME ->
+                    LocalDateTime.of(
+                        request.startedDate,
+                        requireNotNull(request.startTime) { "REALTIME 파티에는 startTime이 필요합니다." },
+                    )
+            }
         val party =
             Party(
                 ownerId = userId,

--- a/src/main/kotlin/com/team2/server/party/service/PartyService.kt
+++ b/src/main/kotlin/com/team2/server/party/service/PartyService.kt
@@ -10,6 +10,7 @@ import com.team2.server.party.dto.PartyInfoResponse
 import com.team2.server.party.entity.Participant
 import com.team2.server.party.entity.Party
 import com.team2.server.party.entity.PartyInvite
+import com.team2.server.party.entity.PartyOption
 import com.team2.server.party.repository.ParticipantRepository
 import com.team2.server.party.repository.PartyInviteRepository
 import com.team2.server.party.repository.PartyRepository
@@ -17,6 +18,7 @@ import com.team2.server.user.repository.UserRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
+import java.time.LocalTime
 
 @Service
 class PartyService(
@@ -30,14 +32,16 @@ class PartyService(
     fun createParty(
         userId: Long,
         request: CreatePartyRequest,
+        partyOption: PartyOption,
     ): CreatePartyResponse {
         val user = findUser(userId)
-        val startedAt = LocalDateTime.of(request.startedDate, request.startTime)
+        val startedAt = LocalDateTime.of(request.startedDate, request.startTime ?: LocalTime.MIDNIGHT)
         val party =
             Party(
                 ownerId = userId,
                 celebrantNickname = request.celebrantNickname,
                 startedAt = startedAt,
+                option = partyOption,
             )
         val saved = partyRepository.save(party)
         participantRepository.save(

--- a/src/test/kotlin/com/team2/server/party/controller/PartyControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/party/controller/PartyControllerTest.kt
@@ -378,7 +378,7 @@ class PartyControllerTest
         @Test
         fun `인증 없이 실시간 파티 생성 시 401`() {
             mockMvc
-                .post("/api/v1/parties/realtime") {
+                .post("/api/v1/parties/REALTIME") {
                     contentType = MediaType.APPLICATION_JSON
                     content =
                         """
@@ -396,7 +396,7 @@ class PartyControllerTest
         @Test
         fun `인증 없이 롤링페이퍼 파티 생성 시 401`() {
             mockMvc
-                .post("/api/v1/parties/paper") {
+                .post("/api/v1/parties/PAPER_ONLY") {
                     contentType = MediaType.APPLICATION_JSON
                     content =
                         """
@@ -412,7 +412,7 @@ class PartyControllerTest
         }
 
         @Test
-        fun `실시간 파티 생성 성공`() {
+        fun `REALTIME 파티 생성 성공`() {
             val user =
                 userRepository.save(
                     User(
@@ -426,7 +426,7 @@ class PartyControllerTest
             val token = tokenProvider.issue(user)
 
             mockMvc
-                .post("/api/v1/parties/realtime") {
+                .post("/api/v1/parties/REALTIME") {
                     contentType = MediaType.APPLICATION_JSON
                     content =
                         """
@@ -444,7 +444,7 @@ class PartyControllerTest
         }
 
         @Test
-        fun `롤링페이퍼 파티 생성 성공 - 닉네임과 시작일만 필요`() {
+        fun `PAPER_ONLY 파티 생성 성공 - startTime 없이 가능`() {
             val user =
                 userRepository.save(
                     User(
@@ -458,7 +458,7 @@ class PartyControllerTest
             val token = tokenProvider.issue(user)
 
             mockMvc
-                .post("/api/v1/parties/paper") {
+                .post("/api/v1/parties/PAPER_ONLY") {
                     contentType = MediaType.APPLICATION_JSON
                     content =
                         """
@@ -471,6 +471,30 @@ class PartyControllerTest
                 }.andExpect {
                     status { isCreated() }
                     jsonPath("$.data.partyId") { isNumber() }
+                }
+        }
+
+        @Test
+        fun `잘못된 파티 유형으로 생성 시 400`() {
+            val user =
+                userRepository.save(
+                    User(
+                        name = "파티장",
+                        birthDay = "01-01",
+                        provider = AuthProvider.KAKAO,
+                        providerId = "kakao-invalid-1",
+                        email = "invalid@kakao.local",
+                    ),
+                )
+            val token = tokenProvider.issue(user)
+
+            mockMvc
+                .post("/api/v1/parties/invalid-type") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = """{"celebrantNickname": "홍길동", "startedDate": "2026-04-28", "startTime": "14:30"}"""
+                    header("Authorization", "Bearer $token")
+                }.andExpect {
+                    status { isBadRequest() }
                 }
         }
 

--- a/src/test/kotlin/com/team2/server/party/controller/PartyControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/party/controller/PartyControllerTest.kt
@@ -376,9 +376,9 @@ class PartyControllerTest
         }
 
         @Test
-        fun `인증 없이 파티 생성 시 401`() {
+        fun `인증 없이 실시간 파티 생성 시 401`() {
             mockMvc
-                .post("/api/v1/parties") {
+                .post("/api/v1/parties/realtime") {
                     contentType = MediaType.APPLICATION_JSON
                     content =
                         """
@@ -390,6 +390,87 @@ class PartyControllerTest
                         """.trimIndent()
                 }.andExpect {
                     status { isUnauthorized() }
+                }
+        }
+
+        @Test
+        fun `인증 없이 롤링페이퍼 파티 생성 시 401`() {
+            mockMvc
+                .post("/api/v1/parties/paper") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content =
+                        """
+                        {
+                          "celebrantNickname": "홍길동",
+                          "startedDate": "2026-04-28",
+                          "startTime": "14:30"
+                        }
+                        """.trimIndent()
+                }.andExpect {
+                    status { isUnauthorized() }
+                }
+        }
+
+        @Test
+        fun `실시간 파티 생성 성공`() {
+            val user =
+                userRepository.save(
+                    User(
+                        name = "파티장",
+                        birthDay = "01-01",
+                        provider = AuthProvider.KAKAO,
+                        providerId = "kakao-create-1",
+                        email = "create@kakao.local",
+                    ),
+                )
+            val token = tokenProvider.issue(user)
+
+            mockMvc
+                .post("/api/v1/parties/realtime") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content =
+                        """
+                        {
+                          "celebrantNickname": "홍길동",
+                          "startedDate": "2026-04-28",
+                          "startTime": "14:30"
+                        }
+                        """.trimIndent()
+                    header("Authorization", "Bearer $token")
+                }.andExpect {
+                    status { isCreated() }
+                    jsonPath("$.data.partyId") { isNumber() }
+                }
+        }
+
+        @Test
+        fun `롤링페이퍼 파티 생성 성공 - 닉네임과 시작일만 필요`() {
+            val user =
+                userRepository.save(
+                    User(
+                        name = "파티장",
+                        birthDay = "01-01",
+                        provider = AuthProvider.KAKAO,
+                        providerId = "kakao-create-2",
+                        email = "create2@kakao.local",
+                    ),
+                )
+            val token = tokenProvider.issue(user)
+
+            mockMvc
+                .post("/api/v1/parties/paper") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content =
+                        """
+                        {
+                          "celebrantNickname": "홍길동",
+                          "startedDate": "2026-04-28"
+                        }
+                        """.trimIndent()
+                    header("Authorization", "Bearer $token")
+                }.andExpect {
+                    status { isCreated() }
+                    jsonPath("$.data.partyId") { isNumber() }
                 }
         }
 

--- a/src/test/kotlin/com/team2/server/party/service/PartyInviteServiceTest.kt
+++ b/src/test/kotlin/com/team2/server/party/service/PartyInviteServiceTest.kt
@@ -4,6 +4,7 @@ import com.team2.server.common.exception.BusinessException
 import com.team2.server.common.exception.ErrorCode
 import com.team2.server.party.entity.Party
 import com.team2.server.party.entity.PartyInvite
+import com.team2.server.party.entity.PartyOption
 import com.team2.server.party.repository.ParticipantRepository
 import com.team2.server.party.repository.PartyInviteRepository
 import com.team2.server.party.repository.PartyRepository
@@ -31,8 +32,9 @@ class PartyInviteServiceTest {
         ownerId: Long = 1L,
         startedAt: LocalDateTime? = LocalDateTime.now().plusDays(2),
         endedAt: LocalDateTime? = LocalDateTime.now().plusDays(2).plusHours(3),
+        option: PartyOption = PartyOption.REALTIME,
     ): Party {
-        val party = Party(ownerId = ownerId, startedAt = startedAt, endedAt = endedAt)
+        val party = Party(ownerId = ownerId, startedAt = startedAt, endedAt = endedAt, option = option)
         val idField: Field = party.javaClass.superclass.getDeclaredField("id")
         idField.isAccessible = true
         idField.set(party, id)

--- a/src/test/kotlin/com/team2/server/party/service/PartyServiceTest.kt
+++ b/src/test/kotlin/com/team2/server/party/service/PartyServiceTest.kt
@@ -119,7 +119,7 @@ class PartyServiceTest {
     // --- 파티 생성 ---
 
     @Test
-    fun `createParty startTime이 null이면 00시로 저장됨`() {
+    fun `createParty PAPER_ONLY에서 startTime null이면 00시로 저장됨`() {
         val user = newUser(id = 1L)
         val savedParty = newParty(id = 9L)
         val request =
@@ -137,6 +137,23 @@ class PartyServiceTest {
         val partyCaptor = argumentCaptor<Party>()
         verify(partyRepository).save(partyCaptor.capture())
         assertEquals(LocalDate.of(2026, 5, 1).atStartOfDay(), partyCaptor.firstValue.startedAt)
+    }
+
+    @Test
+    fun `createParty REALTIME에서 startTime null이면 예외 발생`() {
+        val request =
+            CreatePartyRequest(
+                celebrantNickname = "홍길동",
+                startedDate = LocalDate.of(2026, 5, 1),
+                startTime = null,
+            )
+
+        whenever(userRepository.findById(1L)).thenReturn(Optional.of(newUser(id = 1L)))
+
+        assertThrows<IllegalArgumentException> {
+            partyService.createParty(1L, request, PartyOption.REALTIME)
+        }
+        verify(partyRepository, never()).save(any())
     }
 
     @Test

--- a/src/test/kotlin/com/team2/server/party/service/PartyServiceTest.kt
+++ b/src/test/kotlin/com/team2/server/party/service/PartyServiceTest.kt
@@ -119,6 +119,69 @@ class PartyServiceTest {
     // --- 파티 생성 ---
 
     @Test
+    fun `createParty startTime이 null이면 00시로 저장됨`() {
+        val user = newUser(id = 1L)
+        val savedParty = newParty(id = 9L)
+        val request =
+            CreatePartyRequest(
+                celebrantNickname = "홍길동",
+                startedDate = LocalDate.of(2026, 5, 1),
+                startTime = null,
+            )
+
+        whenever(userRepository.findById(1L)).thenReturn(Optional.of(user))
+        whenever(partyRepository.save(any())).thenReturn(savedParty)
+
+        partyService.createParty(1L, request, PartyOption.PAPER_ONLY)
+
+        val partyCaptor = argumentCaptor<Party>()
+        verify(partyRepository).save(partyCaptor.capture())
+        assertEquals(LocalDate.of(2026, 5, 1).atStartOfDay(), partyCaptor.firstValue.startedAt)
+    }
+
+    @Test
+    fun `createParty REALTIME 옵션으로 생성하면 REALTIME이 저장됨`() {
+        val user = newUser(id = 1L)
+        val savedParty = newParty(id = 7L)
+        val request =
+            CreatePartyRequest(
+                celebrantNickname = "홍길동",
+                startedDate = LocalDate.of(2026, 4, 29),
+                startTime = LocalTime.of(14, 30),
+            )
+
+        whenever(userRepository.findById(1L)).thenReturn(Optional.of(user))
+        whenever(partyRepository.save(any())).thenReturn(savedParty)
+
+        partyService.createParty(1L, request, PartyOption.REALTIME)
+
+        val partyCaptor = argumentCaptor<Party>()
+        verify(partyRepository).save(partyCaptor.capture())
+        assertEquals(PartyOption.REALTIME, partyCaptor.firstValue.option)
+    }
+
+    @Test
+    fun `createParty PAPER_ONLY 옵션으로 생성하면 PAPER_ONLY가 저장됨`() {
+        val user = newUser(id = 1L)
+        val savedParty = newParty(id = 7L)
+        val request =
+            CreatePartyRequest(
+                celebrantNickname = "홍길동",
+                startedDate = LocalDate.of(2026, 4, 29),
+                startTime = LocalTime.of(14, 30),
+            )
+
+        whenever(userRepository.findById(1L)).thenReturn(Optional.of(user))
+        whenever(partyRepository.save(any())).thenReturn(savedParty)
+
+        partyService.createParty(1L, request, PartyOption.PAPER_ONLY)
+
+        val partyCaptor = argumentCaptor<Party>()
+        verify(partyRepository).save(partyCaptor.capture())
+        assertEquals(PartyOption.PAPER_ONLY, partyCaptor.firstValue.option)
+    }
+
+    @Test
     fun `createParty 파티 생성 시 주최자를 참여자로 저장`() {
         val user = newUser(id = 1L)
         val savedParty = newParty(id = 7L)
@@ -132,7 +195,7 @@ class PartyServiceTest {
         whenever(userRepository.findById(1L)).thenReturn(Optional.of(user))
         whenever(partyRepository.save(any())).thenReturn(savedParty)
 
-        val result = partyService.createParty(1L, request)
+        val result = partyService.createParty(1L, request, PartyOption.REALTIME)
 
         val participantCaptor = argumentCaptor<Participant>()
         verify(participantRepository).save(participantCaptor.capture())
@@ -156,7 +219,7 @@ class PartyServiceTest {
 
         val ex =
             assertThrows<BusinessException> {
-                partyService.createParty(1L, request)
+                partyService.createParty(1L, request, PartyOption.REALTIME)
             }
 
         assertEquals(ErrorCode.AUTH_USER_NOT_FOUND, ex.errorCode)


### PR DESCRIPTION
## 🔗 Issue
- closes #45

## 💬 Context
파티 생성 시 롤링페이퍼 전용 파티와 실시간 파티 중 유형을 선택할 수 있도록 엔드포인트를 분리했습니다.
기존 단일 `POST /api/v1/parties` 엔드포인트는 파티 유형을 구분하지 않았으나, 유형에 따라 요청 스펙(시작 시간 필수 여부 등)이 달라지므로 엔드포인트 수준에서 명확히 분리하였습니다.

## 🛠 Changes
- `POST /api/v1/parties` → `POST /api/v1/parties/realtime` (실시간 파티) / `POST /api/v1/parties/paper` (롤링페이퍼 파티) 로 분리
- `PartyService.createParty()`에 `partyOption: PartyOption` 파라미터 추가, 엔티티 저장 시 `option` 필드 반영
- `CreatePartyRequest.startTime`을 nullable로 변경 — 미전송 시 `00:00`으로 자동 세팅 (롤링페이퍼 파티용)
- 각 엔드포인트에 대한 서비스 단위 테스트 및 통합 테스트 추가

## 👀 Review Focus
- 롤링페이퍼 파티에서 `startTime`이 null일 때 `LocalTime.MIDNIGHT`으로 대체하는 방식이 적절한지
- 엔드포인트 분리 방식(`/realtime`, `/paper`)이 REST 설계 관점에서 적합한지

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 실시간 파티와 페이퍼 온리 파티 생성을 위한 별도의 엔드포인트 추가
  * 파티 생성 시 시작 시간을 선택 사항으로 변경 (미입력 시 자정으로 설정)

* **테스트**
  * 새로운 파티 생성 엔드포인트에 대한 테스트 커버리지 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->