### PR TITLE
[Chore] nginx 배포를 앱 CD에서 분리

### DIFF
--- a/docker/docker-compose.nginx.yml
+++ b/docker/docker-compose.nginx.yml
@@ -1,3 +1,5 @@
+name: team2-nginx
+
 services:
   nginx:
     container_name: team2-nginx

--- a/scripts/deploy-nginx.sh
+++ b/scripts/deploy-nginx.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+cd "$PROJECT_ROOT"
+
+for network in dev-network prod-network; do
+    if ! docker network inspect "$network" &>/dev/null; then
+        echo "==> Creating network: $network"
+        docker network create "$network"
+    fi
+done
+
+EXISTING_CONTAINER_ID="$(docker ps -aq -f name='^/team2-nginx$' | head -n 1)"
+if [ -n "$EXISTING_CONTAINER_ID" ]; then
+    EXISTING_PROJECT="$(docker inspect -f '{{ index .Config.Labels "com.docker.compose.project" }}' "$EXISTING_CONTAINER_ID" 2>/dev/null || true)"
+    if [ "$EXISTING_PROJECT" != "team2-nginx" ]; then
+        echo "==> Removing legacy nginx container: team2-nginx"
+        docker stop "$EXISTING_CONTAINER_ID" >/dev/null 2>&1 || true
+        docker rm "$EXISTING_CONTAINER_ID" >/dev/null
+    fi
+fi
+
+NGINX_FILES="-f docker/docker-compose.nginx.yml"
+
+echo "==> Stopping nginx..."
+docker compose $NGINX_FILES down --remove-orphans
+
+echo "==> Starting nginx..."
+docker compose $NGINX_FILES up -d
+
+if ! docker compose $NGINX_FILES ps --status running --services | grep -qx nginx; then
+    echo "ERROR: nginx is not running. Dumping logs:"
+    docker compose $NGINX_FILES logs --tail=50 nginx
+    exit 1
+fi
+
+echo "==> Done!"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -101,7 +101,7 @@ done
 if [ "$ENV" = "dev" ] || [ "$ENV" = "all" ]; then
     DEV_FILES="--env-file .env -f docker/docker-compose.dev.yml"
     echo "==> Stopping existing DEV containers..."
-    docker compose $DEV_FILES down
+    docker compose $DEV_FILES down --remove-orphans
     echo "==> Building and starting DEV containers..."
     docker compose $DEV_FILES up -d --build
     wait_healthy "$DEV_FILES" "app-dev"
@@ -110,7 +110,7 @@ fi
 if [ "$ENV" = "prod" ] || [ "$ENV" = "all" ]; then
     PROD_FILES="--env-file .env -f docker/docker-compose.prod.yml"
     echo "==> Stopping existing PROD containers..."
-    docker compose $PROD_FILES down
+    docker compose $PROD_FILES down --remove-orphans
     echo "==> Building and starting PROD containers..."
     docker compose $PROD_FILES up -d --build
     wait_healthy "$PROD_FILES" "app-prod"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -98,15 +98,10 @@ for network in dev-network prod-network; do
     fi
 done
 
-# nginx는 dev/prod와 독립적으로 관리 (항상 띄워둠)
-NGINX_FILES="-p team2-nginx -f docker/docker-compose.nginx.yml"
-echo "==> Ensuring nginx is running..."
-docker compose $NGINX_FILES up -d
-
 if [ "$ENV" = "dev" ] || [ "$ENV" = "all" ]; then
     DEV_FILES="--env-file .env -f docker/docker-compose.dev.yml"
     echo "==> Stopping existing DEV containers..."
-    docker compose $DEV_FILES down --remove-orphans
+    docker compose $DEV_FILES down
     echo "==> Building and starting DEV containers..."
     docker compose $DEV_FILES up -d --build
     wait_healthy "$DEV_FILES" "app-dev"
@@ -115,7 +110,7 @@ fi
 if [ "$ENV" = "prod" ] || [ "$ENV" = "all" ]; then
     PROD_FILES="--env-file .env -f docker/docker-compose.prod.yml"
     echo "==> Stopping existing PROD containers..."
-    docker compose $PROD_FILES down --remove-orphans
+    docker compose $PROD_FILES down
     echo "==> Building and starting PROD containers..."
     docker compose $PROD_FILES up -d --build
     wait_healthy "$PROD_FILES" "app-prod"


### PR DESCRIPTION
## 🔗 Issue
- closes #76

## 💬 Context
- 앱 dev/prod CD에서 nginx를 매번 `up -d` 하면서, 서버에 기존 `team2-nginx` 컨테이너가 남아 있는 경우 이름 충돌로 배포가 실패할 수 있습니다.
- nginx는 앱 컨테이너와 수명주기가 다른 인프라 성격의 컨테이너라 앱 CD와 분리해 관리합니다.
- nginx 설정 변경이 필요한 경우에는 별도 nginx 배포 스크립트를 실행하도록 경계를 나눕니다.

## 🛠 Changes
- `scripts/deploy.sh`에서 nginx 기동 단계를 제거
- dev/prod 앱 배포의 `down --remove-orphans`를 일반 `down`으로 변경해 앱 CD가 nginx 같은 외부 컨테이너를 정리하지 않도록 조정
- `scripts/deploy-nginx.sh`를 추가해 nginx 전용 배포 시 기존 legacy `team2-nginx` 컨테이너를 정리한 뒤 재기동
- `docker-compose.nginx.yml`에 `name: team2-nginx`를 추가해 수동 실행 시에도 compose project 이름 고정

## 👀 Review Focus
- 앱 CD에서 nginx를 제외하고 별도 스크립트로 분리하는 방향이 현재 운영 방식과 맞는지
- `--remove-orphans` 제거 후 앱 compose에 정의된 서비스만 내리는 방식이 충분한지
- 기존 `team2-nginx` 컨테이너 정리 조건이 안전한지

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [ ] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **운영 개선**
  * Docker Compose 배포 구성을 업데이트했습니다.
  * 배포 프로세스를 최적화하여 환경 설정 효율성을 개선했습니다.
  * 인프라 재배포 흐름을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->