### PR TITLE
[Feat] Party 도메인을 RealtimeParty/PaperOnlyParty로 분리 및 상태 정의 추가

### DIFF
--- a/docs/party-status.md
+++ b/docs/party-status.md
@@ -1,0 +1,67 @@
+# 파티 상태 정의
+
+파티 타입별 상태 전이 규칙을 정의한다.
+
+---
+
+## 1. 롤링페이퍼 전용 파티 (`PaperOnlyParty`)
+
+`startedAt: LocalDateTime` — 생일 날짜를 `날짜 00:00`으로 저장 (시간 입력 없음)
+
+| 상태 | 시점 | 참가자 | 주최자 |
+|------|------|--------|--------|
+| **READY** | 파티 생성 직후 ~ startedAt 전 | 작성 가능, 조회 가능 | 확인 불가 |
+| **OPEN** | startedAt ~ 생성일 +7일 | 작성 가능, 조회 가능 | 조회 가능 |
+| **CLOSED** | 생성일 +7일 이후 | 조회만 가능 | 조회만 가능 |
+
+### 상태 전이 조건
+
+```
+READY  : now < startedAt
+OPEN   : startedAt ≤ now < createdAt + 7일
+CLOSED : now ≥ createdAt + 7일
+```
+
+| 상수 | 값 |
+|------|----|
+| `CLOSED_AFTER_DAYS` | `7` |
+
+---
+
+## 2. 라이브 파티 (`RealtimeParty`)
+
+`startedAt: LocalDateTime` — 라이브 시작 날짜+시간을 저장 (년월일시간 모두 입력)
+
+생성 순간부터 롤링페이퍼 작성 가능. `startedAt` 시각부터 10분간 라이브(채팅) 진행.
+
+| 상태 | 시점 | 기능 |
+|------|------|------|
+| **ROLLING_PAPER_OPEN** | 파티 생성 직후 ~ 라이브 시작 전 | 롤페 작성·조회 가능 |
+| **LIVE_OPEN** | 라이브 시작 ~ +10분 | 라이브 진행(채팅 활성화) + 롤페 작성·조회 가능 |
+| **LIVE_CLOSED** | 라이브 종료 후 ~ 생성일 +7일 | 롤페 추가 작성·조회 가능 |
+| **ROLLING_PAPER_CLOSED** | 생성일 +7일 이후 | 롤페 조회만 가능 |
+
+### 상태 전이 조건
+
+```
+ROLLING_PAPER_OPEN   : now < startedAt
+LIVE_OPEN            : startedAt ≤ now < startedAt + 10분
+LIVE_CLOSED          : startedAt + 10분 ≤ now < createdAt + 7일
+ROLLING_PAPER_CLOSED : now ≥ createdAt + 7일
+```
+
+| 상수 | 값 |
+|------|----|
+| `LIVE_DURATION_MINUTES` | `10` |
+| `ENDED_AFTER_DAYS` | `7` |
+
+---
+
+## 구현
+
+상태 계산은 각 엔티티의 `status(now: LocalDateTime)` 메서드로 제공한다.
+
+```kotlin
+val status: PaperOnlyPartyStatus = paperParty.status()
+val status: RealtimePartyStatus  = realtimeParty.status()
+```

--- a/src/main/kotlin/com/team2/server/party/entity/PaperOnlyParty.kt
+++ b/src/main/kotlin/com/team2/server/party/entity/PaperOnlyParty.kt
@@ -1,0 +1,36 @@
+package com.team2.server.party.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "paper_only_party")
+class PaperOnlyParty(
+    ownerId: Long,
+    backgroundImageUrl: String? = null,
+    name: String? = null,
+    celebrantNickname: String? = null,
+    purpose: PartyPurpose = PartyPurpose.BIRTHDAY,
+    startedAt: LocalDateTime,
+) : Party(ownerId, backgroundImageUrl, name, celebrantNickname, startedAt, purpose) {
+    fun status(now: LocalDateTime = LocalDateTime.now()): PaperOnlyPartyStatus {
+        val openTime = startedAt
+        val closeTime = createdAt.plusDays(CLOSED_AFTER_DAYS)
+        return when {
+            now >= closeTime -> PaperOnlyPartyStatus.CLOSED
+            now >= openTime -> PaperOnlyPartyStatus.OPEN
+            else -> PaperOnlyPartyStatus.READY
+        }
+    }
+
+    companion object {
+        const val CLOSED_AFTER_DAYS: Long = 7
+    }
+}
+
+enum class PaperOnlyPartyStatus {
+    READY,
+    OPEN,
+    CLOSED,
+}

