### PR TITLE
[Fix] nginx가 deploy 시 orphan으로 삭제되는 문제 수정

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -99,14 +99,14 @@ for network in dev-network prod-network; do
 done
 
 # nginx는 dev/prod와 독립적으로 관리 (항상 띄워둠)
-NGINX_FILES="-f docker/docker-compose.nginx.yml"
+NGINX_FILES="-p team2-nginx -f docker/docker-compose.nginx.yml"
 echo "==> Ensuring nginx is running..."
 docker compose $NGINX_FILES up -d
 
 if [ "$ENV" = "dev" ] || [ "$ENV" = "all" ]; then
     DEV_FILES="--env-file .env -f docker/docker-compose.dev.yml"
     echo "==> Stopping existing DEV containers..."
-    docker compose $DEV_FILES down --remove-orphans
+    docker compose $DEV_FILES down
     echo "==> Building and starting DEV containers..."
     docker compose $DEV_FILES up -d --build
     wait_healthy "$DEV_FILES" "app-dev"
@@ -115,7 +115,7 @@ fi
 if [ "$ENV" = "prod" ] || [ "$ENV" = "all" ]; then
     PROD_FILES="--env-file .env -f docker/docker-compose.prod.yml"
     echo "==> Stopping existing PROD containers..."
-    docker compose $PROD_FILES down --remove-orphans
+    docker compose $PROD_FILES down
     echo "==> Building and starting PROD containers..."
     docker compose $PROD_FILES up -d --build
     wait_healthy "$PROD_FILES" "app-prod"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -106,7 +106,7 @@ docker compose $NGINX_FILES up -d
 if [ "$ENV" = "dev" ] || [ "$ENV" = "all" ]; then
     DEV_FILES="--env-file .env -f docker/docker-compose.dev.yml"
     echo "==> Stopping existing DEV containers..."
-    docker compose $DEV_FILES down
+    docker compose $DEV_FILES down --remove-orphans
     echo "==> Building and starting DEV containers..."
     docker compose $DEV_FILES up -d --build
     wait_healthy "$DEV_FILES" "app-dev"
@@ -115,7 +115,7 @@ fi
 if [ "$ENV" = "prod" ] || [ "$ENV" = "all" ]; then
     PROD_FILES="--env-file .env -f docker/docker-compose.prod.yml"
     echo "==> Stopping existing PROD containers..."
-    docker compose $PROD_FILES down
+    docker compose $PROD_FILES down --remove-orphans
     echo "==> Building and starting PROD containers..."
     docker compose $PROD_FILES up -d --build
     wait_healthy "$PROD_FILES" "app-prod"


### PR DESCRIPTION
## 🔗 Issue
- closes #70

## 💬 Context
#71 머지 후 배포 시 nginx가 `--remove-orphans`에 의해 orphan 컨테이너로 인식되어 삭제되는 문제 발생. nginx를 별도 compose 파일로 분리했지만, dev/prod compose와 같은 프로젝트로 인식되어 nginx가 orphan으로 판단됨.

## 🛠 Changes
- nginx compose에 `-p team2-nginx`로 별도 프로젝트 이름 부여하여 dev/prod compose와 완전 분리
- 프로젝트 분리로 `--remove-orphans`가 nginx에 영향을 주지 않으므로 dev/prod `down --remove-orphans` 유지

## 👀 Review Focus
- `-p team2-nginx`로 프로젝트를 분리하여 orphan 판단 범위를 격리하는 방식이 적절한지

## ✅ Check List
- [x] Assignees 등록
- [ ] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견