### PR TITLE
[Chore] 로컬 환경 모니터링 스택 제거

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -18,55 +18,5 @@ services:
       retries: 5
     restart: unless-stopped
 
-  prometheus:
-    image: prom/prometheus:latest
-    container_name: team2-local-prometheus
-    ports:
-      - "9090:9090"
-    volumes:
-      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
-      - prometheus_data:/prometheus
-    command:
-      - '--config.file=/etc/prometheus/prometheus.yml'
-      - '--storage.tsdb.path=/prometheus'
-      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
-      - '--web.console.templates=/usr/share/prometheus/consoles'
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    restart: unless-stopped
-
-  loki:
-    image: grafana/loki:latest
-    container_name: team2-local-loki
-    user: root
-    ports:
-      - "3100:3100"
-    volumes:
-      - ./monitoring/loki/loki-config.yml:/etc/loki/local-config.yaml
-      - loki_data:/tmp/loki
-    command: -config.file=/etc/loki/local-config.yaml
-    restart: unless-stopped
-
-  grafana:
-    image: grafana/grafana:latest
-    container_name: team2-local-grafana
-    ports:
-      - "3000:3000"
-    environment:
-      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
-      - GF_USERS_ALLOW_SIGN_UP=false
-    volumes:
-      - grafana_data:/var/lib/grafana
-      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning
-      - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards
-    depends_on:
-      - prometheus
-      - loki
-    restart: unless-stopped
-
 volumes:
   db-data:
-  prometheus_data:
-  loki_data:
-  grafana_data:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -9,6 +9,3 @@ management:
   metrics:
     tags:
       application: ${spring.application.name}
-
-loki:
-  url: http://localhost:3100

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -24,11 +24,10 @@
         </format>
     </appender>
 
-    <!-- 로컬: 콘솔 + Loki (localhost:3100) -->
+    <!-- 로컬: 콘솔만 -->
     <springProfile name="local">
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="LOKI"/>
         </root>
     </springProfile>
 


### PR DESCRIPTION
## 🔗 Issue
- closes #55

## 💬 Context
로컬 개발 환경에서는 Grafana 대시보드를 확인할 일이 없어 Loki/Prometheus/Grafana를 띄울 필요가 없습니다. 기존에는 `docker-compose.local.yml`에 모니터링 스택이 포함되어 있어 불필요하게 리소스를 사용했고, logback의 `local` 프로필에도 Loki appender가 붙어 있어 Loki가 없는 상태에서 실행하면 연결 실패 경고가 계속 출력되었습니다. 로컬은 콘솔 로그만으로 충분하다는 판단 하에 모니터링 스택을 제거합니다.

## 🛠 Changes
- `docker-compose.local.yml` — Prometheus, Loki, Grafana 서비스 및 관련 볼륨 제거, MySQL만 유지
- `logback-spring.xml` — `local` 프로필에서 Loki appender 제거, 콘솔 출력만 사용
- `application-local.yml` — 더 이상 사용하지 않는 `loki.url` 설정 제거

## 👀 Review Focus
- 로컬에서 모니터링 스택이 아예 필요 없는 게 맞는지 팀 의견 확인 (모니터링 설정 개발/테스트 시에는 필요할 수 있음)

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 로컬 개발 환경에서 옵저버빌리티 스택 제거: Prometheus, Loki, Grafana 서비스 및 관련 볼륨 삭제
  * 로컬 Spring 설정에서 Loki 엔드포인트 제거
  * 로컬 환경의 로그 출력을 콘솔로만 제한 (Loki 통합 제거)

로컬 개발 환경이 간소화되었으며, 관리할 서비스의 수가 줄어들었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->