### PR TITLE
[Chore] Prometheus Docker 네트워크 연결로 메트릭 수집 문제 해결

### DIFF
--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -13,9 +13,9 @@ services:
       - '--web.console.libraries=/usr/share/prometheus/console_libraries'
       - '--web.console.templates=/usr/share/prometheus/consoles'
     restart: unless-stopped
-    # TODO: [운영] 앱도 Docker로 띄울 경우 extra_hosts 제거 후 같은 네트워크로 묶고 서비스명으로 통신
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
+    networks:
+      - dev-network
+      - prod-network
 
   loki:
     image: grafana/loki:latest
@@ -52,3 +52,9 @@ volumes:
   prometheus_data:
   loki_data:
   grafana_data:
+
+networks:
+  dev-network:
+    external: true
+  prod-network:
+    external: true

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -3,8 +3,12 @@ global:
   evaluation_interval: 15s
 
 scrape_configs:
-  - job_name: 'team2-backend'
+  - job_name: 'team2-backend-dev'
     metrics_path: '/actuator/prometheus'
     static_configs:
-      # TODO: [운영] 앱도 Docker로 띄울 경우 host.docker.internal:8080 → 앱 서비스명:8080 으로 변경
-      - targets: ['host.docker.internal:8080']
+      - targets: ['app-dev:8080']
+
+  - job_name: 'team2-backend-prod'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['app-prod:8080']


### PR DESCRIPTION
## 🔗 Issue
- closes #58

## 💬 Context
Prometheus가 `host.docker.internal`을 통해 앱에 접근하는 방식은 포트가 동적으로 바뀌거나 네트워크 구성이 달라질 경우 불안정합니다. 

## 🛠 Changes
- `docker-compose.monitoring.yml` — prometheus에 `dev-network`, `prod-network` 추가, `extra_hosts` 및 `host.docker.internal` 제거
- `prometheus.yml` — 단일 `host.docker.internal:8080` 타겟을 `app-dev:8080`, `app-prod:8080` 서비스명으로 분리

## 👀 Review Focus
- `dev-network`, `prod-network`가 실제 서버에 external network로 미리 생성되어 있어야 동작함 — 배포 스크립트에서 네트워크 생성 여부 확인 필요

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* 모니터링 시스템의 네트워크 연결 방식을 개선했습니다. 서비스 간 통신이 더욱 효율적으로 처리됩니다.
* 개발 및 프로덕션 환경별 모니터링 설정을 추가하여 각 환경에 맞는 메트릭 수집이 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->