### PR TITLE
[Test] ArchUnit 아키텍처 검증 테스트 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     testImplementation("org.springframework.security:spring-security-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("org.mockito.kotlin:mockito-kotlin:5.4.0")
+    testImplementation("com.tngtech.archunit:archunit-junit5:1.4.0")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testRuntimeOnly("com.h2database:h2")
 }

--- a/docs/superpowers/specs/2026-04-29-layered-architecture-design.md
+++ b/docs/superpowers/specs/2026-04-29-layered-architecture-design.md
@@ -1,0 +1,418 @@
+# Layered Architecture Design — UseCase + Service 분리
+
+- 작성일: 2026-04-29
+- 대상: `com.team2.server` (Kotlin + Spring Boot)
+- 목적: 기능별로 일관된 4-레이어 구조와 명확한 책임 분리 규칙 확립
+
+---
+
+## 1. 결정 사항
+
+전 패키지를 다음 4-레이어 구조로 통일한다.
+
+```
+feature/
+├── api/                  HTTP 진입점, Request/Response DTO
+├── application/
+│   ├── usecase/          유스케이스 (흐름 제어, 트랜잭션 경계)
+│   └── service/          Aggregate 단위 행위 (재사용 단위)
+├── domain/
+│   ├── entity/           행동 있는 JPA 엔티티
+│   ├── policy/           여러 엔티티 걸친 도메인 규칙
+│   └── vo/               enum, value object
+└── infrastructure/
+    └── persistence/      JpaRepository, 외부 어댑터
+```
+
+핵심 원칙: **UseCase = 흐름, Service = 행위**.
+
+- UseCase: 여러 Aggregate를 어떻게 엮을지
+- Service: 한 Aggregate를 어떻게 다룰지
+
+---
+
+## 2. 의존성 규칙
+
+### 2-1. 의존 방향
+```
+api ──▶ application.usecase ──▶ application.service ──▶ infrastructure
+                  │                       │
+                  └───────▶ domain ◀──────┘
+```
+
+### 2-2. 의존성 매트릭스
+
+| From ↓ \ To → | UseCase | Service | Repository | Domain | 다른 feature UseCase | 다른 feature Service |
+|---|---|---|---|---|---|---|
+| Controller (api) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| UseCase | ❌ | ✅ | ⚠️ 조회만 | ✅ | ✅ | ❌ |
+| Service | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ |
+| Domain | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
+| Infrastructure | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ |
+
+핵심:
+- Controller는 UseCase만 안다
+- UseCase는 Service를 조합한다
+- Service는 자기 Aggregate의 Repository와 Domain만 안다
+- Cross-feature 호출은 **UseCase ↔ UseCase**만 허용
+
+---
+
+## 3. UseCase 규칙
+
+### 3-1. 형태
+- 1 UseCase = 1 클래스 = 1 public 메서드 (`invoke` 또는 `execute`)
+- `@Transactional`은 **UseCase에만** 선언 (Service에는 절대 금지)
+- 클래스 길이 **60줄 이내**, 생성자 의존성 **5개 이내**
+
+### 3-2. UseCase의 5단계
+```
+① 입력 → 도메인 식별자 변환 (필요 시)
+② Service/조회로 도메인 객체 획득
+③ 도메인 규칙 호출 (Entity 메서드, Policy)
+④ Service로 행위 위임 (저장/변경)
+⑤ 응답 DTO 변환
+```
+
+### 3-3. UseCase가 하면 안 되는 것
+| 금지 | 대신 |
+|---|---|
+| `Repository.save / saveAndFlush / delete` | Service에 위임 |
+| `try/catch DataIntegrityViolationException` | Service 내부에서 처리 |
+| `entity.field = value` 도메인 변경 | Service의 도메인 행위 메서드 |
+| 다른 feature의 Repository 직접 호출 | 그 feature의 UseCase 주입 |
+| 같은 feature 다른 UseCase 호출 | 금지 — 공통 로직은 Service로 |
+
+### 3-4. UseCase 비대화 한도
+- 클래스 길이 60줄
+- 생성자 의존성 5개
+- private helper 1개 이하 (그 이상은 추출 신호)
+
+---
+
+## 4. Service 규칙
+
+### 4-1. 형태
+- 1 Aggregate = 1 Service (`PartyService`, `ParticipantService`, `InviteService`)
+- 모호한 이름 금지 (`PartyManagementService` ❌)
+- 클래스 길이 **150줄 이내**, 생성자 의존성 **4개 이내**, public 메서드 **5개 이내**
+
+### 4-2. Service 메서드는 도메인 동사
+| ✅ 좋은 이름 | ❌ 나쁜 이름 |
+|---|---|
+| `participantService.join(...)` | `participantService.create(...)` |
+| `inviteService.activate(...)` | `inviteService.save(...)` |
+| `inviteService.findValid(...)` | `inviteService.get(...)` |
+| `partyService.close(...)` | `partyService.update(...)` |
+
+### 4-3. Service가 하는 일
+1. Aggregate 생성/조회/변경/삭제 (Repository 직접 호출)
+2. Aggregate 도메인 규칙 호출 (`party.assertJoinable()`)
+3. 인프라 예외 → 도메인 예외 변환
+4. **도메인 객체 반환** (Response DTO 변환은 UseCase 책임)
+
+### 4-4. Service가 하면 안 되는 것
+| 금지 | 이유 |
+|---|---|
+| `@Transactional` | 트랜잭션 단일 진실점은 UseCase |
+| 다른 feature의 Repository/Service 호출 | feature 경계 침범 |
+| 같은 feature 내 다른 Service 호출 | 의존 지옥 방지 — 조합은 UseCase가 |
+| Response DTO 반환 | DTO는 application 경계의 일 |
+| HTTP 정보 접근 (`HttpServletRequest`, principal) | Web 영역은 Controller |
+
+### 4-5. Service ↔ Service 호출 금지
+다른 Aggregate를 참조해야 하면 **인자로 받는다**.
+```kotlin
+// ✅ OK
+fun ParticipantService.join(party: Party, user: User?, ...): Participant
+
+// ❌ NO
+class ParticipantService(private val partyService: PartyService, ...)
+```
+
+---
+
+## 5. Domain 규칙
+
+### 5-1. Entity는 행동을 가진다 (anemic 모델 금지)
+```kotlin
+@Entity
+class Party(...) : BaseEntity() {
+    fun assertJoinable(now: LocalDateTime) {
+        if (endedAt?.let { !it.isAfter(now) } == true)
+            throw BusinessException(ErrorCode.PARTY_ENDED)
+    }
+    fun requiresCharacter(): Boolean = isChattingAllow
+}
+```
+
+### 5-2. 여러 엔티티 걸친 규칙은 Policy
+```kotlin
+@Component
+class CharacterSelectionPolicy {
+    fun validate(party: Party, characterId: Long?) {
+        when {
+            party.requiresCharacter() && characterId == null ->
+                throw BusinessException(ErrorCode.CHARACTER_REQUIRED)
+            !party.requiresCharacter() && characterId != null ->
+                throw BusinessException(ErrorCode.CHARACTER_NOT_ALLOWED)
+        }
+    }
+}
+```
+
+### 5-3. Domain은 Spring 의존 최소화
+- JPA 어노테이션은 허용 (현실적 타협)
+- `@Service`, `@Component`는 Policy에만 (Stateless 도메인 서비스 한정)
+- Repository 의존 금지
+
+---
+
+## 6. 패키지 트리 (목표)
+
+```
+com.team2.server
+│
+├── ServerApplication.kt
+│
+├── common/
+│   ├── config/         (JpaConfig, SwaggerConfig)
+│   ├── web/            (ApiResponse, ErrorResponse, GlobalExceptionHandler, MdcLoggingFilter)
+│   ├── exception/      (BusinessException, ErrorCode)
+│   └── persistence/    (BaseEntity)
+│
+├── auth/
+│   ├── api/            (AuthController, DevTokenController, dto/)
+│   ├── application/
+│   │   ├── usecase/    (ProcessOAuth2LoginUseCase)
+│   │   └── service/    (JwtIssueService)
+│   ├── domain/         (UserPrincipal, OAuth2Attributes, KakaoAttributes, OAuth2AttributesFactory)
+│   └── infrastructure/
+│       ├── security/   (SecurityConfig, JwtFilter/EntryPoint/Provider/Properties)
+│       └── oauth2/     (CustomOAuth2UserService, Success/FailureHandler)
+│
+├── user/
+│   ├── api/
+│   ├── application/
+│   │   ├── usecase/    (UpsertOAuth2UserUseCase)
+│   │   └── service/    (UserService)
+│   ├── domain/         (User, AuthProvider)
+│   └── infrastructure/persistence/  (UserRepository)
+│
+├── party/
+│   ├── api/            (PartyController, PartyInviteController, dto/)
+│   ├── application/
+│   │   ├── usecase/    (CreatePartyUseCase, GetPartyInfoUseCase, JoinPartyUseCase, ActivateInviteLinkUseCase)
+│   │   └── service/    (PartyService, ParticipantService, InviteService)
+│   ├── domain/
+│   │   ├── entity/     (Party, Participant, PartyInvite, Character)
+│   │   ├── policy/     (PartyJoinPolicy, CharacterSelectionPolicy)
+│   │   └── vo/         (PartyOption, PartyPurpose)
+│   └── infrastructure/
+│       ├── persistence/  (PartyRepository, ParticipantRepository, PartyInviteRepository, CharacterRepository)
+│       ├── CharacterImageResolver.kt
+│       └── SecureRandomInviteTokenGenerator.kt
+│
+├── image/
+│   ├── domain/         (Image, ImageTargetType)
+│   └── infrastructure/persistence/  (ImageRepository)
+│
+├── chat/               (4-레이어 골격만, 미구현)
+│   ├── api/
+│   ├── application/
+│   ├── domain/         (ChatMessage)
+│   └── infrastructure/persistence/
+│
+└── rollingpaper/       (4-레이어 골격만, 미구현)
+    ├── api/
+    ├── application/
+    ├── domain/         (RollingPaper, RollingPaperWrapper)
+    └── infrastructure/persistence/
+```
+
+---
+
+## 7. 의사결정 플로우차트
+
+새 메서드를 어디에 둘까?
+```
+HTTP 입출력?              ──▶ Controller (api)
+여러 Aggregate 조합 흐름?  ──▶ UseCase
+한 Aggregate의 행위?       ──▶ Service
+Aggregate 자체의 불변식?   ──▶ Domain Entity
+여러 Entity 걸친 규칙?     ──▶ Domain Policy
+```
+
+---
+
+## 8. 책임 분배 — Join Party 예시
+
+| 책임 | 위치 |
+|---|---|
+| `@Transactional` 시작/종료 | `JoinPartyUseCase` |
+| 흐름 순서 제어 | `JoinPartyUseCase` |
+| `@NotBlank`, `@Size` 입력 검증 | `api/dto/JoinPartyRequest` (`@Valid`) |
+| `Party.endedAt > now` 검증 | `Party.assertJoinable()` (domain) |
+| 캐릭터 선택 규칙 | `CharacterSelectionPolicy` (domain) |
+| 초대 토큰 만료 검증 | `PartyInvite.assertNotExpired()` (domain) |
+| 초대 조회 + 만료 검증 호출 | `InviteService.findValid()` |
+| 중복 가입 검증 | `ParticipantService.join()` 내부 |
+| 참여자 저장 + DB 제약 위반 처리 | `ParticipantService.join()` |
+| 응답 DTO 변환 | `JoinPartyUseCase` (`ParticipantResponse.from(...)`) |
+| HTTP 200 / ErrorCode → HTTP status | `PartyController` + `GlobalExceptionHandler` |
+
+---
+
+## 9. 코드 골격 — Join Party
+
+```kotlin
+// application/usecase/JoinPartyUseCase.kt
+@Service
+class JoinPartyUseCase(
+    private val inviteService: InviteService,
+    private val participantService: ParticipantService,
+    private val userQueryService: UserQueryService,
+    private val characterSelectionPolicy: CharacterSelectionPolicy,
+    private val characterImageResolver: CharacterImageResolver,
+) {
+    @Transactional
+    fun invoke(token: String, userId: Long?, nickname: String, characterId: Long?): ParticipantResponse {
+        val invite = inviteService.findValid(token)
+        val party = invite.party
+
+        party.assertJoinable(LocalDateTime.now())
+        characterSelectionPolicy.validate(party, characterId)
+
+        val user = userId?.let(userQueryService::findOrThrow)
+        val participant = participantService.join(party, user, nickname, characterId)
+
+        val imageUrl = participant.character?.let(characterImageResolver::resolve)
+        return ParticipantResponse.from(participant, imageUrl)
+    }
+}
+
+// application/service/InviteService.kt
+@Service
+class InviteService(
+    private val partyInviteRepository: PartyInviteRepository,
+    private val tokenGenerator: InviteTokenGenerator,
+) {
+    fun findValid(token: String): PartyInvite {
+        val invite = partyInviteRepository.findByToken(token)
+            ?: throw BusinessException(ErrorCode.PARTY_NOT_FOUND)
+        invite.assertNotExpired(LocalDateTime.now())
+        return invite
+    }
+
+    fun activateFor(party: Party): PartyInvite {
+        val now = LocalDateTime.now()
+        return partyInviteRepository.findByPartyIdAndExpiresAtAfter(party.id, now)
+            ?: partyInviteRepository.save(
+                PartyInvite(
+                    party = party,
+                    token = tokenGenerator.generate(),
+                    expiresAt = party.endedAt ?: now.plusHours(EXPIRY_HOURS),
+                )
+            )
+    }
+
+    companion object { private const val EXPIRY_HOURS = 24L }
+}
+
+// application/service/ParticipantService.kt
+@Service
+class ParticipantService(
+    private val participantRepository: ParticipantRepository,
+    private val characterRepository: CharacterRepository,
+) {
+    fun join(party: Party, user: User?, nickname: String, characterId: Long?): Participant {
+        if (user != null && participantRepository.existsByPartyAndUser(party, user))
+            throw BusinessException(ErrorCode.ALREADY_JOINED)
+
+        val character = characterId?.let {
+            characterRepository.findById(it)
+                .orElseThrow { BusinessException(ErrorCode.CHARACTER_NOT_FOUND) }
+        }
+
+        return try {
+            participantRepository.saveAndFlush(
+                Participant(party = party, character = character, user = user, nickname = nickname)
+            )
+        } catch (e: DataIntegrityViolationException) {
+            if (e.isConstraintViolation(PARTICIPANT_UNIQUE_CONSTRAINT))
+                throw BusinessException(ErrorCode.ALREADY_JOINED)
+            throw e
+        }
+    }
+
+    companion object { private const val PARTICIPANT_UNIQUE_CONSTRAINT = "uk_participant_party_user" }
+}
+```
+
+---
+
+## 10. 트랜잭션 & 예외 경계
+
+```
+Controller         예외 catch ❌  — 그대로 전파
+UseCase            @Transactional 시작/끝 — 도메인 예외 그대로 전파
+Service            인프라 예외 → 도메인 예외 변환
+Domain             BusinessException 던짐
+GlobalExceptionHandler  BusinessException → ErrorCode 기반 HTTP 응답
+```
+
+---
+
+## 11. Cross-Feature 의존
+
+다른 feature가 필요하면 **그 feature의 UseCase를 주입**한다.
+```kotlin
+// ✅ OK
+class ProcessOAuth2LoginUseCase(
+    private val upsertOAuth2UserUseCase: UpsertOAuth2UserUseCase,  // user feature
+    private val jwtIssueService: JwtIssueService,
+) { ... }
+
+// ❌ NO
+class ProcessOAuth2LoginUseCase(
+    private val userRepository: UserRepository,  // 다른 feature infrastructure
+)
+```
+
+UseCase가 다른 feature의 UseCase를 호출할 때 **별도 트랜잭션이 아닌, 같은 트랜잭션** 안에서 진행된다 (Spring 기본 PROPAGATION_REQUIRED).
+
+---
+
+## 12. 마이그레이션 우선순위
+
+| 단계 | 범위 | 위험도 |
+|---|---|---|
+| 1 | `common` 정리 — `web/persistence` 분리, `image` feature 분가 | 낮음 |
+| 2 | `party` 4-레이어 재배치 + UseCase/Service 분리 + 도메인 메서드 추출 | 중간 (핵심 도메인) |
+| 3 | `user` application 레이어 신설 (`UserService`, `UpsertOAuth2UserUseCase`) | 중간 |
+| 4 | `auth` 기술별 → 4-레이어 재배치 (security/oauth2 → infrastructure) | 중간 |
+| 5 | `chat`, `rollingpaper` 골격 정비 | 낮음 |
+
+각 단계는 별도 PR로 진행하며, PR마다 빌드+테스트 통과 후 머지한다.
+
+---
+
+## 13. 한 페이지 요약 (팀 가이드)
+
+```
+UseCase = 흐름 (1 클래스 = 1 메서드 invoke, @Transactional)
+Service = 행위 (1 Aggregate = 1 Service, 도메인 동사 메서드)
+
+UseCase ↛ UseCase (같은 feature)
+Service ↛ Service (어디든)
+Service ↛ 다른 feature (어디든)
+UseCase → 다른 feature UseCase ✅
+
+UseCase 한도: 60줄 / 의존성 5개
+Service 한도: 150줄 / 의존성 4개 / public 메서드 5개
+
+Repository 쓰기 = Service만
+@Transactional = UseCase만
+Response DTO 변환 = UseCase에서
+도메인 규칙 = Entity / Policy
+```

