### PR TITLE
Swagger API 인터페이스 분리 및 공통 에러 어노테이션 도입

### DIFF
--- a/docs/swagger-interface.md
+++ b/docs/swagger-interface.md
@@ -1,0 +1,141 @@
+# Swagger API 인터페이스 패턴 가이드
+
+## 개요
+
+컨트롤러의 Swagger 문서 어노테이션을 `*Api.kt` 인터페이스로 분리하여, **문서와 비즈니스 로직을 완전히 분리**하는 패턴입니다.
+
+## 구조
+
+```
+party/controller/
+├── PartyApi.kt              ← Swagger 문서 (인터페이스)
+├── PartyController.kt       ← 비즈니스 로직 (구현체)
+├── PartyInviteApi.kt
+└── PartyInviteController.kt
+
+common/swagger/
+├── AuthErrorResponses.kt         ← 401 (인증 실패)
+├── ForbiddenResponse.kt          ← 403 (권한 없음)
+├── ValidationErrorResponse.kt    ← 400 (입력값 검증 실패)
+└── InternalServerErrorResponse.kt ← 500 (서버 내부 오류)
+```
+
+## 사용법
+
+### 1. 새 API 엔드포인트 추가 시
+
+**Api 인터페이스에 메서드 + Swagger 어노테이션 정의:**
+
+```kotlin
+// ExampleApi.kt
+@Tag(name = "Example", description = "예시 API")
+interface ExampleApi {
+
+    @Operation(
+        summary = "예시 조회",
+        security = [SecurityRequirement(name = "Bearer Authentication")],
+    )
+    @SwaggerApiResponse(
+        responseCode = "200",
+        description = "조회 성공",
+        content = [Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ApiResponse::class),
+            examples = [ExampleObject(value = """
+                {
+                  "status": 200,
+                  "data": { "id": 1, "name": "예시" }
+                }
+            """)]
+        )]
+    )
+    @AuthErrorResponses          // 401 자동 포함
+    @InternalServerErrorResponse // 500 자동 포함
+    fun getExample(
+        @Parameter(hidden = true) principal: UserPrincipal,
+        @Parameter(description = "예시 ID", example = "1") id: Long,
+    ): ApiResponse<ExampleResponse>
+}
+```
+
+**Controller는 인터페이스 구현만:**
+
+```kotlin
+// ExampleController.kt
+@RestController
+@RequestMapping("/api/v1/examples")
+class ExampleController(
+    private val exampleService: ExampleService,
+) : ExampleApi {
+
+    @GetMapping("/{id}")
+    override fun getExample(
+        @AuthenticationPrincipal principal: UserPrincipal,
+        @PathVariable id: Long,
+    ): ApiResponse<ExampleResponse> =
+        ApiResponse.success(exampleService.getExample(id))
+}
+```
+
+### 2. 공통 에러 어노테이션 사용
+
+메서드 위에 붙이면 해당 에러 응답이 Swagger UI에 자동으로 포함됩니다.
+
+| 어노테이션 | 응답 코드 | 언제 사용 |
+|---|---|---|
+| `@AuthErrorResponses` | 401 | 로그인 필수 API |
+| `@ForbiddenResponse` | 403 | 리소스 소유자 검증 API |
+| `@ValidationErrorResponse` | 400 | `@Valid` 사용하는 API |
+| `@InternalServerErrorResponse` | 500 | 모든 API |
+
+### 3. 인증 선택 API (토큰 있으면 쓰고, 없어도 동작)
+
+```kotlin
+@Operation(
+    summary = "파티 정보 조회",
+    security = [
+        SecurityRequirement(name = "Bearer Authentication"),
+        SecurityRequirement(name = ""),  // 토큰 없이도 호출 가능
+    ],
+)
+```
+
+### 4. 도메인 특화 에러 응답
+
+공통 어노테이션에 없는 에러(404, 409 등)는 인터페이스에서 직접 작성합니다.
+
+```kotlin
+@SwaggerApiResponse(
+    responseCode = "404",
+    description = "존재하지 않는 파티",
+    content = [Content(
+        mediaType = "application/json",
+        schema = Schema(implementation = ErrorResponse::class),
+        examples = [ExampleObject(value = """
+            {
+              "status": 404,
+              "error": {
+                "code": "PARTY_NOT_FOUND",
+                "message": "파티를 찾을 수 없습니다"
+              }
+            }
+        """)]
+    )]
+)
+```
+
+## 규칙
+
+- **Api 인터페이스**: `@Tag`, `@Operation`, `@SwaggerApiResponse`, `@Parameter`, 공통 에러 어노테이션만 작성
+- **Controller**: `@RestController`, `@RequestMapping`, HTTP 메서드 매핑(`@GetMapping` 등), `@AuthenticationPrincipal`, `@PathVariable`, `@RequestBody`만 작성
+- **ExampleObject**: 반드시 실제 JSON 예시를 포함 (schema만으로는 `"code": "string"` 같이 표시됨)
+- **import alias**: Swagger의 `@ApiResponse`는 우리 `ApiResponse`와 이름이 겹치므로 `import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse`로 사용
+
+## 새 도메인 추가 체크리스트
+
+1. `{도메인}/controller/{Domain}Api.kt` 인터페이스 생성
+2. `@Tag(name = "도메인명")` 지정
+3. 각 메서드에 `@Operation` + 성공 응답 + 에러 응답 작성
+4. 공통 에러는 어노테이션으로, 도메인 특화 에러는 직접 작성
+5. Controller에서 인터페이스 구현 (`: {Domain}Api`)
+6. Controller에서 기존 Swagger 어노테이션 제거

