### PR TITLE
profiles.include 대신 profiles.group으로 시크릿 프로파일 분리

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,6 +1,4 @@
 spring:
-  profiles:
-    include: secret-dev
   jpa:
     hibernate:
       ddl-auto: update

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,6 +1,4 @@
 spring:
-  profiles:
-    include: secret-prod
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,11 @@ spring:
   application:
     name: team2-backend
   profiles:
-    include: secret
+    default: local
+    group:
+      local: secret
+      dev: secret-dev
+      prod: secret-prod
   jpa:
     hibernate:
       ddl-auto: update


### PR DESCRIPTION
## 🔗 Issue
- closes #46

## 💬 Context
`spring.profiles.include`는 프로파일별 파일(`application-dev.yml`)에서 사용할 수 없어 배포 시 앱 기동이 실패했습니다.
`spring.profiles.group`을 사용하여 `application.yml`에서 환경별 시크릿 프로파일을 매핑하도록 변경합니다.

## 🛠 Changes
- `application.yml`: `profiles.include: secret` → `profiles.default: local` + `profiles.group` (local→secret, dev→secret-dev, prod→secret-prod)
- `application-dev.yml`: `profiles.include: secret-dev` 제거
- `application-prod.yml`: `profiles.include: secret-prod` 제거

## 👀 Review Focus
- `profiles.group` 매핑이 기존 환경별 동작과 일치하는지
- 로컬 기본 프로파일이 `local`로 변경되는 것의 영향

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [ ] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견