--- a/docs/superpowers/specs/2026-05-02-archunit-tests-design.md
+++ b/docs/superpowers/specs/2026-05-02-archunit-tests-design.md
@@ -1,0 +1,313 @@
+# ArchUnit Architecture Tests Design
+
+- 작성일: 2026-05-02
+- 대상: `com.team2.server` (Kotlin + Spring Boot)
+- 의존 문서: [`2026-04-29-layered-architecture-design.md`](./2026-04-29-layered-architecture-design.md)
+- 목적: 레이어드 아키텍처 규칙을 컴파일/테스트 단계에서 자동 검증
+
+---
+
+## 1. 결정 사항
+
+- **검증 도구**: ArchUnit 1.4.0 (JUnit 5 통합)
+- **적용 강도**: Strict-Now — 모든 규칙을 즉시 추가, 마이그레이션 단계에 따라 `@ArchIgnore`로 단계별 활성화
+- **테스트 분할**: 레이어별로 6개 파일 분할
+- **커버리지**: A(레이어 의존) + B(명명/패키지) + C(어노테이션) + D(금지 호출) + E(Cross-feature) + H(순환 참조) + X(common)
+- **위치**: `src/test/kotlin/com/team2/server/architecture/`
+
+---
+
+## 2. 의존성 추가
+
+`build.gradle.kts`:
+```kotlin
+dependencies {
+    testImplementation("com.tngtech.archunit:archunit-junit5:1.4.0")
+}
+```
+
+---
+
+## 3. 테스트 파일 구성
+
+```
+src/test/kotlin/com/team2/server/architecture/
+├── ArchUnitConstants.kt          공통 상수 (BASE_PACKAGE, FEATURES 등)
+├── LayerDependencyTest.kt        A. 레이어 의존 방향
+├── PackageStructureTest.kt       B. 명명 규칙 / 패키지 위치
+├── AnnotationRuleTest.kt         C. 어노테이션 위치
+├── ForbiddenCallRuleTest.kt      D. 금지 호출
+├── CrossFeatureRuleTest.kt       E. feature 경계
+├── PackageCycleTest.kt           H. 순환 참조
+└── CommonPackageRuleTest.kt      X. common 패키지
+```
+
+각 파일은 다음 골격을 따른다:
+```kotlin
+@AnalyzeClasses(
+    packages = ["com.team2.server"],
+    importOptions = [ImportOption.DoNotIncludeTests::class, ImportOption.DoNotIncludeJars::class],
+)
+class XxxTest {
+    @ArchTest
+    val rule_name: ArchRule = ...
+}
+```
+
+---
+
+## 4. 공통 상수 (`ArchUnitConstants.kt`)
+
+```kotlin
+object ArchUnitConstants {
+    const val BASE_PACKAGE = "com.team2.server"
+
+    val FEATURES = listOf("auth", "user", "party", "image", "chat", "rollingpaper")
+
+    const val API = "..api.."
+    const val USECASE = "..application.usecase.."
+    const val SERVICE = "..application.service.."
+    const val APPLICATION = "..application.."
+    const val DOMAIN = "..domain.."
+    const val INFRASTRUCTURE = "..infrastructure.."
+    const val COMMON = "..common.."
+}
+```
+
+---
+
+## 5. 검증 규칙 카탈로그 (총 22개)
+
+### A. 레이어 의존 방향 (5)
+
+| # | 규칙 | 활성화 Phase |
+|---|---|---|
+| A1 | Controller(api)는 UseCase만 의존 | 2 |
+| A2 | UseCase는 Service, Domain만 의존 (다른 feature UseCase 추가 허용) | 2 |
+| A3 | Service는 Repository, Domain만 의존 | 2 |
+| A4 | Domain은 application/api/infrastructure 의존 ❌ | 0 |
+| A5 | Domain은 `JpaRepository` / `org.springframework.data.*` 의존 ❌ | 0 |
+
+A1~A4는 `Architectures.layeredArchitecture()` DSL로 구현:
+```kotlin
+@ArchTest
+val layered_architecture_rules: ArchRule =
+    layeredArchitecture()
+        .consideringAllDependencies()
+        .layer("Api").definedBy("..api..")
+        .layer("UseCase").definedBy("..application.usecase..")
+        .layer("Service").definedBy("..application.service..")
+        .layer("Domain").definedBy("..domain..")
+        .layer("Infrastructure").definedBy("..infrastructure..")
+        .whereLayer("Api").mayNotBeAccessedByAnyLayer()
+        .whereLayer("UseCase").mayOnlyBeAccessedByLayers("Api")
+        .whereLayer("Service").mayOnlyBeAccessedByLayers("UseCase")
+        .whereLayer("Infrastructure").mayOnlyBeAccessedByLayers("Service", "UseCase")
+        .whereLayer("Domain").mayOnlyBeAccessedByLayers("Api", "UseCase", "Service", "Infrastructure")
+        .as("레이어 의존 방향: api → usecase → service → infrastructure, domain은 모두에서 참조")
+```
+
+A5:
+```kotlin
+@ArchTest
+val domain_should_not_depend_on_spring_data: ArchRule =
+    noClasses()
+        .that().resideInAPackage("..domain..")
+        .should().dependOnClassesThat().resideInAPackage("org.springframework.data..")
+        .as("Domain은 Spring Data JPA 의존 금지")
+```
+
+### B. 명명 규칙 / 패키지 위치 (5)
+
+| # | 규칙 | Phase |
+|---|---|---|
+| B1 | `*Controller` 는 `..api..` 에만 | 2 |
+| B2 | `*UseCase` 는 `..application.usecase..` 에만 | 2 |
+| B3 | `*Service` 는 `..application.service..` 에만 (Spring 확장 클래스 예외 허용) | 2 |
+| B4 | `*Repository` 는 `..infrastructure.persistence..` 에만 | 2 |
+| B5 | `..application.usecase..` 안의 클래스는 `*UseCase` 접미사 | 2 |
+
+B3 예외 처리 (auth feature의 `CustomOAuth2UserService` 같은 Spring 확장):
+```kotlin
+@ArchTest
+val service_classes_only_in_application_service: ArchRule =
+    classes()
+        .that().haveSimpleNameEndingWith("Service")
+        .and().areNotAssignableTo("org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService")
+        .should().resideInAPackage("..application.service..")
+```
+
+### C. 어노테이션 위치 (3)
+
+| # | 규칙 | Phase |
+|---|---|---|
+| C1 | `@RestController` / `@Controller` 는 `..api..` 에만 | 2 |
+| C2 | `@Transactional` 은 `..application.usecase..` 에만 | 2 |
+| C3 | `@Component` / `@Service` 는 `..application..` 또는 `..infrastructure..` 또는 `..domain.policy..` 에만 | 2 |
+
+```kotlin
+@ArchTest
+val transactional_only_on_usecase: ArchRule =
+    classes()
+        .that().areAnnotatedWith(Transactional::class.java)
+        .or().containAnyMethodsThat(areAnnotatedWith(Transactional::class.java))
+        .should().resideInAPackage("..application.usecase..")
+        .as("@Transactional은 UseCase에만 선언")
+```
+
+### D. 금지 호출 (3)
+
+| # | 규칙 | Phase |
+|---|---|---|
+| D1 | UseCase는 `JpaRepository.save/saveAndFlush/delete/deleteAll/deleteById` 호출 ❌ | 2 |
+| D2 | Service는 다른 Service를 필드로 의존 ❌ | 2 |
+| D3 | UseCase는 같은 feature 내 다른 UseCase 의존 ❌ (cross-feature는 허용) | 2 |
+
+D1:
+```kotlin
+@ArchTest
+val usecase_should_not_call_repository_writes: ArchRule =
+    noClasses()
+        .that().resideInAPackage("..application.usecase..")
+        .should().callMethodWhere(
+            JavaCall.Predicates.target(
+                HasName.Predicates.nameMatching("save|saveAndFlush|delete|deleteAll|deleteById")
+                    .and(HasOwner.Predicates.With.owner(assignableTo(JpaRepository::class.java)))
+            )
+        )
+        .as("UseCase는 Repository 쓰기 호출 금지 (Service 위임)")
+```
+
+D2:
+```kotlin
+@ArchTest
+val service_should_not_have_other_service_field: ArchRule =
+    noClasses()
+        .that().resideInAPackage("..application.service..")
+        .should().dependOnClassesThat()
+            .haveSimpleNameEndingWith("Service")
+            .and().resideInAPackage("..application.service..")
+            .and().areNotAssignableFrom(JavaClass.Predicates.simpleNameOf(thisClassName))
+        .as("Service는 다른 Service 의존 금지 (조합은 UseCase가)")
+```
+
+D3 — 같은 feature 판별을 위한 커스텀 조건:
+```kotlin
+@ArchTest
+val usecase_should_not_depend_on_same_feature_usecase: ArchRule =
+    FEATURES.map { feature ->
+        noClasses()
+            .that().resideInAPackage("..$feature.application.usecase..")
+            .should().dependOnClassesThat()
+                .resideInAPackage("..$feature.application.usecase..")
+                .and().areNotAssignableFrom(thisClass)
+    }.reduce(ArchRule::and)
+```
+
+### E. Cross-feature 규칙 (3)
+
+| # | 규칙 | Phase |
+|---|---|---|
+| E1 | feature A → feature B의 `infrastructure` 의존 ❌ | 3 |
+| E2 | feature A의 Service → feature B의 어떤 패키지 의존 ❌ | 3 |
+| E3 | feature A의 Domain → feature B 의존 ❌ | 3 |
+
+```kotlin
+@ArchTest
+val cross_feature_infrastructure_access: ArchRule =
+    FEATURES.flatMap { from ->
+        FEATURES.filter { it != from && it != "common" }.map { to ->
+            noClasses()
+                .that().resideInAPackage("..$from..")
+                .should().dependOnClassesThat().resideInAPackage("..$to.infrastructure..")
+        }
+    }.reduce(ArchRule::and)
+    .as("다른 feature의 infrastructure 직접 접근 금지")
+```
+
+### H. 순환 참조 (1)
+
+| # | 규칙 | Phase |
+|---|---|---|
+| H1 | `com.team2.server.{feature}` 패키지 간 순환 참조 ❌ | 0 |
+
+```kotlin
+@ArchTest
+val no_package_cycles: ArchRule =
+    slices()
+        .matching("com.team2.server.(*)..")
+        .should().beFreeOfCycles()
+        .as("패키지 간 순환 참조 금지")
+```
+
+### X. common 패키지 (2)
+
+| # | 규칙 | Phase |
+|---|---|---|
+| X1 | `common.*` 은 어떤 feature 패키지도 의존 ❌ | 0 |
+| X2 | `..domain..` 클래스는 `common.exception`, `common.persistence`만 사용 | 1 |
+
+```kotlin
+@ArchTest
+val common_should_not_depend_on_features: ArchRule =
+    noClasses()
+        .that().resideInAPackage("..common..")
+        .should().dependOnClassesThat().resideInAnyPackage(
+            *FEATURES.map { "..$it.." }.toTypedArray()
+        )
+        .as("common 패키지는 feature 패키지 의존 금지")
+```
+
+---
+
+## 6. 단계별 활성화 전략
+
+`@ArchIgnore` 어노테이션으로 마이그레이션 진행에 따라 점진 활성화.
+
+| Phase | 마이그레이션 시점 | 활성화 규칙 |
+|---|---|---|
+| 0 | 즉시 (현재 코드 통과 가능) | A4, A5, H1, X1 |
+| 1 | common 정리 PR 후 | X2 |
+| 2 | party 4-레이어 재배치 PR 후 | A1, A2, A3, B1~B5, C1, C2, C3, D1, D2, D3 |
+| 3 | user application 신설 PR 후 | E1, E2, E3 (user-party 간) |
+| 4 | auth 4-레이어 재배치 PR 후 | (이미 활성화된 모든 규칙이 전 패키지에 적용) |
+
+`@ArchIgnore` 해제는 각 마이그레이션 PR에서 같이 진행.
+
+---
+
+## 7. CI 통합
+
+- 기존 `./gradlew test` 에 자동 포함 — 별도 Gradle task 불필요
+- 로컬 단독 실행: `./gradlew test --tests "com.team2.server.architecture.*"`
+- 실패 메시지는 한국어로 `as("...")` 사용
+
+---
+
+## 8. 한 페이지 요약
+
+```
+ArchUnit 1.4.0 (JUnit5)
+
+검증 영역 (총 22개 규칙)
+─────────────────────────
+A. 레이어 의존 방향        5
+B. 명명 / 패키지 위치       5
+C. 어노테이션 위치          3
+D. 금지 호출                3
+E. Cross-feature           3
+H. 순환 참조                1
+X. common 패키지           2
+
+활성화 전략
+─────────────────────────
+Phase 0 (즉시)   : A4, A5, H1, X1
+Phase 1 (common): + X2
+Phase 2 (party) : + A1~A3, B1~B5, C1~C3, D1~D3
+Phase 3 (user)  : + E1~E3
+Phase 4 (auth)  : 전체 활성
+
+테스트 위치
+─────────────────────────
+src/test/kotlin/com/team2/server/architecture/ (6 파일)
+```

