### PR TITLE
[Fix] Swagger UI CORS 에러 수정

### DIFF
--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -33,6 +33,8 @@ services:
     restart: unless-stopped
     networks:
       - monitoring-net
+      - dev-network
+      - prod-network
 
   grafana:
     image: grafana/grafana:latest

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -33,8 +33,6 @@ services:
     restart: unless-stopped
     networks:
       - monitoring-net
-      - dev-network
-      - prod-network
 
   grafana:
     image: grafana/grafana:latest

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -17,6 +17,7 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Port $server_port;
             proxy_connect_timeout 60s;
             proxy_read_timeout 120s;
             proxy_send_timeout 60s;
@@ -35,6 +36,7 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Port $server_port;
             proxy_connect_timeout 60s;
             proxy_read_timeout 120s;
             proxy_send_timeout 60s;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+server:
+  forward-headers-strategy: FRAMEWORK
+
 spring:
   application:
     name: team2-backend


### PR DESCRIPTION
## 🔗 Issue
- closes #63

## 💬 Context
nginx 리버스 프록시 뒤에서 실행되는 앱에서 Swagger UI 사용 시 "Failed to fetch / URL scheme must be http or https for CORS request" 에러가 발생했습니다. Spring Boot가 `X-Forwarded-*` 헤더를 무시하여 OpenAPI 스펙의 서버 URL이 내부 Docker 주소(`team2-app-dev:8080`)로 생성되고, 브라우저가 해당 주소로 CORS 요청을 시도하다 실패하는 것이 원인입니다.

## 🛠 Changes
- `nginx/nginx.conf` — dev/prod 서버 블록에 `X-Forwarded-Port $server_port` 헤더 추가
- `application.yml` — `server.forward-headers-strategy: FRAMEWORK` 설정 추가로 Spring이 X-Forwarded 헤더를 신뢰하여 올바른 서버 URL 생성

## 👀 Review Focus
- `forward-headers-strategy: FRAMEWORK`는 Spring이 직접 포워드 헤더를 처리하는 방식으로, nginx 같은 신뢰할 수 있는 프록시 뒤에서만 사용해야 합니다
- nginx가 `X-Forwarded-Port`를 전달해야 포트(8081/80)가 OpenAPI 스펙에 정확히 반영됩니다

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견