### PR TITLE
[Chore] 모니터링 설정 환경별 분리 (local/dev/prod)

### DIFF
--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,14 +1,3 @@
-spring:
-  profiles:
-    include: secret-dev
-  jpa:
-    hibernate:
-      ddl-auto: update
-    show-sql: true
-    properties:
-      hibernate:
-        format_sql: true
-
 management:
   endpoints:
     web:
@@ -22,4 +11,4 @@ management:
       application: ${spring.application.name}
 
 loki:
-  url: http://loki:3100
+  url: http://localhost:3100

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -12,3 +12,18 @@ spring:
 springdoc:
   swagger-ui:
     enabled: false
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: never
+  metrics:
+    tags:
+      application: ${spring.application.name}
+
+loki:
+  url: http://loki:3100

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,15 +11,3 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.MySQLDialect
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health, info, prometheus, metrics
-  endpoint:
-    health:
-      show-details: always
-  metrics:
-    tags:
-      application: ${spring.application.name}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,19 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <springProperty scope="context" name="APP_NAME" source="spring.application.name"/>
+    <springProperty scope="context" name="LOKI_URL" source="loki.url" defaultValue="http://localhost:3100"/>
 
-    <!-- 콘솔 출력 (MDC 포함) -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level [%X{traceId}] [%X{requestId}] %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 
-    <!-- Loki 전송 -->
-    <!-- TODO: [운영] 앱을 Docker로 띄울 경우 URL을 http://loki:3100/loki/api/v1/push 로 변경 -->
     <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
         <http>
-            <url>http://localhost:3100/loki/api/v1/push</url>
+            <url>${LOKI_URL}/loki/api/v1/push</url>
         </http>
         <format>
             <label>
@@ -26,6 +24,7 @@
         </format>
     </appender>
 
+    <!-- 로컬: 콘솔 + Loki (localhost:3100) -->
     <springProfile name="local">
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
@@ -33,24 +32,25 @@
         </root>
     </springProfile>
 
+    <!-- dev: 콘솔 + Loki (Docker loki:3100) -->
+    <springProfile name="dev">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="LOKI"/>
+        </root>
+    </springProfile>
+
+    <!-- prod: Loki만 (Docker loki:3100) -->
     <springProfile name="prod">
         <root level="INFO">
             <appender-ref ref="LOKI"/>
         </root>
     </springProfile>
 
-    <!-- 테스트 프로필: Loki 미사용 -->
+    <!-- test: 콘솔만 -->
     <springProfile name="test">
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
-        </root>
-    </springProfile>
-
-    <!-- 프로필 미지정 시 기본 -->
-    <springProfile name="!local &amp; !prod &amp; !test">
-        <root level="INFO">
-            <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="LOKI"/>
         </root>
     </springProfile>
 </configuration>


### PR DESCRIPTION
## 🔗 Issue
- closes #

## 💬 Context
기존에는 Actuator 엔드포인트 노출 범위와 Loki URL이 `application.yml`에 공통으로 설정되어 있어, prod 환경에서도 prometheus/metrics 엔드포인트가 인증 없이 열려 있었습니다. 또한 logback의 Loki URL이 `localhost:3100`으로 하드코딩되어 있어 Docker 환경(dev/prod)에서는 TODO 주석을 보고 수동으로 변경해야 했습니다. 환경별 관심사를 분리하여 보안을 강화하고 설정의 명확성을 높였습니다.

## 🛠 Changes
- `application.yml` — 공통 management 설정 제거
- `application-local.yml` 신규 생성 — 전체 Actuator 엔드포인트 노출, Loki URL을 `localhost:3100`으로 설정
- `application-dev.yml` — 전체 Actuator 노출, Loki URL을 Docker 컨테이너 주소(`http://loki:3100`)로 설정
- `application-prod.yml` — Actuator는 `health` 엔드포인트만 노출, `show-details: never`, Loki URL Docker 주소 설정
- `logback-spring.xml` — Loki URL을 `springProperty`로 주입(`loki.url`)하여 하드코딩 제거, 명시적 `dev` 프로필 추가

## 👀 Review Focus
- prod의 management 노출 범위가 `health`만인 것이 적절한지 — prometheus 수집이 내부망에서 이루어진다면 prod에도 추가가 필요할 수 있습니다
- `logback-spring.xml`에서 `springProperty`로 `loki.url`을 읽어오는 방식이 Spring 초기화 순서상 안전한지 확인 필요

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 개발, 로컬, 프로덕션 환경별 모니터링 및 로깅 구성 업데이트
  * 애플리케이션 메트릭, 상태 정보, Prometheus 모니터링 엔드포인트 환경별 활성화
  * Loki 로그 수집 서비스 통합 추가
  * 환경별 차별화된 로깅 프로필 설정으로 콘솔 및 Loki 출력 구성

<!-- end of auto-generated comment: release notes by coderabbit.ai -->