--- a/src/test/kotlin/com/team2/server/architecture/AnnotationRuleTest.kt
+++ b/src/test/kotlin/com/team2/server/architecture/AnnotationRuleTest.kt
@@ -1,0 +1,59 @@
+package com.team2.server.architecture
+
+import com.tngtech.archunit.core.importer.ImportOption
+import com.tngtech.archunit.junit.AnalyzeClasses
+import com.tngtech.archunit.junit.ArchIgnore
+import com.tngtech.archunit.junit.ArchTest
+import com.tngtech.archunit.lang.ArchRule
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods
+import org.springframework.stereotype.Controller
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * C. 어노테이션 위치.
+ *
+ * 활성화 Phase: 2 (4-레이어 재배치 후)
+ */
+@AnalyzeClasses(
+    packages = ["com.team2.server"],
+    importOptions = [ImportOption.DoNotIncludeTests::class, ImportOption.DoNotIncludeJars::class],
+)
+class AnnotationRuleTest {
+    /** C1: @RestController / @Controller 는 ..api.. 에만. */
+    @ArchTest
+    @ArchIgnore(reason = "Phase 2: 마이그레이션 후 활성화")
+    val restControllerAnnotationsOnlyInApiPackage: ArchRule =
+        classes()
+            .that()
+            .areAnnotatedWith(RestController::class.java)
+            .or()
+            .areAnnotatedWith(Controller::class.java)
+            .should()
+            .resideInAPackage("..api..")
+            .`as`("@RestController/@Controller 는 ..api.. 에만 선언")
+
+    /** C2-class: 클래스 레벨 @Transactional 은 ..application.usecase.. 에만. */
+    @ArchTest
+    @ArchIgnore(reason = "Phase 2: 마이그레이션 후 활성화")
+    val classLevelTransactionalOnlyOnUseCase: ArchRule =
+        classes()
+            .that()
+            .areAnnotatedWith(Transactional::class.java)
+            .should()
+            .resideInAPackage("..application.usecase..")
+            .`as`("클래스 레벨 @Transactional 은 UseCase 에만 선언")
+
+    /** C2-method: 메서드 레벨 @Transactional 도 ..application.usecase.. 에만. */
+    @ArchTest
+    @ArchIgnore(reason = "Phase 2: 마이그레이션 후 활성화")
+    val methodLevelTransactionalOnlyOnUseCase: ArchRule =
+        methods()
+            .that()
+            .areAnnotatedWith(Transactional::class.java)
+            .should()
+            .beDeclaredInClassesThat()
+            .resideInAPackage("..application.usecase..")
+            .`as`("메서드 레벨 @Transactional 은 UseCase 에만 선언")
+}

