### PR TITLE
[Fix] dev DB URL Docker 내부 서비스명으로 수정 및 monitoring 프로젝트 분리

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -26,6 +26,7 @@ services:
       - dev-network
 
   db-dev:
+    container_name: team2-db-dev
     image: mysql:8.0
     environment:
       - MYSQL_DATABASE=team2_dev

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -16,13 +16,13 @@ services:
       - '--web.console.templates=/usr/share/prometheus/consoles'
     restart: unless-stopped
     networks:
+      - monitoring-net
       - dev-network
       - prod-network
 
   loki:
     image: grafana/loki:latest
     container_name: loki
-    # TODO: [운영] root 대신 전용 유저 생성 후 볼륨 디렉토리 소유권을 해당 유저로 변경하여 최소 권한 원칙 적용
     user: root
     ports:
       - "3100:3100"
@@ -31,6 +31,8 @@ services:
       - loki_data:/tmp/loki
     command: -config.file=/etc/loki/local-config.yaml
     restart: unless-stopped
+    networks:
+      - monitoring-net
 
   grafana:
     image: grafana/grafana:latest
@@ -49,6 +51,8 @@ services:
       - prometheus
       - loki
     restart: unless-stopped
+    networks:
+      - monitoring-net
 
 volumes:
   prometheus_data:
@@ -56,6 +60,7 @@ volumes:
   grafana_data:
 
 networks:
+  monitoring-net: {}
   dev-network:
     external: true
   prod-network:

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -1,3 +1,5 @@
+name: team2-monitoring
+
 services:
   prometheus:
     image: prom/prometheus:latest

