### PR TITLE
[Chore] Prometheus Docker 네트워크 연결로 메트릭 수집 문제 해결

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,6 @@
 services:
   app-dev:
+    container_name: team2-app-dev
     build:
       context: .
       dockerfile: Dockerfile

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,5 +1,6 @@
 services:
   app-prod:
+    container_name: team2-app-prod
     build:
       context: .
       dockerfile: Dockerfile

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -6,9 +6,9 @@ scrape_configs:
   - job_name: 'team2-backend-dev'
     metrics_path: '/actuator/prometheus'
     static_configs:
-      - targets: ['18th-team2-server-app-dev-1:8080']
+      - targets: ['team2-app-dev:8080']
 
   - job_name: 'team2-backend-prod'
     metrics_path: '/actuator/prometheus'
     static_configs:
-      - targets: ['18th-team2-server-app-prod-1:8080']
+      - targets: ['team2-app-prod:8080']

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -6,9 +6,9 @@ scrape_configs:
   - job_name: 'team2-backend-dev'
     metrics_path: '/actuator/prometheus'
     static_configs:
-      - targets: ['app-dev:8080']
+      - targets: ['18th-team2-server-app-dev-1:8080']
 
   - job_name: 'team2-backend-prod'
     metrics_path: '/actuator/prometheus'
     static_configs:
-      - targets: ['app-prod:8080']
+      - targets: ['18th-team2-server-app-prod-1:8080']


### PR DESCRIPTION
## 🔗 Issue
- closes #58

## 💬 Context
Prometheus가 `host.docker.internal`을 통해 앱에 접근하는 방식은 다른 Compose 프로젝트 간 DNS가 동작하지 않아 메트릭 수집이 불가능합니다. Prometheus를 앱과 같은 Docker 네트워크에 묶고 고정된 컨테이너명으로 접근하도록 변경합니다.

## 🛠 Changes
- `docker-compose.monitoring.yml` — prometheus에 `dev-network`, `prod-network` 추가, `extra_hosts` 제거
- `docker-compose.dev.yml` — `container_name: team2-app-dev` 명시
- `docker-compose.prod.yml` — `container_name: team2-app-prod` 명시
- `prometheus.yml` — 타겟을 `team2-app-dev:8080`, `team2-app-prod:8080`으로 변경

## 👀 Review Focus
- `dev-network`, `prod-network`가 서버에 미리 생성되어 있어야 동작 (deploy.sh에서 자동 생성됨)
- `container_name` 고정으로 디렉토리명과 무관하게 컨테이너명이 예측 가능해짐

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견