### PR TITLE
[Feat] Party 도메인을 RealtimeParty/PaperOnlyParty로 분리

### DIFF
--- a/src/main/kotlin/com/team2/server/party/entity/PaperOnlyParty.kt
+++ b/src/main/kotlin/com/team2/server/party/entity/PaperOnlyParty.kt
@@ -8,12 +8,11 @@ import java.time.LocalDateTime
 @Table(name = "paper_only_party")
 class PaperOnlyParty(
     ownerId: Long,
-    backgroundImageUrl: String? = null,
     name: String? = null,
     celebrantNickname: String? = null,
     purpose: PartyPurpose = PartyPurpose.BIRTHDAY,
     startedAt: LocalDateTime,
-) : Party(ownerId, backgroundImageUrl, name, celebrantNickname, startedAt, purpose, PartyOption.PAPER_ONLY) {
+) : Party(ownerId, name, celebrantNickname, startedAt, purpose, PartyOption.PAPER_ONLY) {
     fun status(now: LocalDateTime = LocalDateTime.now()): PaperOnlyPartyStatus {
         val openTime = startedAt
         val closeTime = createdAt.plusDays(CLOSED_AFTER_DAYS)

--- a/src/main/kotlin/com/team2/server/party/entity/Party.kt
+++ b/src/main/kotlin/com/team2/server/party/entity/Party.kt
@@ -16,8 +16,6 @@ import java.time.LocalDateTime
 abstract class Party(
     @Column(name = "owner_id", nullable = false)
     val ownerId: Long,
-    @Column(name = "background_image_url")
-    var backgroundImageUrl: String? = null,
     @Column(name = "name")
     var name: String? = null,
     @Column(name = "celebrant_nickname")

--- a/src/main/kotlin/com/team2/server/party/entity/RealtimeParty.kt
+++ b/src/main/kotlin/com/team2/server/party/entity/RealtimeParty.kt
@@ -8,12 +8,11 @@ import java.time.LocalDateTime
 @Table(name = "realtime_party")
 class RealtimeParty(
     ownerId: Long,
-    backgroundImageUrl: String? = null,
     name: String? = null,
     celebrantNickname: String? = null,
     purpose: PartyPurpose = PartyPurpose.BIRTHDAY,
     startedAt: LocalDateTime,
-) : Party(ownerId, backgroundImageUrl, name, celebrantNickname, startedAt, purpose, PartyOption.REALTIME) {
+) : Party(ownerId, name, celebrantNickname, startedAt, purpose, PartyOption.REALTIME) {
     fun status(now: LocalDateTime = LocalDateTime.now()): RealtimePartyStatus {
         val liveStart = startedAt
         val liveEnd = liveStart.plusMinutes(LIVE_DURATION_MINUTES)


### PR DESCRIPTION
## 🔗 Issue
- closes #87

## 💬 Context
기존 `Party` 엔티티가 단일 클래스로 모든 파티 타입을 처리하면서 타입별 상태 전이 로직이 없었고, `endedAt`, `isChattingAllow` 등 타입에 따라 의미가 다른 필드들이 혼재해 있었습니다. `RealtimeParty`와 `PaperOnlyParty`로 도메인을 분리하여 각 파티 타입의 상태 전이 로직을 엔티티 내에 캡슐화하고, 불필요한 필드를 제거했습니다.

## 🛠 Changes
- `Party`를 추상 클래스로 변경하고 `@Inheritance(JOINED)` 전략 적용
- `RealtimeParty` 엔티티 추가 — 4단계 상태 관리 (ROLLING_PAPER_OPEN → LIVE_OPEN → LIVE_CLOSED → ROLLING_PAPER_CLOSED)
- `PaperOnlyParty` 엔티티 추가 — 3단계 상태 관리 (READY → OPEN → CLOSED)
- `PartyService`에서 `partyOption`에 따라 적절한 서브클래스 생성하도록 수정
- `PartyInviteService`에서 `RealtimeParty`의 라이브 종료 시간(`startedAt + 10분`)을 초대 링크 만료 시간으로 활용
- `backgroundImageUrl`, `endedAt`, `isChattingAllow`, `paperOpenedAt` 등 미사용 필드 제거
- 파티 상태 정의 문서(`docs/party-status.md`) 추가
- 관련 테스트 코드 전면 업데이트 및 상태 전이 테스트(`PartyStatusTest`) 추가

## 👀 Review Focus
- `@Inheritance(JOINED)` 전략 선택의 적절성 — 파티 타입별 테이블 분리가 쿼리 성능에 미치는 영향
- `PartyInviteService`의 타입 캐스팅(`party as? RealtimeParty`) 패턴 — 다형성 처리 방식이 적절한지
- `PaperOnlyParty`의 `startedAt`을 당일 00:00으로 고정하는 처리가 요구사항과 일치하는지

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 파티 엔티티의 배경 이미지 관련 필드를 제거하여 데이터 모델 간소화
  * 파티 생성 시 필수 파라미터를 명확히 정의하여 안정성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->