--- a/src/main/kotlin/com/team2/server/party/entity/PaperOnlyParty.kt
+++ b/src/main/kotlin/com/team2/server/party/entity/PaperOnlyParty.kt
@@ -13,7 +13,7 @@ class PaperOnlyParty(
     celebrantNickname: String? = null,
     purpose: PartyPurpose = PartyPurpose.BIRTHDAY,
     startedAt: LocalDateTime,
-) : Party(ownerId, backgroundImageUrl, name, celebrantNickname, startedAt, purpose) {
+) : Party(ownerId, backgroundImageUrl, name, celebrantNickname, startedAt, purpose, PartyOption.PAPER_ONLY) {
     fun status(now: LocalDateTime = LocalDateTime.now()): PaperOnlyPartyStatus {
         val openTime = startedAt
         val closeTime = createdAt.plusDays(CLOSED_AFTER_DAYS)

--- a/src/main/kotlin/com/team2/server/party/entity/Party.kt
+++ b/src/main/kotlin/com/team2/server/party/entity/Party.kt
@@ -22,7 +22,7 @@ abstract class Party(
     var name: String? = null,
     @Column(name = "celebrant_nickname")
     var celebrantNickname: String? = null,
-    @Column(name = "started_at")
+    @Column(name = "started_at", nullable = false)
     var startedAt: LocalDateTime,
     @Enumerated(EnumType.STRING)
     @Column(name = "purpose")

--- a/src/main/kotlin/com/team2/server/party/entity/Party.kt
+++ b/src/main/kotlin/com/team2/server/party/entity/Party.kt
@@ -5,31 +5,25 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
+import jakarta.persistence.Inheritance
+import jakarta.persistence.InheritanceType
 import jakarta.persistence.Table
 import java.time.LocalDateTime
 
 @Entity
 @Table(name = "party")
-class Party(
+@Inheritance(strategy = InheritanceType.JOINED)
+abstract class Party(
     @Column(name = "owner_id", nullable = false)
     val ownerId: Long,
     @Column(name = "background_image_url")
     var backgroundImageUrl: String? = null,
-    @Column(name = "started_at")
-    var startedAt: LocalDateTime? = null,
-    @Column(name = "ended_at")
-    var endedAt: LocalDateTime? = null,
     @Column(name = "name")
     var name: String? = null,
     @Column(name = "celebrant_nickname")
     var celebrantNickname: String? = null,
-    @Column(name = "is_chatting_allow")
-    var isChattingAllow: Boolean = false,
-    @Column(name = "paper_opened_at")
-    var paperOpenedAt: LocalDateTime? = null,
-    @Enumerated(EnumType.STRING)
-    @Column(name = "party_type")
-    var option: PartyOption,
+    @Column(name = "started_at")
+    var startedAt: LocalDateTime,
     @Enumerated(EnumType.STRING)
     @Column(name = "purpose")
     var purpose: PartyPurpose = PartyPurpose.BIRTHDAY,

--- a/src/main/kotlin/com/team2/server/party/entity/Party.kt
+++ b/src/main/kotlin/com/team2/server/party/entity/Party.kt
@@ -27,6 +27,9 @@ abstract class Party(
     @Enumerated(EnumType.STRING)
     @Column(name = "purpose")
     var purpose: PartyPurpose = PartyPurpose.BIRTHDAY,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "party_option", nullable = false)
+    val partyOption: PartyOption,
 ) : BaseEntity()
 
 enum class PartyOption {

--- a/src/main/kotlin/com/team2/server/party/entity/RealtimeParty.kt
+++ b/src/main/kotlin/com/team2/server/party/entity/RealtimeParty.kt
@@ -13,7 +13,7 @@ class RealtimeParty(
     celebrantNickname: String? = null,
     purpose: PartyPurpose = PartyPurpose.BIRTHDAY,
     startedAt: LocalDateTime,
-) : Party(ownerId, backgroundImageUrl, name, celebrantNickname, startedAt, purpose) {
+) : Party(ownerId, backgroundImageUrl, name, celebrantNickname, startedAt, purpose, PartyOption.REALTIME) {
     fun status(now: LocalDateTime = LocalDateTime.now()): RealtimePartyStatus {
         val liveStart = startedAt
         val liveEnd = liveStart.plusMinutes(LIVE_DURATION_MINUTES)

--- a/src/main/kotlin/com/team2/server/party/entity/RealtimeParty.kt
+++ b/src/main/kotlin/com/team2/server/party/entity/RealtimeParty.kt
@@ -1,0 +1,40 @@
+package com.team2.server.party.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "realtime_party")
+class RealtimeParty(
+    ownerId: Long,
+    backgroundImageUrl: String? = null,
+    name: String? = null,
+    celebrantNickname: String? = null,
+    purpose: PartyPurpose = PartyPurpose.BIRTHDAY,
+    startedAt: LocalDateTime,
+) : Party(ownerId, backgroundImageUrl, name, celebrantNickname, startedAt, purpose) {
+    fun status(now: LocalDateTime = LocalDateTime.now()): RealtimePartyStatus {
+        val liveStart = startedAt
+        val liveEnd = liveStart.plusMinutes(LIVE_DURATION_MINUTES)
+        val endedTime = createdAt.plusDays(ENDED_AFTER_DAYS)
+        return when {
+            now >= endedTime -> RealtimePartyStatus.ROLLING_PAPER_CLOSED
+            now >= liveEnd -> RealtimePartyStatus.LIVE_CLOSED
+            now >= liveStart -> RealtimePartyStatus.LIVE_OPEN
+            else -> RealtimePartyStatus.ROLLING_PAPER_OPEN
+        }
+    }
+
+    companion object {
+        const val LIVE_DURATION_MINUTES: Long = 10
+        const val ENDED_AFTER_DAYS: Long = 7
+    }
+}
+
+enum class RealtimePartyStatus {
+    ROLLING_PAPER_OPEN,
+    LIVE_OPEN,
+    LIVE_CLOSED,
+    ROLLING_PAPER_CLOSED,
+}

--- a/src/main/kotlin/com/team2/server/party/service/PartyInviteService.kt
+++ b/src/main/kotlin/com/team2/server/party/service/PartyInviteService.kt
@@ -5,6 +5,7 @@ import com.team2.server.common.exception.ErrorCode
 import com.team2.server.party.dto.ActivateInviteLinkResponse
 import com.team2.server.party.entity.Party
 import com.team2.server.party.entity.PartyInvite
+import com.team2.server.party.entity.RealtimeParty
 import com.team2.server.party.repository.ParticipantRepository
 import com.team2.server.party.repository.PartyInviteRepository
 import com.team2.server.party.repository.PartyRepository
@@ -53,7 +54,11 @@ class PartyInviteService(
         party: Party,
         now: LocalDateTime,
     ): PartyInvite {
-        val expiresAt = party.endedAt ?: now.plusHours(EXPIRY_HOURS)
+        val expiresAt =
+            (party as? RealtimeParty)
+                ?.startedAt
+                ?.plusMinutes(RealtimeParty.LIVE_DURATION_MINUTES)
+                ?: now.plusHours(EXPIRY_HOURS)
         return partyInviteRepository.save(
             PartyInvite(
                 party = party,

--- a/src/main/kotlin/com/team2/server/party/service/PartyService.kt
+++ b/src/main/kotlin/com/team2/server/party/service/PartyService.kt
@@ -4,10 +4,11 @@ import com.team2.server.common.exception.BusinessException
 import com.team2.server.common.exception.ErrorCode
 import com.team2.server.party.dto.CreatePartyRequest
 import com.team2.server.party.dto.CreatePartyResponse
+import com.team2.server.party.entity.PaperOnlyParty
 import com.team2.server.party.entity.Participant
-import com.team2.server.party.entity.Party
 import com.team2.server.party.entity.PartyOption
 import com.team2.server.party.entity.RealtimeParticipantProfile
+import com.team2.server.party.entity.RealtimeParty
 import com.team2.server.party.repository.ParticipantRepository
 import com.team2.server.party.repository.PartyRepository
 import com.team2.server.party.repository.RealtimeParticipantProfileRepository
@@ -15,7 +16,6 @@ import com.team2.server.user.repository.UserRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
-import java.time.LocalTime
 
 @Service
 class PartyService(
@@ -31,23 +31,25 @@ class PartyService(
         partyOption: PartyOption,
     ): CreatePartyResponse {
         val user = findUser(userId)
-        val startedAt =
+        val party =
             when (partyOption) {
-                PartyOption.PAPER_ONLY ->
-                    LocalDateTime.of(request.startedDate, request.startTime ?: LocalTime.MIDNIGHT)
                 PartyOption.REALTIME ->
-                    LocalDateTime.of(
-                        request.startedDate,
-                        requireNotNull(request.startTime) { "REALTIME 파티에는 startTime이 필요합니다." },
+                    RealtimeParty(
+                        ownerId = userId,
+                        celebrantNickname = request.celebrantNickname,
+                        startedAt =
+                            LocalDateTime.of(
+                                request.startedDate,
+                                requireNotNull(request.startTime) { "REALTIME 파티에는 startTime이 필요합니다." },
+                            ),
+                    )
+                PartyOption.PAPER_ONLY ->
+                    PaperOnlyParty(
+                        ownerId = userId,
+                        celebrantNickname = request.celebrantNickname,
+                        startedAt = request.startedDate.atStartOfDay(),
                     )
             }
-        val party =
-            Party(
-                ownerId = userId,
-                celebrantNickname = request.celebrantNickname,
-                startedAt = startedAt,
-                option = partyOption,
-            )
         val saved = partyRepository.save(party)
         val participant =
             participantRepository.save(

--- a/src/test/kotlin/com/team2/server/party/entity/PartyDomainTest.kt
+++ b/src/test/kotlin/com/team2/server/party/entity/PartyDomainTest.kt
@@ -1,0 +1,47 @@
+package com.team2.server.party.entity
+
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class PartyDomainTest {
+    private val defaultStartedAt = LocalDateTime.of(2026, 6, 1, 14, 0)
+
+    @Test
+    fun `RealtimeParty는 Party의 하위 타입이다`() {
+        val party = RealtimeParty(ownerId = 1L, startedAt = defaultStartedAt)
+        assertIs<Party>(party)
+    }
+
+    @Test
+    fun `PaperOnlyParty는 Party의 하위 타입이다`() {
+        val party = PaperOnlyParty(ownerId = 1L, startedAt = defaultStartedAt)
+        assertIs<Party>(party)
+    }
+
+    @Test
+    fun `Party 공통 필드는 두 타입 모두에서 접근 가능하다`() {
+        val startedAt = LocalDateTime.of(2026, 6, 1, 14, 0)
+        val realtime = RealtimeParty(ownerId = 1L, celebrantNickname = "홍길동", startedAt = startedAt)
+        val paperOnly = PaperOnlyParty(ownerId = 2L, celebrantNickname = "김철수", startedAt = startedAt)
+
+        assertTrue(realtime.celebrantNickname == "홍길동")
+        assertTrue(realtime.startedAt == startedAt)
+        assertTrue(paperOnly.celebrantNickname == "김철수")
+        assertTrue(paperOnly.startedAt == startedAt)
+    }
+
+    @Test
+    fun `RealtimeParty는 PaperOnlyParty가 아니다`() {
+        val party: Party = RealtimeParty(ownerId = 1L, startedAt = defaultStartedAt)
+        assertFalse(party is PaperOnlyParty)
+    }
+
+    @Test
+    fun `PaperOnlyParty는 RealtimeParty가 아니다`() {
+        val party: Party = PaperOnlyParty(ownerId = 1L, startedAt = defaultStartedAt)
+        assertFalse(party is RealtimeParty)
+    }
+}

--- a/src/test/kotlin/com/team2/server/party/entity/PartyParticipationDomainTest.kt
+++ b/src/test/kotlin/com/team2/server/party/entity/PartyParticipationDomainTest.kt
@@ -1,5 +1,6 @@
 package com.team2.server.party.entity
 
+import com.team2.server.party.entity.RealtimeParty
 import com.team2.server.rollingpaper.entity.RollingPaper
 import com.team2.server.rollingpaper.entity.RollingPaperWrapper
 import com.team2.server.user.entity.AuthProvider
@@ -73,9 +74,12 @@ class PartyParticipationDomainTest {
     }
 
     private fun newParty(): Party =
-        Party(
+        RealtimeParty(
             ownerId = 1L,
-            option = PartyOption.REALTIME,
+            startedAt =
+                java.time.LocalDateTime
+                    .now()
+                    .plusDays(1),
         )
 
     private fun newUser(): User =

--- a/src/test/kotlin/com/team2/server/party/entity/PartyStatusTest.kt
+++ b/src/test/kotlin/com/team2/server/party/entity/PartyStatusTest.kt
@@ -1,0 +1,107 @@
+package com.team2.server.party.entity
+
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+import kotlin.test.assertEquals
+
+class PartyStatusTest {
+    private val birthday: LocalDate = LocalDate.of(2026, 5, 10)
+    private val createdAt: LocalDateTime = birthday.minusDays(3).atStartOfDay()
+    private val liveStart: LocalDateTime = birthday.atTime(23, 0)
+
+    private fun paperParty(startedAt: LocalDateTime = birthday.atStartOfDay()): PaperOnlyParty {
+        val party = PaperOnlyParty(ownerId = 1L, startedAt = startedAt)
+        setCreatedAt(party, createdAt)
+        return party
+    }
+
+    private fun realtimeParty(startedAt: LocalDateTime = liveStart): RealtimeParty {
+        val party = RealtimeParty(ownerId = 1L, startedAt = startedAt)
+        setCreatedAt(party, createdAt)
+        return party
+    }
+
+    private fun setCreatedAt(
+        entity: Any,
+        value: LocalDateTime,
+    ) {
+        var clazz: Class<*>? = entity.javaClass
+        while (clazz != null) {
+            try {
+                val f = clazz.getDeclaredField("createdAt")
+                f.isAccessible = true
+                f.set(entity, value)
+                return
+            } catch (_: NoSuchFieldException) {
+                clazz = clazz.superclass
+            }
+        }
+    }
+
+    // --- PaperOnlyParty ---
+
+    @Test
+    fun `PaperOnlyParty - startedAt 이전은 READY`() {
+        val party = paperParty()
+        val now = birthday.atStartOfDay().minusMinutes(1)
+        assertEquals(PaperOnlyPartyStatus.READY, party.status(now))
+    }
+
+    @Test
+    fun `PaperOnlyParty - startedAt 시각은 OPEN`() {
+        val party = paperParty()
+        val now = birthday.atStartOfDay()
+        assertEquals(PaperOnlyPartyStatus.OPEN, party.status(now))
+    }
+
+    @Test
+    fun `PaperOnlyParty - 생성일 +7일 직전은 OPEN`() {
+        val party = paperParty()
+        val now = createdAt.plusDays(7).minusMinutes(1)
+        assertEquals(PaperOnlyPartyStatus.OPEN, party.status(now))
+    }
+
+    @Test
+    fun `PaperOnlyParty - 생성일 +7일 이후는 CLOSED`() {
+        val party = paperParty()
+        val now = createdAt.plusDays(7)
+        assertEquals(PaperOnlyPartyStatus.CLOSED, party.status(now))
+    }
+
+    // --- RealtimeParty ---
+
+    @Test
+    fun `RealtimeParty - 라이브 시작 전은 ROLLING_PAPER_OPEN`() {
+        val party = realtimeParty()
+        val now = liveStart.minusMinutes(1)
+        assertEquals(RealtimePartyStatus.ROLLING_PAPER_OPEN, party.status(now))
+    }
+
+    @Test
+    fun `RealtimeParty - 라이브 시작 시각은 LIVE_OPEN`() {
+        val party = realtimeParty()
+        assertEquals(RealtimePartyStatus.LIVE_OPEN, party.status(liveStart))
+    }
+
+    @Test
+    fun `RealtimeParty - 라이브 시작 +9분은 LIVE_OPEN`() {
+        val party = realtimeParty()
+        val now = liveStart.plusMinutes(9)
+        assertEquals(RealtimePartyStatus.LIVE_OPEN, party.status(now))
+    }
+
+    @Test
+    fun `RealtimeParty - 라이브 종료(+10분) 시각은 LIVE_CLOSED`() {
+        val party = realtimeParty()
+        val now = liveStart.plusMinutes(10)
+        assertEquals(RealtimePartyStatus.LIVE_CLOSED, party.status(now))
+    }
+
+    @Test
+    fun `RealtimeParty - 생성일 +7일 이후는 ROLLING_PAPER_CLOSED`() {
+        val party = realtimeParty()
+        val now = createdAt.plusDays(7)
+        assertEquals(RealtimePartyStatus.ROLLING_PAPER_CLOSED, party.status(now))
+    }
+}

--- a/src/test/kotlin/com/team2/server/party/repository/ParticipantRepositoryTest.kt
+++ b/src/test/kotlin/com/team2/server/party/repository/ParticipantRepositoryTest.kt
@@ -2,9 +2,9 @@ package com.team2.server.party.repository
 
 import com.team2.server.party.entity.Participant
 import com.team2.server.party.entity.Party
-import com.team2.server.party.entity.PartyOption
 import com.team2.server.party.entity.PartyPurpose
 import com.team2.server.party.entity.RealtimeParticipantProfile
+import com.team2.server.party.entity.RealtimeParty
 import com.team2.server.rollingpaper.entity.RollingPaper
 import com.team2.server.rollingpaper.entity.RollingPaperWrapper
 import com.team2.server.user.entity.AuthProvider
@@ -38,15 +38,12 @@ class ParticipantRepositoryTest
         fun setUp() {
             party =
                 partyRepository.save(
-                    Party(
+                    RealtimeParty(
                         ownerId = 1L,
                         name = "테스트파티",
                         celebrantNickname = "홍길동",
                         purpose = PartyPurpose.BIRTHDAY,
-                        option = PartyOption.REALTIME,
                         startedAt = LocalDateTime.now(),
-                        endedAt = LocalDateTime.now().plusDays(7),
-                        isChattingAllow = true,
                     ),
                 )
             user =

--- a/src/test/kotlin/com/team2/server/party/service/PartyInviteServiceTest.kt
+++ b/src/test/kotlin/com/team2/server/party/service/PartyInviteServiceTest.kt
@@ -4,7 +4,7 @@ import com.team2.server.common.exception.BusinessException
 import com.team2.server.common.exception.ErrorCode
 import com.team2.server.party.entity.Party
 import com.team2.server.party.entity.PartyInvite
-import com.team2.server.party.entity.PartyOption
+import com.team2.server.party.entity.RealtimeParty
 import com.team2.server.party.repository.ParticipantRepository
 import com.team2.server.party.repository.PartyInviteRepository
 import com.team2.server.party.repository.PartyRepository
@@ -15,7 +15,6 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import java.lang.reflect.Field
 import java.time.LocalDateTime
 import java.util.Optional
 import kotlin.test.assertEquals
@@ -30,14 +29,20 @@ class PartyInviteServiceTest {
     private fun makeParty(
         id: Long = 1L,
         ownerId: Long = 1L,
-        startedAt: LocalDateTime? = LocalDateTime.now().plusDays(2),
-        endedAt: LocalDateTime? = LocalDateTime.now().plusDays(2).plusHours(3),
-        option: PartyOption = PartyOption.REALTIME,
-    ): Party {
-        val party = Party(ownerId = ownerId, startedAt = startedAt, endedAt = endedAt, option = option)
-        val idField: Field = party.javaClass.superclass.getDeclaredField("id")
-        idField.isAccessible = true
-        idField.set(party, id)
+        startedAt: LocalDateTime = LocalDateTime.now().plusDays(2),
+    ): RealtimeParty {
+        val party = RealtimeParty(ownerId = ownerId, startedAt = startedAt)
+        var clazz: Class<*>? = party.javaClass
+        while (clazz != null) {
+            try {
+                val idField = clazz.getDeclaredField("id")
+                idField.isAccessible = true
+                idField.set(party, id)
+                break
+            } catch (_: NoSuchFieldException) {
+                clazz = clazz.superclass
+            }
+        }
         return party
     }
 
@@ -107,9 +112,9 @@ class PartyInviteServiceTest {
     }
 
     @Test
-    fun `링크 만료 시간은 파티 종료 시간까지`() {
-        val endedAt = LocalDateTime.of(2024, 11, 26, 22, 0)
-        val party = makeParty(endedAt = endedAt)
+    fun `RealtimeParty 링크 만료 시간은 라이브 종료 시간(startedAt + 10분)`() {
+        val startedAt = LocalDateTime.of(2024, 11, 26, 22, 0)
+        val party = makeParty(startedAt = startedAt)
         whenever(partyRepository.findById(1L)).thenReturn(Optional.of(party))
         whenever(participantRepository.existsByPartyIdAndUserId(1L, 1L)).thenReturn(true)
         whenever(partyInviteRepository.findByPartyIdAndExpiresAtAfter(any(), any())).thenReturn(null)
@@ -121,6 +126,6 @@ class PartyInviteServiceTest {
 
         service.activateInviteLink(1L, 1L)
 
-        assertEquals(endedAt, savedInvite!!.expiresAt)
+        assertEquals(startedAt.plusMinutes(RealtimeParty.LIVE_DURATION_MINUTES), savedInvite!!.expiresAt)
     }
 }

--- a/src/test/kotlin/com/team2/server/party/service/PartyServiceTest.kt
+++ b/src/test/kotlin/com/team2/server/party/service/PartyServiceTest.kt
@@ -3,11 +3,13 @@ package com.team2.server.party.service
 import com.team2.server.common.exception.BusinessException
 import com.team2.server.common.exception.ErrorCode
 import com.team2.server.party.dto.CreatePartyRequest
+import com.team2.server.party.entity.PaperOnlyParty
 import com.team2.server.party.entity.Participant
 import com.team2.server.party.entity.Party
 import com.team2.server.party.entity.PartyOption
 import com.team2.server.party.entity.PartyPurpose
 import com.team2.server.party.entity.RealtimeParticipantProfile
+import com.team2.server.party.entity.RealtimeParty
 import com.team2.server.party.repository.ParticipantRepository
 import com.team2.server.party.repository.PartyRepository
 import com.team2.server.party.repository.RealtimeParticipantProfileRepository
@@ -25,7 +27,6 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import java.lang.reflect.Field
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -54,26 +55,28 @@ class PartyServiceTest {
         entity: Any,
         id: Long,
     ) {
-        val idField: Field = entity.javaClass.superclass.getDeclaredField("id")
-        idField.isAccessible = true
-        idField.set(entity, id)
+        var clazz: Class<*>? = entity.javaClass
+        while (clazz != null) {
+            try {
+                val idField = clazz.getDeclaredField("id")
+                idField.isAccessible = true
+                idField.set(entity, id)
+                return
+            } catch (_: NoSuchFieldException) {
+                clazz = clazz.superclass
+            }
+        }
+        throw NoSuchFieldException("id not found in class hierarchy of ${entity.javaClass.name}")
     }
 
-    private fun newParty(
-        id: Long = 1L,
-        endedAt: LocalDateTime = LocalDateTime.now().plusDays(7),
-        isChattingAllow: Boolean = true,
-    ): Party {
+    private fun newParty(id: Long = 1L): RealtimeParty {
         val party =
-            Party(
+            RealtimeParty(
                 ownerId = 1L,
                 name = "생일파티",
                 celebrantNickname = "홍길동",
                 purpose = PartyPurpose.BIRTHDAY,
-                option = PartyOption.REALTIME,
                 startedAt = LocalDateTime.now(),
-                endedAt = endedAt,
-                isChattingAllow = isChattingAllow,
             )
         setId(party, id)
         return party
@@ -95,7 +98,7 @@ class PartyServiceTest {
     // --- 파티 생성 ---
 
     @Test
-    fun `createParty PAPER_ONLY에서 startTime null이면 00시로 저장됨`() {
+    fun `createParty PAPER_ONLY는 startedDate를 당일 00시로 저장한다`() {
         val user = newUser(id = 1L)
         val savedParty = newParty(id = 9L)
         val request =
@@ -113,7 +116,7 @@ class PartyServiceTest {
 
         val partyCaptor = argumentCaptor<Party>()
         verify(partyRepository).save(partyCaptor.capture())
-        assertEquals(LocalDate.of(2026, 5, 1).atStartOfDay(), partyCaptor.firstValue.startedAt)
+        assertEquals(LocalDate.of(2026, 5, 1).atStartOfDay(), (partyCaptor.firstValue as PaperOnlyParty).startedAt)
     }
 
     @Test
@@ -152,7 +155,7 @@ class PartyServiceTest {
 
         val partyCaptor = argumentCaptor<Party>()
         verify(partyRepository).save(partyCaptor.capture())
-        assertEquals(PartyOption.REALTIME, partyCaptor.firstValue.option)
+        assertTrue(partyCaptor.firstValue is RealtimeParty)
     }
 
     @Test
@@ -174,7 +177,7 @@ class PartyServiceTest {
 
         val partyCaptor = argumentCaptor<Party>()
         verify(partyRepository).save(partyCaptor.capture())
-        assertEquals(PartyOption.PAPER_ONLY, partyCaptor.firstValue.option)
+        assertTrue(partyCaptor.firstValue is PaperOnlyParty)
     }
 
     @Test


### PR DESCRIPTION
## 🔗 Issue
- closes #87

## 💬 Context
기존 `Party` 엔티티는 단일 클래스에서 `PartyOption`(REALTIME/PAPER_ONLY) 필드로 타입을 구분하고 있었습니다. 두 파티 타입은 `startedAt`의 의미, 상태 전이 규칙, 라이브 기능 여부 등 핵심 비즈니스 로직이 서로 달라 하나의 클래스에서 관리하기 어려운 구조였습니다. JPA JOINED 상속을 활용해 `Party`를 추상 기반 클래스로 분리하고, 각 타입의 상태 전이 로직을 독립적으로 캡슐화했습니다.

## 🛠 Changes
- `Party`를 추상 클래스로 변경, `@Inheritance(JOINED)` 전략 적용
- `RealtimeParty` 신규 구현: `startedAt` 기준 10분 라이브 윈도우, 4단계 상태 전이 (`ROLLING_PAPER_OPEN` → `LIVE_OPEN` → `LIVE_CLOSED` → `ROLLING_PAPER_CLOSED`)
- `PaperOnlyParty` 신규 구현: `startedAt` 00:00부터 활성화, 3단계 상태 전이 (`READY` → `OPEN` → `CLOSED`)
- `PartyService`: `partyOption`에 따라 올바른 서브타입 생성, `PaperOnlyParty.startedAt`은 `startedDate.atStartOfDay()`로 변환
- `PartyInviteService`: 초대 링크 만료 시간을 `RealtimeParty.startedAt + 10분`으로 계산
- `docs/party-status.md`: 파티 타입별 상태 전이 규칙 문서화
- 도메인 테스트(`PartyDomainTest`) 및 상태 경계값 테스트(`PartyStatusTest`) 추가

## 👀 Review Focus
- `RealtimeParty.status()` / `PaperOnlyParty.status()` — 상태 전이 경계값 when 블록 순서 (liveEnd를 liveStart보다 먼저 체크해야 LIVE_CLOSED 진입 가능)
- `PartyService`에서 `PaperOnlyParty.startedAt = request.startedDate.atStartOfDay()` — 년월일만 받는 입력을 00:00으로 변환하는 로직
- JPA JOINED 상속에서 `@DiscriminatorColumn` / `@DiscriminatorValue` 를 의도적으로 제거한 이유: H2 2.4.x의 CHECK 제약 파싱 버그 회피

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 파티 타입에 따른 상태 관리 시스템 개선: 페이퍼 파티는 7일 후 자동 종료, 실시간 파티는 라이브 세션(10분)과 롤링페이퍼 기간(7일) 분리 관리

* **Documentation**
  * 파티 상태 정의 및 상태 전환 규칙 문서화

* **Tests**
  * 파티 상태 전환 및 도메인 계층 구조 검증 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->