--- a/src/main/kotlin/com/team2/server/common/response/ApiResponse.kt
+++ b/src/main/kotlin/com/team2/server/common/response/ApiResponse.kt
@@ -1,9 +1,13 @@
 package com.team2.server.common.response
 
+import io.swagger.v3.oas.annotations.media.Schema
 import org.springframework.http.HttpStatus
 
+@Schema(description = "공통 성공 응답")
 data class ApiResponse<T>(
+    @Schema(description = "HTTP 상태 코드", example = "200")
     val status: Int,
+    @Schema(description = "응답 데이터")
     val data: T?,
 ) {
     companion object {

--- a/src/main/kotlin/com/team2/server/common/response/ApiResponse.kt
+++ b/src/main/kotlin/com/team2/server/common/response/ApiResponse.kt
@@ -13,6 +13,8 @@ data class ApiResponse<T>(
     companion object {
         fun <T> success(data: T): ApiResponse<T> = ApiResponse(HttpStatus.OK.value(), data)
 
+        fun <T> success(status: HttpStatus, data: T): ApiResponse<T> = ApiResponse(status.value(), data)
+
         fun success(): ApiResponse<Unit> = ApiResponse(HttpStatus.OK.value(), null)
     }
 }

--- a/src/main/kotlin/com/team2/server/common/response/ApiResponse.kt
+++ b/src/main/kotlin/com/team2/server/common/response/ApiResponse.kt
@@ -13,7 +13,10 @@ data class ApiResponse<T>(
     companion object {
         fun <T> success(data: T): ApiResponse<T> = ApiResponse(HttpStatus.OK.value(), data)
 
-        fun <T> success(status: HttpStatus, data: T): ApiResponse<T> = ApiResponse(status.value(), data)
+        fun <T> success(
+            status: HttpStatus,
+            data: T,
+        ): ApiResponse<T> = ApiResponse(status.value(), data)
 
         fun success(): ApiResponse<Unit> = ApiResponse(HttpStatus.OK.value(), null)
     }

--- a/src/main/kotlin/com/team2/server/common/response/ErrorResponse.kt
+++ b/src/main/kotlin/com/team2/server/common/response/ErrorResponse.kt
@@ -1,13 +1,20 @@
 package com.team2.server.common.response
 
+import io.swagger.v3.oas.annotations.media.Schema
 import org.springframework.http.HttpStatusCode
 
+@Schema(description = "공통 에러 응답")
 data class ErrorResponse(
+    @Schema(description = "HTTP 상태 코드", example = "400")
     val status: Int,
+    @Schema(description = "에러 상세")
     val error: ErrorDetail,
 ) {
+    @Schema(description = "에러 상세 정보")
     data class ErrorDetail(
+        @Schema(description = "에러 코드", example = "PARTY_NOT_FOUND")
         val code: String,
+        @Schema(description = "에러 메시지", example = "파티를 찾을 수 없습니다")
         val message: String,
     )
 

--- a/src/main/kotlin/com/team2/server/common/swagger/AuthErrorResponses.kt
+++ b/src/main/kotlin/com/team2/server/common/swagger/AuthErrorResponses.kt
@@ -1,0 +1,62 @@
+package com.team2.server.common.swagger
+
+import com.team2.server.common.response.ErrorResponse
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@ApiResponses(
+    ApiResponse(
+        responseCode = "401",
+        description = "인증 실패",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = ErrorResponse::class),
+                examples = [
+                    ExampleObject(
+                        name = "인증 필요",
+                        value = """
+                            {
+                              "status": 401,
+                              "error": {
+                                "code": "AUTH_UNAUTHORIZED",
+                                "message": "인증이 필요합니다"
+                              }
+                            }
+                        """,
+                    ),
+                    ExampleObject(
+                        name = "만료된 토큰",
+                        value = """
+                            {
+                              "status": 401,
+                              "error": {
+                                "code": "AUTH_EXPIRED_TOKEN",
+                                "message": "만료된 토큰입니다"
+                              }
+                            }
+                        """,
+                    ),
+                    ExampleObject(
+                        name = "유효하지 않은 토큰",
+                        value = """
+                            {
+                              "status": 401,
+                              "error": {
+                                "code": "AUTH_INVALID_TOKEN",
+                                "message": "유효하지 않은 토큰입니다"
+                              }
+                            }
+                        """,
+                    ),
+                ],
+            ),
+        ],
+    ),
+)
+annotation class AuthErrorResponses

--- a/src/main/kotlin/com/team2/server/common/swagger/ForbiddenResponse.kt
+++ b/src/main/kotlin/com/team2/server/common/swagger/ForbiddenResponse.kt
@@ -1,0 +1,34 @@
+package com.team2.server.common.swagger
+
+import com.team2.server.common.response.ErrorResponse
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@ApiResponse(
+    responseCode = "403",
+    description = "권한 없음",
+    content = [
+        Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+            examples = [
+                ExampleObject(
+                    value = """
+                        {
+                          "status": 403,
+                          "error": {
+                            "code": "PARTY_FORBIDDEN",
+                            "message": "파티에 대한 권한이 없습니다"
+                          }
+                        }
+                    """,
+                ),
+            ],
+        ),
+    ],
+)
+annotation class ForbiddenResponse

