### PR TITLE
[Fix] Swagger 성공 응답 스키마 자동 추론 적용

### DIFF
--- a/docs/swagger-interface.md
+++ b/docs/swagger-interface.md
@@ -38,16 +38,6 @@ interface ExampleApi {
     @SwaggerApiResponse(
         responseCode = "200",
         description = "조회 성공",
-        content = [Content(
-            mediaType = "application/json",
-            schema = Schema(implementation = ApiResponse::class),
-            examples = [ExampleObject(value = """
-                {
-                  "status": 200,
-                  "data": { "id": 1, "name": "예시" }
-                }
-            """)]
-        )]
     )
     @AuthErrorResponses          // 401 자동 포함
     @InternalServerErrorResponse // 500 자동 포함
@@ -126,9 +116,11 @@ class ExampleController(
 
 ## 규칙
 
+- **성공 응답(2xx)**: `@SwaggerApiResponse`에 `content`를 지정하지 않는다. 리턴 타입(`ApiResponse<T>`)에서 스키마가 자동 추론된다. `content`를 넣으면 자동 추론이 꺼져서 Schemas 섹션에 응답 DTO가 등록되지 않는다.
+- **에러 응답(4xx, 5xx)**: `content`에 `schema`와 `examples`를 명시한다. 에러는 예외 핸들러에서 발생하므로 자동 추론이 불가능하다.
 - **Api 인터페이스**: `@Tag`, `@Operation`, `@SwaggerApiResponse`, `@Parameter`, 공통 에러 어노테이션만 작성
 - **Controller**: `@RestController`, `@RequestMapping`, HTTP 메서드 매핑(`@GetMapping` 등), `@AuthenticationPrincipal`, `@PathVariable`, `@RequestBody`만 작성
-- **ExampleObject**: 반드시 실제 JSON 예시를 포함 (schema만으로는 `"code": "string"` 같이 표시됨)
+- **ExampleObject**: 에러 응답에는 반드시 실제 JSON 예시를 포함 (schema만으로는 `"code": "string"` 같이 표시됨)
 - **import alias**: Swagger의 `@ApiResponse`는 우리 `ApiResponse`와 이름이 겹치므로 `import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse`로 사용
 
 ## 새 도메인 추가 체크리스트

--- a/src/main/kotlin/com/team2/server/party/controller/PartyApi.kt
+++ b/src/main/kotlin/com/team2/server/party/controller/PartyApi.kt
@@ -30,24 +30,6 @@ interface PartyApi {
     @SwaggerApiResponse(
         responseCode = "201",
         description = "파티 생성 성공",
-        content = [
-            Content(
-                mediaType = "application/json",
-                schema = Schema(implementation = ApiResponse::class),
-                examples = [
-                    ExampleObject(
-                        value = """
-                            {
-                              "status": 201,
-                              "data": {
-                                "partyId": 1
-                              }
-                            }
-                        """,
-                    ),
-                ],
-            ),
-        ],
     )
     @AuthErrorResponses
     @InternalServerErrorResponse
@@ -68,31 +50,6 @@ interface PartyApi {
     @SwaggerApiResponse(
         responseCode = "200",
         description = "파티 정보 조회 성공",
-        content = [
-            Content(
-                mediaType = "application/json",
-                schema = Schema(implementation = ApiResponse::class),
-                examples = [
-                    ExampleObject(
-                        value = """
-                            {
-                              "status": 200,
-                              "data": {
-                                "name": "생일파티",
-                                "celebrantNickname": "홍길동",
-                                "purpose": "BIRTHDAY",
-                                "option": "CHAT_ALLOWED",
-                                "startedAt": "2024-11-26T14:30:00",
-                                "endedAt": null,
-                                "ended": false,
-                                "myParticipant": null
-                              }
-                            }
-                        """,
-                    ),
-                ],
-            ),
-        ],
     )
     @SwaggerApiResponse(
         responseCode = "400",
@@ -160,26 +117,6 @@ interface PartyApi {
     @SwaggerApiResponse(
         responseCode = "200",
         description = "파티 참여 성공",
-        content = [
-            Content(
-                mediaType = "application/json",
-                schema = Schema(implementation = ApiResponse::class),
-                examples = [
-                    ExampleObject(
-                        value = """
-                            {
-                              "status": 200,
-                              "data": {
-                                "participantId": 10,
-                                "nickname": "홍길동",
-                                "characterImageUrl": "/images/characters/character1.jpg"
-                              }
-                            }
-                        """,
-                    ),
-                ],
-            ),
-        ],
     )
     @SwaggerApiResponse(
         responseCode = "400",

--- a/src/main/kotlin/com/team2/server/party/controller/PartyInviteApi.kt
+++ b/src/main/kotlin/com/team2/server/party/controller/PartyInviteApi.kt
@@ -25,24 +25,6 @@ interface PartyInviteApi {
     @SwaggerApiResponse(
         responseCode = "200",
         description = "초대링크 활성화 성공",
-        content = [
-            Content(
-                mediaType = "application/json",
-                schema = Schema(implementation = ApiResponse::class),
-                examples = [
-                    ExampleObject(
-                        value = """
-                            {
-                              "status": 200,
-                              "data": {
-                                "token": "a1b2c3d4e5f67890"
-                              }
-                            }
-                        """,
-                    ),
-                ],
-            ),
-        ],
     )
     @SwaggerApiResponse(
         responseCode = "404",


### PR DESCRIPTION
## 🔗 Issue
- closes #73

## 💬 Context
Swagger 성공 응답(2xx)에서 `content`에 `schema = Schema(implementation = ApiResponse::class)`를 지정하면 제네릭 타입 `T`가 지워져서 응답 DTO(PartyInfoResponse 등)가 Schemas 섹션에 등록되지 않는 문제가 있었습니다.
`content`를 제거하면 Springdoc이 리턴 타입 `ApiResponse<T>`에서 자동으로 스키마를 추론합니다.

## 🛠 Changes
- `PartyApi.kt`: 성공 응답(201, 200) 3곳에서 `content` 블록 제거
- `PartyInviteApi.kt`: 성공 응답(200) 1곳에서 `content` 블록 제거
- `docs/swagger-interface.md`: 성공/에러 응답 처리 규칙 문서화

## 👀 Review Focus
- Swagger UI에서 성공 응답 스키마가 정상적으로 표시되는지 확인
- 에러 응답의 examples는 기존과 동일하게 유지되는지 확인

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견