### PR TITLE
[Fix] Loki를 앱 네트워크에 연결하여 로그 수집 문제 해결

### DIFF
--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -33,6 +33,8 @@ services:
     restart: unless-stopped
     networks:
       - monitoring-net
+      - dev-network
+      - prod-network
 
   grafana:
     image: grafana/grafana:latest

--- a/src/main/kotlin/com/team2/server/common/filter/MdcLoggingFilter.kt
+++ b/src/main/kotlin/com/team2/server/common/filter/MdcLoggingFilter.kt
@@ -4,11 +4,14 @@ import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.slf4j.MDC
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
 import java.util.UUID
 
 @Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
 class MdcLoggingFilter : OncePerRequestFilter() {
     override fun doFilterInternal(
         request: HttpServletRequest,


### PR DESCRIPTION
## 🔗 Issue
- closes #65

## 💬 Context
monitoring 스택 네트워크 분리 작업 이후 Loki가 `monitoring-net`에만 연결되어 `dev-network`/`prod-network`에 있는 앱 컨테이너에서 `http://loki:3100`으로 로그를 전송할 수 없는 문제가 발생했습니다.

## 🛠 Changes
- `docker-compose.monitoring.yml` — Loki에 `dev-network`, `prod-network` 추가 연결

## 👀 Review Focus
- Loki는 앱(dev-network/prod-network)으로부터 로그를 받아야 하고, Grafana(monitoring-net)에도 접근되어야 하므로 세 네트워크 모두 필요합니다

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견