--- a/src/main/kotlin/com/team2/server/common/swagger/InternalServerErrorResponse.kt
+++ b/src/main/kotlin/com/team2/server/common/swagger/InternalServerErrorResponse.kt
@@ -1,0 +1,34 @@
+package com.team2.server.common.swagger
+
+import com.team2.server.common.response.ErrorResponse
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@ApiResponse(
+    responseCode = "500",
+    description = "서버 내부 오류",
+    content = [
+        Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+            examples = [
+                ExampleObject(
+                    value = """
+                        {
+                          "status": 500,
+                          "error": {
+                            "code": "INTERNAL_SERVER_ERROR",
+                            "message": "서버 내부 오류가 발생했습니다"
+                          }
+                        }
+                    """,
+                ),
+            ],
+        ),
+    ],
+)
+annotation class InternalServerErrorResponse

--- a/src/main/kotlin/com/team2/server/common/swagger/ValidationErrorResponse.kt
+++ b/src/main/kotlin/com/team2/server/common/swagger/ValidationErrorResponse.kt
@@ -1,0 +1,34 @@
+package com.team2.server.common.swagger
+
+import com.team2.server.common.response.ErrorResponse
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@ApiResponse(
+    responseCode = "400",
+    description = "입력값 검증 실패",
+    content = [
+        Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+            examples = [
+                ExampleObject(
+                    value = """
+                        {
+                          "status": 400,
+                          "error": {
+                            "code": "VALIDATION_ERROR",
+                            "message": "nickname: 닉네임은 필수입니다"
+                          }
+                        }
+                    """,
+                ),
+            ],
+        ),
+    ],
+)
+annotation class ValidationErrorResponse