--- a/monitoring/grafana/dashboards/spring-boot.json
+++ b/monitoring/grafana/dashboards/spring-boot.json
@@ -19,7 +19,7 @@
       "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single" } },
       "targets": [
         {
-          "expr": "rate(http_server_requests_seconds_count{application=\"team2-backend\"}[1m])",
+          "expr": "rate(http_server_requests_seconds_count{job=\"team2-backend-$env\"}[1m])",
           "legendFormat": "{{method}} {{uri}} {{status}}",
           "refId": "A"
         }
@@ -38,7 +38,7 @@
       "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single" } },
       "targets": [
         {
-          "expr": "rate(http_server_requests_seconds_sum{application=\"team2-backend\"}[1m]) / rate(http_server_requests_seconds_count{application=\"team2-backend\"}[1m])",
+          "expr": "rate(http_server_requests_seconds_sum{job=\"team2-backend-$env\"}[1m]) / rate(http_server_requests_seconds_count{job=\"team2-backend-$env\"}[1m])",
           "legendFormat": "{{method}} {{uri}}",
           "refId": "A"
         }
@@ -57,7 +57,7 @@
       "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single" } },
       "targets": [
         {
-          "expr": "jvm_memory_used_bytes{application=\"team2-backend\"}",
+          "expr": "jvm_memory_used_bytes{job=\"team2-backend-$env\"}",
           "legendFormat": "{{area}} - {{id}}",
           "refId": "A"
         }
@@ -76,7 +76,7 @@
       "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single" } },
       "targets": [
         {
-          "expr": "rate(process_cpu_usage{application=\"team2-backend\"}[1m])",
+          "expr": "rate(process_cpu_usage{job=\"team2-backend-$env\"}[1m])",
           "legendFormat": "CPU 사용률",
           "refId": "A"
         }
@@ -100,7 +100,7 @@
       },
       "targets": [
         {
-          "expr": "{app=\"team2-backend\"}",
+          "expr": "{env=\"$env\"}",
           "legendFormat": "",
           "refId": "A"
         }
@@ -112,7 +112,24 @@
   "refresh": "10s",
   "schemaVersion": 38,
   "tags": ["spring-boot", "team2"],
-  "templating": { "list": [] },
+  "templating": {
+    "list": [
+      {
+        "current": { "text": "dev", "value": "dev" },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "env",
+        "label": "Environment",
+        "options": [
+          { "selected": true, "text": "dev", "value": "dev" },
+          { "selected": false, "text": "prod", "value": "prod" }
+        ],
+        "query": "dev,prod",
+        "type": "custom"
+      }
+    ]
+  },
   "time": { "from": "now-1h", "to": "now" },
   "timepicker": {},
   "timezone": "browser",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -101,14 +101,14 @@ done
 if [ "$ENV" = "dev" ] || [ "$ENV" = "all" ]; then
     DEV_FILES="-f docker-compose.yml -f docker-compose.dev.yml"
     echo "==> Building and starting DEV containers..."
-    docker compose $DEV_FILES up -d --build --remove-orphans
+    docker compose $DEV_FILES up -d --build
     wait_healthy "$DEV_FILES" "app-dev"
 fi
 
 if [ "$ENV" = "prod" ] || [ "$ENV" = "all" ]; then
     PROD_FILES="-f docker-compose.yml -f docker-compose.prod.yml"
     echo "==> Building and starting PROD containers..."
-    docker compose $PROD_FILES up -d --build --remove-orphans
+    docker compose $PROD_FILES up -d --build
     wait_healthy "$PROD_FILES" "app-prod"
 fi
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -101,14 +101,14 @@ done
 if [ "$ENV" = "dev" ] || [ "$ENV" = "all" ]; then
     DEV_FILES="-f docker-compose.yml -f docker-compose.dev.yml"
     echo "==> Building and starting DEV containers..."
-    docker compose $DEV_FILES up -d --build
+    docker compose $DEV_FILES up -d --build --remove-orphans
     wait_healthy "$DEV_FILES" "app-dev"
 fi
 
 if [ "$ENV" = "prod" ] || [ "$ENV" = "all" ]; then
     PROD_FILES="-f docker-compose.yml -f docker-compose.prod.yml"
     echo "==> Building and starting PROD containers..."
-    docker compose $PROD_FILES up -d --build
+    docker compose $PROD_FILES up -d --build --remove-orphans
     wait_healthy "$PROD_FILES" "app-prod"
 fi
 

--- a/src/main/kotlin/com/team2/server/auth/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/team2/server/auth/config/SecurityConfig.kt
@@ -42,6 +42,7 @@ class SecurityConfig(
                         "/login/**",
                         "/actuator/health",
                         "/actuator/info",
+                        "/actuator/prometheus",
                         "/swagger-ui/**",
                         "/v3/api-docs/**",
                         "/api/dev/**",

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -21,3 +21,6 @@ management:
 
 loki:
   url: http://loki:3100
+
+app:
+  env: dev

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -25,3 +25,6 @@ management:
 
 loki:
   url: http://loki:3100
+
+app:
+  env: prod

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -2,6 +2,7 @@
 <configuration>
     <springProperty scope="context" name="APP_NAME" source="spring.application.name"/>
     <springProperty scope="context" name="LOKI_URL" source="loki.url" defaultValue="http://localhost:3100"/>
+    <springProperty scope="context" name="ENV" source="app.env" defaultValue="local"/>
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
@@ -15,7 +16,7 @@
         </http>
         <format>
             <label>
-                <pattern>app=${APP_NAME},host=${HOSTNAME},level=%level</pattern>
+                <pattern>app=${APP_NAME},env=${ENV},host=${HOSTNAME},level=%level</pattern>
             </label>
             <message>
                 <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level [traceId=%X{traceId}] [requestId=%X{requestId}] %logger{36} - %msg%n</pattern>


### PR DESCRIPTION
## 🔗 Issue
- closes #

## 💬 Context
PR #61에서 `container_name: team2-app-dev`를 명시하면서 앱 컨테이너가 재생성됐고, 이 과정에서 기존에 호스트 MySQL(`suker.iptime.org:3307`)을 사용하던 방식이 더 이상 동작하지 않는 문제가 발생했습니다. 또한 monitoring 스택의 네트워크 설정 불일치로 Grafana ↔ Prometheus ↔ Loki 간 통신 장애, Prometheus 401 에러 등 복합적인 문제가 발생하여 이를 일괄 수정합니다.

## 🛠 Changes
- `config/secret/application-secret-dev.yml` — DB URL을 `suker.iptime.org:3307` 하드코딩에서 `${DB_HOST}:3306`으로 변경하여 Docker 내부 네트워크 사용
- `docker-compose.dev.yml` — `db-dev` 서비스에 `container_name: team2-db-dev` 명시
- `docker-compose.monitoring.yml` — `name: team2-monitoring`으로 프로젝트 분리, `monitoring-net` 추가로 prometheus/loki/grafana 내부 통신 연결
- `SecurityConfig.kt` — `/actuator/prometheus` 엔드포인트 인증 제외 추가 (Prometheus 401 해결)
- `application-dev.yml`, `application-prod.yml` — `app.env: dev/prod` 추가 (Loki 라벨 환경 구분)
- `logback-spring.xml` — Loki 라벨에 `env=${ENV}` 추가
- `spring-boot.json` — Grafana 대시보드에 dev/prod 환경 드롭다운 변수 추가, 모든 쿼리를 `$env` 변수 기반으로 전환

## 👀 Review Focus
- `${DB_HOST}`는 `docker-compose.dev.yml`에서 `DB_HOST=db-dev`로 주입되며, `db-dev`는 같은 `dev-network`의 MySQL 서비스명
- monitoring 스택 최초 적용 시 기존 컨테이너 수동 제거 후 재시작 필요: `docker rm -f loki prometheus grafana && docker compose -f docker-compose.monitoring.yml up -d`
- Grafana 대시보드 드롭다운은 재시작 시 자동 로드: `docker compose -f docker-compose.monitoring.yml restart grafana`

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견