### PR TITLE
[Chore] OAuth 공통 설정 분리

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,22 @@ spring:
       local: secret
       dev: secret-dev
       prod: secret-prod
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            scope: [profile_nickname, account_email]
+            client-name: Kakao
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
   jpa:
     hibernate:
       ddl-auto: update


### PR DESCRIPTION
## 🔗 Issue
- N/A

## 💬 Context
시크릿 파일에 카카오 provider URL, scope 등 공개 설정값이 함께 포함되어 있어서,
공통 `application.yml`로 분리하여 시크릿 파일에는 민감한 값(client-id, client-secret, jwt secret, redirect-uri)만 유지하도록 변경

## 🛠 Changes
- `application.yml`에 카카오 OAuth provider, registration 고정값 추가
- 시크릿 파일에서는 고정값 제거 (별도 시크릿 서브모듈 커밋)

## 👀 Review Focus
- Spring Boot 프로필 머지 시 공통 설정 + 시크릿 값이 정상적으로 합쳐지는지 확인

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [ ] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* Kakao 소셜 로그인 기능이 추가되었습니다. 사용자는 이제 Kakao 계정을 통해 애플리케이션에 로그인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->