--- a/src/test/kotlin/com/team2/server/architecture/ArchUnitConstants.kt
+++ b/src/test/kotlin/com/team2/server/architecture/ArchUnitConstants.kt
@@ -1,0 +1,15 @@
+package com.team2.server.architecture
+
+object ArchUnitConstants {
+    const val BASE_PACKAGE = "com.team2.server"
+
+    val FEATURES = listOf("auth", "user", "party", "image", "chat", "rollingpaper")
+
+    const val API = "..api.."
+    const val USECASE = "..application.usecase.."
+    const val SERVICE = "..application.service.."
+    const val APPLICATION = "..application.."
+    const val DOMAIN = "..domain.."
+    const val INFRASTRUCTURE = "..infrastructure.."
+    const val COMMON = "..common.."
+}

--- a/src/test/kotlin/com/team2/server/architecture/CommonPackageRuleTest.kt
+++ b/src/test/kotlin/com/team2/server/architecture/CommonPackageRuleTest.kt
@@ -1,0 +1,50 @@
+package com.team2.server.architecture
+
+import com.tngtech.archunit.core.importer.ImportOption
+import com.tngtech.archunit.junit.AnalyzeClasses
+import com.tngtech.archunit.junit.ArchIgnore
+import com.tngtech.archunit.junit.ArchTest
+import com.tngtech.archunit.lang.ArchRule
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses
+
+/**
+ * X. common 패키지 규칙.
+ *
+ * 활성화 Phase:
+ *  - X1: Phase 0 (즉시)
+ *  - X2: Phase 1 (common 정리 후)
+ */
+@AnalyzeClasses(
+    packages = ["com.team2.server"],
+    importOptions = [ImportOption.DoNotIncludeTests::class, ImportOption.DoNotIncludeJars::class],
+)
+class CommonPackageRuleTest {
+    private val featurePackages = ArchUnitConstants.FEATURES.map { "..$it.." }.toTypedArray()
+
+    /** X1: common 패키지는 어떤 feature 패키지도 의존 금지. */
+    @ArchTest
+    val commonShouldNotDependOnFeatures: ArchRule =
+        noClasses()
+            .that()
+            .resideInAPackage("..common..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAnyPackage(*featurePackages)
+            .`as`("common 패키지는 feature 패키지 의존 금지")
+
+    /** X2: domain 은 common.web/config/filter/response 의존 금지 (exception/persistence/entity 만 허용). */
+    @ArchTest
+    @ArchIgnore(reason = "Phase 1: common 정리 후 활성화")
+    val domainShouldNotDependOnWebLayerCommon: ArchRule =
+        noClasses()
+            .that()
+            .resideInAPackage("..domain..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAnyPackage(
+                "..common.web..",
+                "..common.config..",
+                "..common.filter..",
+                "..common.response..",
+            ).`as`("Domain 은 common 의 web/config/filter/response 의존 금지")
+}

--- a/src/test/kotlin/com/team2/server/architecture/CrossFeatureRuleTest.kt
+++ b/src/test/kotlin/com/team2/server/architecture/CrossFeatureRuleTest.kt
@@ -1,0 +1,84 @@
+package com.team2.server.architecture
+
+import com.tngtech.archunit.core.importer.ImportOption
+import com.tngtech.archunit.junit.AnalyzeClasses
+import com.tngtech.archunit.junit.ArchIgnore
+import com.tngtech.archunit.junit.ArchTest
+import com.tngtech.archunit.lang.ArchRule
+import com.tngtech.archunit.lang.CompositeArchRule
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses
+
+/**
+ * E. Cross-feature 규칙.
+ *
+ * 활성화 Phase: 3 (user application 레이어 신설 후)
+ */
+@AnalyzeClasses(
+    packages = ["com.team2.server"],
+    importOptions = [ImportOption.DoNotIncludeTests::class, ImportOption.DoNotIncludeJars::class],
+)
+class CrossFeatureRuleTest {
+    private val features = ArchUnitConstants.FEATURES
+
+    /** E1: 다른 feature 의 infrastructure 패키지 직접 접근 금지. */
+    @ArchTest
+    @ArchIgnore(reason = "Phase 3: user application 신설 후 활성화")
+    val crossFeatureShouldNotAccessOtherInfrastructure: ArchRule =
+        compose(
+            "다른 feature 의 infrastructure 직접 접근 금지",
+            features.flatMap { from ->
+                features.filter { it != from }.map { to ->
+                    noClasses()
+                        .that()
+                        .resideInAPackage("..$from..")
+                        .should()
+                        .dependOnClassesThat()
+                        .resideInAPackage("..$to.infrastructure..")
+                        .`as`("$from feature 는 $to.infrastructure 직접 접근 금지")
+                }
+            },
+        )
+
+    /** E2: feature A 의 Service 는 feature B 의 어떤 패키지도 의존 금지. */
+    @ArchTest
+    @ArchIgnore(reason = "Phase 3: user application 신설 후 활성화")
+    val serviceShouldNotDependOnOtherFeatures: ArchRule =
+        compose(
+            "Service 는 다른 feature 의존 금지 (UseCase 가 조합)",
+            features.flatMap { from ->
+                features.filter { it != from }.map { to ->
+                    noClasses()
+                        .that()
+                        .resideInAPackage("..$from.application.service..")
+                        .should()
+                        .dependOnClassesThat()
+                        .resideInAPackage("..$to..")
+                        .`as`("$from.application.service 는 $to feature 의존 금지")
+                }
+            },
+        )
+
+    /** E3: feature A 의 Domain 은 다른 feature 의존 금지. */
+    @ArchTest
+    @ArchIgnore(reason = "Phase 3: user application 신설 후 활성화")
+    val domainShouldNotDependOnOtherFeatures: ArchRule =
+        compose(
+            "Domain 은 다른 feature 의존 금지",
+            features.flatMap { from ->
+                features.filter { it != from }.map { to ->
+                    noClasses()
+                        .that()
+                        .resideInAPackage("..$from.domain..")
+                        .should()
+                        .dependOnClassesThat()
+                        .resideInAPackage("..$to..")
+                        .`as`("$from.domain 은 $to feature 의존 금지")
+                }
+            },
+        )
+
+    private fun compose(
+        description: String,
+        rules: List<ArchRule>,
+    ): ArchRule = CompositeArchRule.of(rules).`as`(description)
+}

--- a/src/test/kotlin/com/team2/server/architecture/ForbiddenCallRuleTest.kt
+++ b/src/test/kotlin/com/team2/server/architecture/ForbiddenCallRuleTest.kt
@@ -1,0 +1,147 @@
+package com.team2.server.architecture
+
+import com.tngtech.archunit.core.domain.JavaClass
+import com.tngtech.archunit.core.importer.ImportOption
+import com.tngtech.archunit.junit.AnalyzeClasses
+import com.tngtech.archunit.junit.ArchIgnore
+import com.tngtech.archunit.junit.ArchTest
+import com.tngtech.archunit.lang.ArchCondition
+import com.tngtech.archunit.lang.ArchRule
+import com.tngtech.archunit.lang.ConditionEvents
+import com.tngtech.archunit.lang.SimpleConditionEvent
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses
+import org.springframework.data.repository.Repository
+
+/**
+ * D. 금지 호출.
+ *
+ * 활성화 Phase: 2 (4-레이어 재배치 후)
+ */
+@AnalyzeClasses(
+    packages = ["com.team2.server"],
+    importOptions = [ImportOption.DoNotIncludeTests::class, ImportOption.DoNotIncludeJars::class],
+)
+class ForbiddenCallRuleTest {
+    /**
+     * D1: UseCase 는 Repository 쓰기 메서드 호출 금지.
+     * (save / saveAndFlush / saveAll / delete / deleteAll / deleteById / deleteAllById)
+     */
+    @ArchTest
+    @ArchIgnore(reason = "Phase 2: 마이그레이션 후 활성화")
+    val useCaseShouldNotCallRepositoryWriteMethods: ArchRule =
+        noClasses()
+            .that()
+            .resideInAPackage("..application.usecase..")
+            .should(callWriteMethodOnSpringRepository())
+            .`as`("UseCase는 Repository 쓰기 호출 금지 (Service에 위임)")
+
+    /** D2: Service 는 다른 Service 의존 금지 (자기 자신 제외). */
+    @ArchTest
+    @ArchIgnore(reason = "Phase 2: 마이그레이션 후 활성화")
+    val serviceShouldNotDependOnOtherService: ArchRule =
+        noClasses()
+            .that()
+            .resideInAPackage("..application.service..")
+            .should(dependOnAnotherServiceClass())
+            .`as`("Service는 다른 Service 의존 금지 (조합은 UseCase가)")
+
+    /**
+     * D3: UseCase 는 같은 feature 내 다른 UseCase 의존 금지.
+     * 다른 feature 의 UseCase 는 허용.
+     */
+    @ArchTest
+    @ArchIgnore(reason = "Phase 2: 마이그레이션 후 활성화")
+    val useCaseShouldNotDependOnSameFeatureUseCase: ArchRule =
+        noClasses()
+            .that()
+            .resideInAPackage("..application.usecase..")
+            .should(dependOnSameFeatureUseCase())
+            .`as`("UseCase는 같은 feature 내 다른 UseCase 의존 금지")
+
+    private fun callWriteMethodOnSpringRepository(): ArchCondition<JavaClass> {
+        val writeMethods =
+            setOf(
+                "save",
+                "saveAndFlush",
+                "saveAll",
+                "delete",
+                "deleteAll",
+                "deleteById",
+                "deleteAllById",
+            )
+        return object : ArchCondition<JavaClass>("call Repository write methods") {
+            override fun check(
+                item: JavaClass,
+                events: ConditionEvents,
+            ) {
+                item.methodCallsFromSelf.forEach { call ->
+                    val targetOwner = call.targetOwner
+                    val isRepository =
+                        targetOwner.isAssignableTo(Repository::class.java) ||
+                            targetOwner.simpleName.endsWith("Repository")
+                    if (isRepository && call.target.name in writeMethods) {
+                        events.add(
+                            SimpleConditionEvent.violated(
+                                call,
+                                "${item.fullName} 가 ${targetOwner.simpleName}.${call.target.name} 호출",
+                            ),
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private fun dependOnAnotherServiceClass(): ArchCondition<JavaClass> =
+        object : ArchCondition<JavaClass>("depend on another *Service class in application.service") {
+            override fun check(
+                item: JavaClass,
+                events: ConditionEvents,
+            ) {
+                item.directDependenciesFromSelf
+                    .map { it.targetClass }
+                    .filter { it != item }
+                    .filter { it.simpleName.endsWith("Service") }
+                    .filter { it.packageName.contains(".application.service") }
+                    .forEach { target ->
+                        events.add(
+                            SimpleConditionEvent.violated(
+                                item,
+                                "${item.simpleName} 가 다른 Service ${target.simpleName} 의존",
+                            ),
+                        )
+                    }
+            }
+        }
+
+    private fun dependOnSameFeatureUseCase(): ArchCondition<JavaClass> =
+        object : ArchCondition<JavaClass>("depend on UseCase in same feature") {
+            override fun check(
+                item: JavaClass,
+                events: ConditionEvents,
+            ) {
+                val itemFeature = extractFeature(item.packageName) ?: return
+                item.directDependenciesFromSelf
+                    .map { it.targetClass }
+                    .filter { it != item }
+                    .filter { it.simpleName.endsWith("UseCase") }
+                    .filter { it.packageName.contains(".application.usecase") }
+                    .filter { extractFeature(it.packageName) == itemFeature }
+                    .forEach { target ->
+                        events.add(
+                            SimpleConditionEvent.violated(
+                                item,
+                                "${item.simpleName} 가 같은 feature($itemFeature) UseCase ${target.simpleName} 의존",
+                            ),
+                        )
+                    }
+            }
+        }
+
+    private fun extractFeature(packageName: String): String? {
+        val prefix = "com.team2.server."
+        if (!packageName.startsWith(prefix)) return null
+        val rest = packageName.removePrefix(prefix)
+        return rest.substringBefore('.').takeIf { it.isNotEmpty() }
+    }
+}

--- a/src/test/kotlin/com/team2/server/architecture/LayerDependencyTest.kt
+++ b/src/test/kotlin/com/team2/server/architecture/LayerDependencyTest.kt
@@ -1,0 +1,75 @@
+package com.team2.server.architecture
+
+import com.tngtech.archunit.core.importer.ImportOption
+import com.tngtech.archunit.junit.AnalyzeClasses
+import com.tngtech.archunit.junit.ArchIgnore
+import com.tngtech.archunit.junit.ArchTest
+import com.tngtech.archunit.lang.ArchRule
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses
+import com.tngtech.archunit.library.Architectures.layeredArchitecture
+
+/**
+ * A. 레이어 의존 방향 검증.
+ *
+ * 활성화 Phase:
+ *  - A4, A5: Phase 0 (즉시)
+ *  - A1~A3: Phase 2 (party 4-레이어 재배치 후)
+ */
+@AnalyzeClasses(
+    packages = ["com.team2.server"],
+    importOptions = [ImportOption.DoNotIncludeTests::class, ImportOption.DoNotIncludeJars::class],
+)
+class LayerDependencyTest {
+    /** A1~A4: api → usecase → service → infrastructure 단방향 + domain은 모두에서 참조. */
+    @ArchTest
+    @ArchIgnore(reason = "Phase 2: party 4-레이어 재배치 후 활성화")
+    val layeredArchitectureRules: ArchRule =
+        layeredArchitecture()
+            .consideringAllDependencies()
+            .layer("Api")
+            .definedBy("..api..")
+            .layer("UseCase")
+            .definedBy("..application.usecase..")
+            .layer("Service")
+            .definedBy("..application.service..")
+            .layer("Domain")
+            .definedBy("..domain..")
+            .layer("Infrastructure")
+            .definedBy("..infrastructure..")
+            .whereLayer("Api")
+            .mayNotBeAccessedByAnyLayer()
+            .whereLayer("UseCase")
+            .mayOnlyBeAccessedByLayers("Api")
+            .whereLayer("Service")
+            .mayOnlyBeAccessedByLayers("UseCase")
+            .whereLayer("Infrastructure")
+            .mayOnlyBeAccessedByLayers("Service", "UseCase")
+            .whereLayer("Domain")
+            .mayOnlyBeAccessedByLayers("Api", "UseCase", "Service", "Infrastructure")
+            .`as`("레이어 의존 방향: api → usecase → service → infrastructure, domain은 모두에서 참조")
+
+    /** A4: Domain은 application/api/infrastructure 의존 금지. */
+    @ArchTest
+    val domainShouldNotDependOnOuterLayers: ArchRule =
+        noClasses()
+            .that()
+            .resideInAPackage("..domain..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAnyPackage(
+                "..api..",
+                "..application..",
+                "..infrastructure..",
+            ).`as`("Domain은 application/api/infrastructure 의존 금지")
+
+    /** A5: Domain은 Spring Data JPA 의존 금지. */
+    @ArchTest
+    val domainShouldNotDependOnSpringData: ArchRule =
+        noClasses()
+            .that()
+            .resideInAPackage("..domain..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAPackage("org.springframework.data..")
+            .`as`("Domain은 Spring Data JPA 의존 금지")
+}

--- a/src/test/kotlin/com/team2/server/architecture/PackageCycleTest.kt
+++ b/src/test/kotlin/com/team2/server/architecture/PackageCycleTest.kt
@@ -1,0 +1,27 @@
+package com.team2.server.architecture
+
+import com.tngtech.archunit.core.importer.ImportOption
+import com.tngtech.archunit.junit.AnalyzeClasses
+import com.tngtech.archunit.junit.ArchTest
+import com.tngtech.archunit.lang.ArchRule
+import com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices
+
+/**
+ * H. 순환 참조 금지.
+ *
+ * 활성화 Phase: 0 (즉시)
+ */
+@AnalyzeClasses(
+    packages = ["com.team2.server"],
+    importOptions = [ImportOption.DoNotIncludeTests::class, ImportOption.DoNotIncludeJars::class],
+)
+class PackageCycleTest {
+    /** H1: feature 패키지 간 순환 참조 금지. */
+    @ArchTest
+    val noPackageCyclesBetweenFeatures: ArchRule =
+        slices()
+            .matching("com.team2.server.(*)..")
+            .should()
+            .beFreeOfCycles()
+            .`as`("패키지 간 순환 참조 금지")
+}

--- a/src/test/kotlin/com/team2/server/architecture/PackageStructureTest.kt
+++ b/src/test/kotlin/com/team2/server/architecture/PackageStructureTest.kt
@@ -1,0 +1,81 @@
+package com.team2.server.architecture
+
+import com.tngtech.archunit.core.importer.ImportOption
+import com.tngtech.archunit.junit.AnalyzeClasses
+import com.tngtech.archunit.junit.ArchIgnore
+import com.tngtech.archunit.junit.ArchTest
+import com.tngtech.archunit.lang.ArchRule
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes
+
+/**
+ * B. 명명 규칙 / 패키지 위치.
+ *
+ * 활성화 Phase: 2 (party 4-레이어 재배치 후)
+ */
+@AnalyzeClasses(
+    packages = ["com.team2.server"],
+    importOptions = [ImportOption.DoNotIncludeTests::class, ImportOption.DoNotIncludeJars::class],
+)
+class PackageStructureTest {
+    /** B1: *Controller 는 ..api.. 에만. */
+    @ArchTest
+    @ArchIgnore(reason = "Phase 2: 마이그레이션 후 활성화")
+    val controllerClassesOnlyInApiPackage: ArchRule =
+        classes()
+            .that()
+            .haveSimpleNameEndingWith("Controller")
+            .should()
+            .resideInAPackage("..api..")
+            .`as`("*Controller 클래스는 ..api.. 에만 위치")
+
+    /** B2: *UseCase 는 ..application.usecase.. 에만. */
+    @ArchTest
+    @ArchIgnore(reason = "Phase 2: 마이그레이션 후 활성화")
+    val useCaseClassesOnlyInApplicationUseCasePackage: ArchRule =
+        classes()
+            .that()
+            .haveSimpleNameEndingWith("UseCase")
+            .should()
+            .resideInAPackage("..application.usecase..")
+            .`as`("*UseCase 클래스는 ..application.usecase.. 에만 위치")
+
+    /**
+     * B3: *Service 는 ..application.service.. 에만 (Spring 확장 클래스 예외).
+     *
+     * 예외:
+     *  - DefaultOAuth2UserService 상속 클래스(`CustomOAuth2UserService`) — Spring 확장
+     */
+    @ArchTest
+    @ArchIgnore(reason = "Phase 2: 마이그레이션 후 활성화")
+    val serviceClassesOnlyInApplicationServicePackage: ArchRule =
+        classes()
+            .that()
+            .haveSimpleNameEndingWith("Service")
+            .and()
+            .areNotAssignableTo("org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService")
+            .should()
+            .resideInAPackage("..application.service..")
+            .`as`("*Service 클래스는 ..application.service.. 에만 위치 (Spring 확장 예외)")
+
+    /** B4: *Repository 는 ..infrastructure.persistence.. 에만. */
+    @ArchTest
+    @ArchIgnore(reason = "Phase 2: 마이그레이션 후 활성화")
+    val repositoryClassesOnlyInInfrastructurePersistencePackage: ArchRule =
+        classes()
+            .that()
+            .haveSimpleNameEndingWith("Repository")
+            .should()
+            .resideInAPackage("..infrastructure.persistence..")
+            .`as`("*Repository 클래스는 ..infrastructure.persistence.. 에만 위치")
+
+    /** B5: ..application.usecase.. 안의 클래스는 *UseCase 접미사. */
+    @ArchTest
+    @ArchIgnore(reason = "Phase 2: 마이그레이션 후 활성화")
+    val classesInUseCasePackageShouldEndWithUseCase: ArchRule =
+        classes()
+            .that()
+            .resideInAPackage("..application.usecase..")
+            .should()
+            .haveSimpleNameEndingWith("UseCase")
+            .`as`("..application.usecase.. 안의 클래스는 *UseCase 접미사 필수")
+}

--- a/src/test/resources/archunit.properties
+++ b/src/test/resources/archunit.properties
@@ -1,0 +1,4 @@
+# 빈 매칭(rule 가 검사할 클래스가 없을 때) 시 실패시키지 않음.
+# 마이그레이션 진행 중에는 ..domain.., ..application.usecase.. 등 패키지가
+# 아직 존재하지 않을 수 있음 - 그 경우 vacuous pass.
+archRule.failOnEmptyShould=false


### PR DESCRIPTION
## 🔗 Issue
- closes #78

## 💬 Context
프로젝트가 성장함에 따라 패키지/레이어 구조가 일관되지 않게 흐트러질 위험이 있습니다. 특히 다음과 같은 문제를 사람이 PR 리뷰 단계에서 매번 잡아내는 것은 비현실적입니다.
- Controller → UseCase → Service → Repository 의존 방향이 무너짐
- `@Transactional` 이 Service/Repository 에 흩뿌려져 트랜잭션 경계가 모호해짐
- feature 간 결합 (예: `party` 가 `user.repository` 를 직접 호출)
- 패키지 간 순환 참조

이를 자동 검증하기 위해 ArchUnit 기반 아키텍처 테스트를 도입합니다. 동시에 검증의 기반이 되는 **레이어드 아키텍처 설계 (UseCase + Service 분리)** 와 **ArchUnit 테스트 설계** 문서를 함께 추가합니다.

마이그레이션과 병행하기 위해 단계별 활성화 전략 (`@ArchIgnore`) 을 사용했고, 현재 코드 베이스에 즉시 적용 가능한 규칙(Phase 0) 만 활성화 상태로 두었습니다.

## 🛠 Changes
**의존성/설정**
- `build.gradle.kts` 에 `archunit-junit5:1.4.0` 추가
- `src/test/resources/archunit.properties` 추가 (`archRule.failOnEmptyShould=false` — 마이그레이션 중 빈 매칭 허용)

**아키텍처 테스트 (`src/test/kotlin/com/team2/server/architecture/`)**
- `LayerDependencyTest` — 레이어 의존 방향 (api → usecase → service → infrastructure, domain 은 모두에서 참조)
- `PackageStructureTest` — `*Controller` / `*UseCase` / `*Service` / `*Repository` 위치 강제
- `AnnotationRuleTest` — `@RestController` 는 api 에만, `@Transactional` 은 UseCase 에만
- `ForbiddenCallRuleTest` — UseCase 의 Repository 쓰기 호출 / Service ↔ Service 의존 / 같은 feature 내 UseCase ↔ UseCase 의존 금지
- `CrossFeatureRuleTest` — 다른 feature 의 infrastructure / Service / Domain 직접 접근 금지
- `PackageCycleTest` — feature 간 순환 참조 금지
- `CommonPackageRuleTest` — common 이 feature 에 의존 금지, Domain 의 common.web/config/filter 의존 금지
- `ArchUnitConstants` — 공통 상수 (BASE_PACKAGE, FEATURES 등)

**설계 문서**
- `docs/superpowers/specs/2026-04-29-layered-architecture-design.md` — UseCase + Service 분리 기준의 4-레이어 아키텍처 규칙
- `docs/superpowers/specs/2026-05-02-archunit-tests-design.md` — ArchUnit 테스트 카탈로그 및 단계별 활성화 전략

**활성화 상태**
| Phase | 시점 | 규칙 수 | 상태 |
|---|---|---|---|
| 0 | 즉시 | 4 (A4, A5, H1, X1) | ✅ 활성 |
| 1 | common 정리 후 | 1 (X2) | `@ArchIgnore` |
| 2 | party 4-레이어 후 | 14 (A1~A3, B1~B5, C1~C3, D1~D3) | `@ArchIgnore` |
| 3 | user 신설 후 | 3 (E1~E3) | `@ArchIgnore` |

## 👀 Review Focus
- **활성화 전략의 적절성**: Phase 0 만 즉시 활성화하고 나머지는 `@ArchIgnore` 처리한 단계별 접근 방식이 합리적인지
- **규칙 강도**: 특히 `D2` (Service ↔ Service 의존 금지), `D3` (같은 feature 내 UseCase ↔ UseCase 의존 금지) 가 너무 엄격하지 않은지
- **예외 처리**: `B3` 에서 `DefaultOAuth2UserService` 상속 클래스(`CustomOAuth2UserService`)를 예외로 둔 부분
- **`archunit.properties` 의 `failOnEmptyShould=false` 설정**: 마이그레이션 완료 후 다시 `true` 로 되돌릴지 여부

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인 (./gradlew build 로컬 통과 확인)

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **Tests**
  * 계층화 아키텍처 검증을 위한 자동화된 테스트 체계가 구축되었습니다. 패키지 구조, 레이어 간 의존성, 크로스 기능 경계, 금지된 호출 등을 자동으로 검증합니다.

* **Documentation**
  * 계층화 아키텍처 설계 가이드 및 테스트 명세 문서가 추가되었습니다. UseCase/Service 분리, 각 계층의 책임 및 규칙이 명시됩니다.

* **Chores**
  * 아키텍처 테스트 의존성 및 설정이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->