--- a/src/main/kotlin/com/team2/server/party/controller/PartyApi.kt
+++ b/src/main/kotlin/com/team2/server/party/controller/PartyApi.kt
@@ -38,7 +38,7 @@ interface PartyApi {
                     ExampleObject(
                         value = """
                             {
-                              "status": 200,
+                              "status": 201,
                               "data": {
                                 "partyId": 1
                               }

--- a/src/main/kotlin/com/team2/server/party/controller/PartyApi.kt
+++ b/src/main/kotlin/com/team2/server/party/controller/PartyApi.kt
@@ -1,0 +1,299 @@
+package com.team2.server.party.controller
+
+import com.team2.server.auth.principal.UserPrincipal
+import com.team2.server.common.response.ApiResponse
+import com.team2.server.common.response.ErrorResponse
+import com.team2.server.common.swagger.AuthErrorResponses
+import com.team2.server.common.swagger.InternalServerErrorResponse
+import com.team2.server.common.swagger.ValidationErrorResponse
+import com.team2.server.party.dto.CreatePartyRequest
+import com.team2.server.party.dto.CreatePartyResponse
+import com.team2.server.party.dto.JoinPartyRequest
+import com.team2.server.party.dto.ParticipantResponse
+import com.team2.server.party.dto.PartyInfoResponse
+import com.team2.server.party.entity.PartyOption
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
+
+@Tag(name = "Party", description = "파티 API")
+interface PartyApi {
+    @Operation(
+        summary = "파티 생성 (REALTIME | PAPER_ONLY)",
+        security = [SecurityRequirement(name = "Bearer Authentication")],
+    )
+    @SwaggerApiResponse(
+        responseCode = "201",
+        description = "파티 생성 성공",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = ApiResponse::class),
+                examples = [
+                    ExampleObject(
+                        value = """
+                            {
+                              "status": 200,
+                              "data": {
+                                "partyId": 1
+                              }
+                            }
+                        """,
+                    ),
+                ],
+            ),
+        ],
+    )
+    @AuthErrorResponses
+    @InternalServerErrorResponse
+    fun createParty(
+        @Parameter(hidden = true) principal: UserPrincipal,
+        @Parameter(description = "파티 옵션", example = "REALTIME") partyOption: PartyOption,
+        request: CreatePartyRequest,
+    ): ApiResponse<CreatePartyResponse>
+
+    @Operation(summary = "파티 정보 조회", description = "초대 토큰으로 파티 정보를 조회한다.")
+    @SwaggerApiResponse(
+        responseCode = "200",
+        description = "파티 정보 조회 성공",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = ApiResponse::class),
+                examples = [
+                    ExampleObject(
+                        value = """
+                            {
+                              "status": 200,
+                              "data": {
+                                "name": "생일파티",
+                                "celebrantNickname": "홍길동",
+                                "purpose": "BIRTHDAY",
+                                "option": "CHAT_ALLOWED",
+                                "startedAt": "2024-11-26T14:30:00",
+                                "endedAt": null,
+                                "ended": false,
+                                "myParticipant": null
+                              }
+                            }
+                        """,
+                    ),
+                ],
+            ),
+        ],
+    )
+    @SwaggerApiResponse(
+        responseCode = "400",
+        description = "만료된 초대 토큰",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = ErrorResponse::class),
+                examples = [
+                    ExampleObject(
+                        value = """
+                            {
+                              "status": 400,
+                              "error": {
+                                "code": "INVITE_LINK_EXPIRED",
+                                "message": "만료된 초대링크입니다"
+                              }
+                            }
+                        """,
+                    ),
+                ],
+            ),
+        ],
+    )
+    @SwaggerApiResponse(
+        responseCode = "404",
+        description = "존재하지 않는 파티",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = ErrorResponse::class),
+                examples = [
+                    ExampleObject(
+                        value = """
+                            {
+                              "status": 404,
+                              "error": {
+                                "code": "PARTY_NOT_FOUND",
+                                "message": "파티를 찾을 수 없습니다"
+                              }
+                            }
+                        """,
+                    ),
+                ],
+            ),
+        ],
+    )
+    @InternalServerErrorResponse
+    fun getPartyInfo(
+        @Parameter(description = "초대 토큰", example = "a1b2c3d4e5f67890") inviteToken: String,
+        @Parameter(hidden = true) principal: UserPrincipal?,
+    ): ApiResponse<PartyInfoResponse>
+
+    @Operation(
+        summary = "파티 참여",
+        description =
+            "초대 토큰으로 파티에 참여한다. 회원/비회원 모두 가능. " +
+                "채팅 허용 파티는 characterId가 필수이며 누락 시 CHARACTER_REQUIRED를 반환한다. " +
+                "채팅 비허용 파티는 characterId를 보낼 수 없으며 전달 시 CHARACTER_NOT_ALLOWED를 반환한다.",
+    )
+    @SwaggerApiResponse(
+        responseCode = "200",
+        description = "파티 참여 성공",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = ApiResponse::class),
+                examples = [
+                    ExampleObject(
+                        value = """
+                            {
+                              "status": 200,
+                              "data": {
+                                "participantId": 10,
+                                "nickname": "홍길동",
+                                "characterImageUrl": "/images/characters/character1.jpg"
+                              }
+                            }
+                        """,
+                    ),
+                ],
+            ),
+        ],
+    )
+    @SwaggerApiResponse(
+        responseCode = "400",
+        description = "잘못된 요청 (만료된 초대 토큰, 종료된 파티, 캐릭터 선택 규칙 위반)",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = ErrorResponse::class),
+                examples = [
+                    ExampleObject(
+                        name = "만료된 초대링크",
+                        value = """
+                            {
+                              "status": 400,
+                              "error": {
+                                "code": "INVITE_LINK_EXPIRED",
+                                "message": "만료된 초대링크입니다"
+                              }
+                            }
+                        """,
+                    ),
+                    ExampleObject(
+                        name = "종료된 파티",
+                        value = """
+                            {
+                              "status": 400,
+                              "error": {
+                                "code": "PARTY_ENDED",
+                                "message": "이미 종료된 파티입니다"
+                              }
+                            }
+                        """,
+                    ),
+                    ExampleObject(
+                        name = "캐릭터 선택 필수",
+                        value = """
+                            {
+                              "status": 400,
+                              "error": {
+                                "code": "CHARACTER_REQUIRED",
+                                "message": "채팅 허용 파티는 캐릭터 선택이 필수입니다"
+                              }
+                            }
+                        """,
+                    ),
+                    ExampleObject(
+                        name = "캐릭터 선택 불가",
+                        value = """
+                            {
+                              "status": 400,
+                              "error": {
+                                "code": "CHARACTER_NOT_ALLOWED",
+                                "message": "채팅 비허용 파티는 캐릭터를 선택할 수 없습니다"
+                              }
+                            }
+                        """,
+                    ),
+                ],
+            ),
+        ],
+    )
+    @SwaggerApiResponse(
+        responseCode = "404",
+        description = "존재하지 않는 파티 또는 캐릭터",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = ErrorResponse::class),
+                examples = [
+                    ExampleObject(
+                        name = "파티 없음",
+                        value = """
+                            {
+                              "status": 404,
+                              "error": {
+                                "code": "PARTY_NOT_FOUND",
+                                "message": "파티를 찾을 수 없습니다"
+                              }
+                            }
+                        """,
+                    ),
+                    ExampleObject(
+                        name = "캐릭터 없음",
+                        value = """
+                            {
+                              "status": 404,
+                              "error": {
+                                "code": "CHARACTER_NOT_FOUND",
+                                "message": "캐릭터를 찾을 수 없습니다"
+                              }
+                            }
+                        """,
+                    ),
+                ],
+            ),
+        ],
+    )
+    @SwaggerApiResponse(
+        responseCode = "409",
+        description = "이미 참여한 파티",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = ErrorResponse::class),
+                examples = [
+                    ExampleObject(
+                        value = """
+                            {
+                              "status": 409,
+                              "error": {
+                                "code": "ALREADY_JOINED",
+                                "message": "이미 참여한 파티입니다"
+                              }
+                            }
+                        """,
+                    ),
+                ],
+            ),
+        ],
+    )
+    @ValidationErrorResponse
+    @InternalServerErrorResponse
+    fun joinParty(
+        @Parameter(description = "초대 토큰", example = "a1b2c3d4e5f67890") inviteToken: String,
+        request: JoinPartyRequest,
+        @Parameter(hidden = true) principal: UserPrincipal?,
+    ): ApiResponse<ParticipantResponse>
+}

--- a/src/main/kotlin/com/team2/server/party/controller/PartyApi.kt
+++ b/src/main/kotlin/com/team2/server/party/controller/PartyApi.kt
@@ -57,7 +57,14 @@ interface PartyApi {
         request: CreatePartyRequest,
     ): ApiResponse<CreatePartyResponse>
 
-    @Operation(summary = "파티 정보 조회", description = "초대 토큰으로 파티 정보를 조회한다.")
+    @Operation(
+        summary = "파티 정보 조회",
+        description = "초대 토큰으로 파티 정보를 조회한다. 인증은 선택사항이며, 토큰이 있으면 회원 정보를 활용한다.",
+        security = [
+            SecurityRequirement(name = "Bearer Authentication"),
+            SecurityRequirement(name = ""),
+        ],
+    )
     @SwaggerApiResponse(
         responseCode = "200",
         description = "파티 정보 조회 성공",
@@ -145,6 +152,10 @@ interface PartyApi {
             "초대 토큰으로 파티에 참여한다. 회원/비회원 모두 가능. " +
                 "채팅 허용 파티는 characterId가 필수이며 누락 시 CHARACTER_REQUIRED를 반환한다. " +
                 "채팅 비허용 파티는 characterId를 보낼 수 없으며 전달 시 CHARACTER_NOT_ALLOWED를 반환한다.",
+        security = [
+            SecurityRequirement(name = "Bearer Authentication"),
+            SecurityRequirement(name = ""),
+        ],
     )
     @SwaggerApiResponse(
         responseCode = "200",

--- a/src/main/kotlin/com/team2/server/party/controller/PartyController.kt
+++ b/src/main/kotlin/com/team2/server/party/controller/PartyController.kt
@@ -2,7 +2,6 @@ package com.team2.server.party.controller
 
 import com.team2.server.auth.principal.UserPrincipal
 import com.team2.server.common.response.ApiResponse
-import com.team2.server.common.response.ErrorResponse
 import com.team2.server.party.dto.CreatePartyRequest
 import com.team2.server.party.dto.CreatePartyResponse
 import com.team2.server.party.dto.JoinPartyRequest
@@ -11,12 +10,6 @@ import com.team2.server.party.dto.PartyInfoResponse
 import com.team2.server.party.entity.PartyOption
 import com.team2.server.party.service.PartyParticipationService
 import com.team2.server.party.service.PartyService
-import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.media.Content
-import io.swagger.v3.oas.annotations.media.Schema
-import io.swagger.v3.oas.annotations.responses.ApiResponses
-import io.swagger.v3.oas.annotations.security.SecurityRequirement
-import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -27,117 +20,30 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
-import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
 
-@Tag(name = "Party", description = "파티 API")
 @RestController
 @RequestMapping("/api/v1/parties")
 class PartyController(
     private val partyService: PartyService,
     private val partyParticipationService: PartyParticipationService,
-) {
-    @Operation(
-        summary = "파티 생성 (REALTIME | PAPER_ONLY)",
-        security = [SecurityRequirement(name = "Bearer Authentication")],
-    )
+) : PartyApi {
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/{partyOption}")
-    fun createParty(
+    override fun createParty(
         @AuthenticationPrincipal principal: UserPrincipal,
         @PathVariable partyOption: PartyOption,
         @RequestBody request: CreatePartyRequest,
     ): ApiResponse<CreatePartyResponse> =
         ApiResponse.success(partyService.createParty(principal.userId, request, partyOption))
 
-    @Operation(summary = "파티 정보 조회", description = "초대 토큰으로 파티 정보를 조회한다.")
-    @ApiResponses(
-        value = [
-            SwaggerApiResponse(
-                responseCode = "200",
-                description = "파티 정보 조회 성공",
-                content = [
-                    Content(
-                        schema = Schema(implementation = ApiResponse::class),
-                    ),
-                ],
-            ),
-            SwaggerApiResponse(
-                responseCode = "400",
-                description = "만료된 초대 토큰 (INVITE_LINK_EXPIRED)",
-                content = [
-                    Content(
-                        schema = Schema(implementation = ErrorResponse::class),
-                    ),
-                ],
-            ),
-            SwaggerApiResponse(
-                responseCode = "404",
-                description = "존재하지 않는 파티 또는 초대 토큰 (PARTY_NOT_FOUND)",
-                content = [
-                    Content(
-                        schema = Schema(implementation = ErrorResponse::class),
-                    ),
-                ],
-            ),
-        ],
-    )
     @GetMapping("/{inviteToken}")
-    fun getPartyInfo(
+    override fun getPartyInfo(
         @PathVariable inviteToken: String,
         @AuthenticationPrincipal principal: UserPrincipal?,
     ): ApiResponse<PartyInfoResponse> = ApiResponse.success(partyService.getPartyInfo(inviteToken, principal?.userId))
 
-    @Operation(
-        summary = "파티 참여",
-        description =
-            "초대 토큰으로 파티에 참여한다. 회원/비회원 모두 가능. " +
-                "채팅 허용 파티는 characterId가 필수이며 누락 시 CHARACTER_REQUIRED를 반환한다. " +
-                "채팅 비허용 파티는 characterId를 보낼 수 없으며 전달 시 CHARACTER_NOT_ALLOWED를 반환한다.",
-    )
-    @ApiResponses(
-        value = [
-            SwaggerApiResponse(
-                responseCode = "200",
-                description = "파티 참여 성공",
-                content = [
-                    Content(
-                        schema = Schema(implementation = ApiResponse::class),
-                    ),
-                ],
-            ),
-            SwaggerApiResponse(
-                responseCode = "400",
-                description =
-                    "잘못된 요청, 만료된 초대 토큰, 종료된 파티, 캐릭터 선택 규칙 위반 " +
-                        "(INVITE_LINK_EXPIRED, PARTY_ENDED, CHARACTER_REQUIRED, CHARACTER_NOT_ALLOWED)",
-                content = [
-                    Content(
-                        schema = Schema(implementation = ErrorResponse::class),
-                    ),
-                ],
-            ),
-            SwaggerApiResponse(
-                responseCode = "404",
-                description = "존재하지 않는 파티 또는 캐릭터 (PARTY_NOT_FOUND, CHARACTER_NOT_FOUND)",
-                content = [
-                    Content(
-                        schema = Schema(implementation = ErrorResponse::class),
-                    ),
-                ],
-            ),
-            SwaggerApiResponse(
-                responseCode = "409",
-                description = "이미 참여한 파티 (ALREADY_JOINED)",
-                content = [
-                    Content(
-                        schema = Schema(implementation = ErrorResponse::class),
-                    ),
-                ],
-            ),
-        ],
-    )
     @PostMapping("/{inviteToken}/participants")
-    fun joinParty(
+    override fun joinParty(
         @PathVariable inviteToken: String,
         @Valid @RequestBody request: JoinPartyRequest,
         @AuthenticationPrincipal principal: UserPrincipal?,

--- a/src/main/kotlin/com/team2/server/party/controller/PartyController.kt
+++ b/src/main/kotlin/com/team2/server/party/controller/PartyController.kt
@@ -34,7 +34,7 @@ class PartyController(
         @PathVariable partyOption: PartyOption,
         @RequestBody request: CreatePartyRequest,
     ): ApiResponse<CreatePartyResponse> =
-        ApiResponse.success(partyService.createParty(principal.userId, request, partyOption))
+        ApiResponse.success(HttpStatus.CREATED, partyService.createParty(principal.userId, request, partyOption))
 
     @GetMapping("/{inviteToken}")
     override fun getPartyInfo(

--- a/src/main/kotlin/com/team2/server/party/controller/PartyInviteApi.kt
+++ b/src/main/kotlin/com/team2/server/party/controller/PartyInviteApi.kt
@@ -1,0 +1,77 @@
+package com.team2.server.party.controller
+
+import com.team2.server.auth.principal.UserPrincipal
+import com.team2.server.common.response.ApiResponse
+import com.team2.server.common.response.ErrorResponse
+import com.team2.server.common.swagger.AuthErrorResponses
+import com.team2.server.common.swagger.ForbiddenResponse
+import com.team2.server.common.swagger.InternalServerErrorResponse
+import com.team2.server.party.dto.ActivateInviteLinkResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
+
+@Tag(name = "Party", description = "파티 API")
+interface PartyInviteApi {
+    @Operation(
+        summary = "파티 초대링크 활성화",
+        security = [SecurityRequirement(name = "Bearer Authentication")],
+    )
+    @SwaggerApiResponse(
+        responseCode = "200",
+        description = "초대링크 활성화 성공",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = ApiResponse::class),
+                examples = [
+                    ExampleObject(
+                        value = """
+                            {
+                              "status": 200,
+                              "data": {
+                                "token": "a1b2c3d4e5f67890"
+                              }
+                            }
+                        """,
+                    ),
+                ],
+            ),
+        ],
+    )
+    @SwaggerApiResponse(
+        responseCode = "404",
+        description = "존재하지 않는 파티",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = ErrorResponse::class),
+                examples = [
+                    ExampleObject(
+                        value = """
+                            {
+                              "status": 404,
+                              "error": {
+                                "code": "PARTY_NOT_FOUND",
+                                "message": "파티를 찾을 수 없습니다"
+                              }
+                            }
+                        """,
+                    ),
+                ],
+            ),
+        ],
+    )
+    @AuthErrorResponses
+    @ForbiddenResponse
+    @InternalServerErrorResponse
+    fun activateInviteLink(
+        @Parameter(hidden = true) principal: UserPrincipal,
+        @Parameter(description = "파티 ID", example = "1") partyId: Long,
+    ): ApiResponse<ActivateInviteLinkResponse>
+}

--- a/src/main/kotlin/com/team2/server/party/controller/PartyInviteController.kt
+++ b/src/main/kotlin/com/team2/server/party/controller/PartyInviteController.kt
@@ -4,27 +4,19 @@ import com.team2.server.auth.principal.UserPrincipal
 import com.team2.server.common.response.ApiResponse
 import com.team2.server.party.dto.ActivateInviteLinkResponse
 import com.team2.server.party.service.PartyInviteService
-import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.security.SecurityRequirement
-import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
-@Tag(name = "Party", description = "파티 API")
 @RestController
 @RequestMapping("/api/v1/parties")
 class PartyInviteController(
     private val partyInviteService: PartyInviteService,
-) {
-    @Operation(
-        summary = "파티 초대링크 활성화",
-        security = [SecurityRequirement(name = "Bearer Authentication")],
-    )
+) : PartyInviteApi {
     @PostMapping("/{partyId}/invite-link")
-    fun activateInviteLink(
+    override fun activateInviteLink(
         @AuthenticationPrincipal principal: UserPrincipal,
         @PathVariable partyId: Long,
     ): ApiResponse<ActivateInviteLinkResponse> =


### PR DESCRIPTION
## 🔗 Issue
- closes #53

## 💬 Context
Swagger 어노테이션이 컨트롤러에 비즈니스 로직과 섞여 가독성이 떨어지고, 401/403/400/500 같은 공통 에러 응답을 매 엔드포인트마다 반복 작성해야 하는 문제를 해결합니다.
레퍼런스 프로젝트(5-team-service-cloud)의 인터페이스 분리 패턴을 Kotlin으로 도입했습니다.

## 🛠 Changes
- `ApiResponse`, `ErrorResponse`에 `@Schema` 어노테이션 추가 → Swagger UI에서 응답 구조 정확히 표시
- 공통 Swagger 에러 어노테이션 4종 생성 (`@AuthErrorResponses`, `@ForbiddenResponse`, `@ValidationErrorResponse`, `@InternalServerErrorResponse`)
- `PartyApi` 인터페이스 생성 → `PartyController`는 비즈니스 로직만 담당
- `PartyInviteApi` 인터페이스 생성 → `PartyInviteController`는 비즈니스 로직만 담당
- 선택적 인증 API(`getPartyInfo`, `joinParty`)에 `SecurityRequirement(name = "")` 추가
- Swagger API 인터페이스 패턴 가이드 문서 추가

## 📖 사용 가이드
새 API 추가 시 [`docs/swagger-interface.md`](docs/swagger-interface.md)를 참고해주세요.
공통 에러 어노테이션 사용법, 인터페이스 작성 규칙, 새 도메인 추가 체크리스트가 정리되어 있습니다.

## 👀 Review Focus
- 커스텀 합성 어노테이션(`@AuthErrorResponses` 등)이 Swagger UI에 정상 반영되는지 확인
- 인터페이스 메서드 시그니처와 컨트롤러 구현체의 파라미터 매핑이 올바른지

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [ ] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견