### PR TITLE
[Chore] 배포 후 healthcheck 대기 및 CD 실패 처리 추가

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -60,10 +60,16 @@ wait_healthy() {
     local service="$2"
     local max_attempts=10
     local interval=10
+    local status
 
     echo "==> Waiting for $service to become healthy..."
     for i in $(seq 1 $max_attempts); do
-        status=$(docker compose $compose_files ps "$service" --format '{{.Health}}' 2>/dev/null || echo "unknown")
+        if ! status=$(docker compose $compose_files ps "$service" --format '{{.Health}}' 2>/dev/null); then
+            echo "ERROR: failed to read health status for $service"
+            return 1
+        fi
+        status=${status:-unknown}
+
         if [ "$status" = "healthy" ]; then
             echo "==> $service is healthy!"
             return 0
@@ -72,8 +78,11 @@ wait_healthy() {
             docker compose $compose_files logs --tail=50 "$service"
             return 1
         fi
-        echo "  [$i/$max_attempts] status=$status, waiting ${interval}s..."
-        sleep "$interval"
+
+        if [ "$i" -lt "$max_attempts" ]; then
+            echo "  [$i/$max_attempts] status=$status, waiting ${interval}s..."
+            sleep "$interval"
+        fi
     done
 
     echo "ERROR: $service failed to become healthy within $((max_attempts * interval))s. Dumping logs:"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -54,6 +54,33 @@ if [ "$ENV" = "prod" ] || [ "$ENV" = "all" ]; then
     parse_db_info "$SECRET_DIR/application-secret-prod.yml" "PROD" >> "$PROJECT_ROOT/.env"
 fi
 
+# 컨테이너 healthcheck 대기
+wait_healthy() {
+    local compose_files="$1"
+    local service="$2"
+    local max_attempts=10
+    local interval=10
+
+    echo "==> Waiting for $service to become healthy..."
+    for i in $(seq 1 $max_attempts); do
+        status=$(docker compose $compose_files ps "$service" --format '{{.Health}}' 2>/dev/null || echo "unknown")
+        if [ "$status" = "healthy" ]; then
+            echo "==> $service is healthy!"
+            return 0
+        elif [ "$status" = "unhealthy" ]; then
+            echo "ERROR: $service is unhealthy. Dumping logs:"
+            docker compose $compose_files logs --tail=50 "$service"
+            return 1
+        fi
+        echo "  [$i/$max_attempts] status=$status, waiting ${interval}s..."
+        sleep "$interval"
+    done
+
+    echo "ERROR: $service failed to become healthy within $((max_attempts * interval))s. Dumping logs:"
+    docker compose $compose_files logs --tail=50 "$service"
+    return 1
+}
+
 # 공유 네트워크 생성
 for network in dev-network prod-network; do
     if ! docker network inspect "$network" &>/dev/null; then
@@ -63,20 +90,17 @@ for network in dev-network prod-network; do
 done
 
 if [ "$ENV" = "dev" ] || [ "$ENV" = "all" ]; then
+    DEV_FILES="-f docker-compose.yml -f docker-compose.dev.yml"
     echo "==> Building and starting DEV containers..."
-    docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build
+    docker compose $DEV_FILES up -d --build
+    wait_healthy "$DEV_FILES" "app-dev"
 fi
 
 if [ "$ENV" = "prod" ] || [ "$ENV" = "all" ]; then
+    PROD_FILES="-f docker-compose.yml -f docker-compose.prod.yml"
     echo "==> Building and starting PROD containers..."
-    docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
+    docker compose $PROD_FILES up -d --build
+    wait_healthy "$PROD_FILES" "app-prod"
 fi
 
-echo "==> Done! Checking container status..."
-if [ "$ENV" = "dev" ]; then
-    docker compose -f docker-compose.yml -f docker-compose.dev.yml ps
-elif [ "$ENV" = "prod" ]; then
-    docker compose -f docker-compose.yml -f docker-compose.prod.yml ps
-else
-    docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.prod.yml ps
-fi
+echo "==> Done!"


### PR DESCRIPTION
## 🔗 Issue
- closes #49

## 💬 Context
`deploy.sh`가 `docker compose up -d`로 컨테이너를 띄운 후 healthcheck 결과를 기다리지 않고 바로 종료되어, 앱 기동 실패(시크릿 누락 등)해도 CD가 성공 처리되는 문제가 있었습니다.

## 🛠 Changes
- `deploy.sh`에 `wait_healthy` 함수 추가
  - 10초 간격으로 최대 10회(100초) healthcheck 상태 확인
  - `healthy` → 배포 성공
  - `unhealthy` → 컨테이너 로그 50줄 출력 후 exit 1
  - 타임아웃 → 컨테이너 로그 50줄 출력 후 exit 1

## 👀 Review Focus
- 대기 시간(100초)이 Spring Boot 기동 시간 대비 충분한지
- `start_period: 40s` 설정과의 조합이 적절한지

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [ ] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 배포 개선사항

* **Chores**
  * 배포 스크립트에 서비스 헬스 체크 기능이 추가되었습니다.
  * 컨테이너 시작 후 서비스가 정상 상태가 될 때까지 자동으로 대기합니다.
  * 헬스 체크 실패 시 최근 로그를 수집하여 문제 진단이 개선됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->