### PR TITLE
[Feat] 초대장 조회 API 추가

### DIFF
--- a/docs/superpowers/specs/2026-05-04-party-invite-lookup-design.md
+++ b/docs/superpowers/specs/2026-05-04-party-invite-lookup-design.md
@@ -72,7 +72,6 @@ GET /api/v1/party-invites/{inviteToken}
 
 ```json
 {
-  "partyId": 1,
   "celebrantNickname": "홍길동",
   "partyOption": "REALTIME",
   "partyEnded": false,
@@ -89,7 +88,6 @@ GET /api/v1/party-invites/{inviteToken}
 
 ```json
 {
-  "partyId": 2,
   "celebrantNickname": "홍길동",
   "partyOption": "PAPER_ONLY",
   "partyEnded": false,
@@ -106,7 +104,6 @@ GET /api/v1/party-invites/{inviteToken}
 
 | 응답 필드 | source | 계산 |
 |---|---|---|
-| `partyId` | `Party.id` | 그대로 |
 | `celebrantNickname` | `Party.celebrantNickname` | 컬럼명과 동일 의미 유지 |
 | `partyOption` | 현재 코드의 `Party.partyOption` | 그대로 |
 | `partyEnded` | `Party.createdAt` | `now >= createdAt.plusDays(7)` |
@@ -222,6 +219,7 @@ controller -> usecase -> repository/entity/dto
 트랜잭션:
 
 - 현재 `GetCharactersUseCase` 패턴에 맞춰 `LookupPartyInviteUseCase`의 조회 메서드에 `@Transactional(readOnly = true)`를 둔다.
+- public 메서드명은 컨트롤러에서 의미가 드러나도록 `lookup(...)`을 사용한다.
 - 조회 유스케이스이므로 Repository write method는 호출하지 않는다.
 
 ---
@@ -258,9 +256,11 @@ src/main/kotlin/com/team2/server/party/controller/PartyInviteLookupApi.kt
 
 문서화할 응답:
 
-- 200: REALTIME/PAPER_ONLY 예시
 - 404: `PARTY_NOT_FOUND`
 - 500: 공통 서버 오류
+
+성공 응답은 `ApiResponse<PartyInviteLookupResponse>` 반환 타입으로 자동 매칭되게 두고, Swagger에 200 응답을 수동 작성하지 않는다.
+Enum 필드는 DTO `@Schema` 설명에 값별 의미를 명시한다.
 
 만료된 토큰도 조회 가능하므로 `INVITE_LINK_EXPIRED`는 이 API의 Swagger 응답으로 문서화하지 않는다.
 
@@ -322,7 +322,6 @@ src/main/kotlin/com/team2/server/party/dto/PartyInviteLookupResponse.kt
 
 Kotlin 타입:
 
-- `partyId: Long`
 - `celebrantNickname: String?`
 - `partyOption: PartyOption`
 - `partyEnded: Boolean`
@@ -334,6 +333,7 @@ Kotlin 타입:
 - `liveDurationMinutes: Long?`
 
 현재 엔티티 필드명도 `partyOption`이므로 DTO 필드명도 그대로 `partyOption`으로 둔다.
+`partyOption`과 `realtimeStatus`는 Swagger 필드 설명에 enum 값별 의미를 함께 적는다.
 
 ### 7-5. SecurityConfig
 

--- a/docs/superpowers/specs/2026-05-04-party-invite-lookup-design.md
+++ b/docs/superpowers/specs/2026-05-04-party-invite-lookup-design.md
@@ -43,7 +43,7 @@
 - 신규 조회 API 경로는 `GET /api/v1/party-invites/{inviteToken}`이다.
 - 응답은 초대장 조회 전용 응답이다.
 - `partyEnded`, `partyStartDate`, `partyEndDate`는 `endedAt` 전용 컬럼이 아니라 `createdAt + 7일` 기준으로 계산한다.
-- `realtimeStatus`는 기존 도메인 상태가 아니라 초대장 조회 응답 전용 상태다.
+- `REALTIME` 파티는 조회 시점 상태값 대신 프론트가 버튼/카운트다운 상태를 계산할 기준 시각을 내려준다.
 
 ---
 
@@ -78,9 +78,12 @@ GET /api/v1/party-invites/{inviteToken}
   "rollingPaperWritten": false,
   "partyStartDate": "2026-05-04",
   "partyEndDate": "2026-05-11",
-  "realtimeStatus": "ENTERABLE",
-  "liveStartAt": "2026-05-04T20:00:00",
-  "liveDurationMinutes": 10
+  "realtimeSchedule": {
+    "liveStartAt": "2026-05-04T20:00:00",
+    "enterableFrom": "2026-05-04T19:55:00",
+    "liveEndAt": "2026-05-04T20:10:00",
+    "liveDurationMinutes": 10
+  }
 }
 ```
 
@@ -94,9 +97,7 @@ GET /api/v1/party-invites/{inviteToken}
   "rollingPaperWritten": false,
   "partyStartDate": "2026-05-04",
   "partyEndDate": "2026-05-11",
-  "realtimeStatus": null,
-  "liveStartAt": null,
-  "liveDurationMinutes": null
+  "realtimeSchedule": null
 }
 ```
 
@@ -110,37 +111,43 @@ GET /api/v1/party-invites/{inviteToken}
 | `rollingPaperWritten` | `Participant.hasWrittenPaper` | 식별 가능한 회원 participant가 있으면 해당 값, 없으면 false |
 | `partyStartDate` | `Party.createdAt` | `createdAt.toLocalDate()` |
 | `partyEndDate` | `Party.createdAt` | `createdAt.plusDays(7).toLocalDate()` |
-| `realtimeStatus` | 조회 응답 전용 계산 | `REALTIME`이면 계산, `PAPER_ONLY`이면 null |
-| `liveStartAt` | `Party.startedAt` | `REALTIME`이면 내려줌 |
-| `liveDurationMinutes` | 정책 상수 | `REALTIME`이면 `10` |
+| `realtimeSchedule` | 실시간 파티 일정 기준 시각 | `REALTIME`이면 내려주고, `PAPER_ONLY`이면 null |
+| `realtimeSchedule.liveStartAt` | `Party.startedAt` | 실시간 파티 시작 시각 |
+| `realtimeSchedule.enterableFrom` | `Party.startedAt - 5분` | 프론트 입장 버튼 활성화 기준 시작 시각 |
+| `realtimeSchedule.liveEndAt` | `Party.startedAt + 10분` | 프론트 종료 상태 기준 시각 |
+| `realtimeSchedule.liveDurationMinutes` | 정책 상수 | 실시간 파티 진행 시간 |
 
 ---
 
-## 4. RealtimeStatus 설계
+## 4. Realtime Schedule 설계
 
-응답 DTO 전용 enum:
+응답 DTO 전용 schedule:
 
 ```kotlin
-enum class RealtimeStatus {
-    NOT_ENTERABLE,
-    ENTERABLE,
-    ENDED,
-}
+data class RealtimeSchedule(
+    val liveStartAt: LocalDateTime,
+    val enterableFrom: LocalDateTime,
+    val liveEndAt: LocalDateTime,
+    val liveDurationMinutes: Long,
+)
 ```
 
 계산 규칙:
 
-- `party.partyOption == PAPER_ONLY`이면 `realtimeStatus = null`
+- `party.partyOption == PAPER_ONLY`이면 `realtimeSchedule = null`
 - `REALTIME`일 때:
-  - `now < startedAt.minusMinutes(5)` -> `NOT_ENTERABLE`
-  - `startedAt.minusMinutes(5) <= now < startedAt.plusMinutes(10)` -> `ENTERABLE`
-  - `now >= startedAt.plusMinutes(10)` -> `ENDED`
+  - `liveStartAt = startedAt`
+  - `enterableFrom = startedAt.minusMinutes(5)`
+  - `liveEndAt = startedAt.plusMinutes(10)`
+  - `liveDurationMinutes = 10`
 
 설계 판단:
 
 - 현재 `develop`에는 `RealtimeParty` 하위 타입이 있고 `RealtimeParty.status()`는 도메인 상태를 유지한다.
-- 초대장 조회에서는 `party is RealtimeParty`일 때만 응답 전용 `RealtimeStatus`를 계산한다.
-- 5분 전 입장 가능 정책은 `RealtimeParty.status()`에 넣지 않고 조회 유스케이스의 응답 계산으로 둔다.
+- 초대장 조회에서는 조회 시점의 `RealtimeStatus`를 내려주지 않는다.
+- 프론트는 `enterableFrom`, `liveEndAt`과 현재 시각을 비교해 버튼 활성화/카운트다운/종료 표시를 계산한다.
+- 백엔드는 이후 실시간 파티 입장 API에서 같은 기준으로 최종 입장 가능 여부를 검증한다.
+- 5분 전 입장 가능 정책은 `RealtimeParty.status()`에 넣지 않고 초대장 조회 응답 schedule 계산에만 둔다.
 - `RealtimeParty.startedAt`은 non-null이므로 REALTIME 정상 데이터에서는 null 방어가 필요 없다.
 
 ---
@@ -150,14 +157,14 @@ enum class RealtimeStatus {
 결정:
 
 - 기존 `PartyInviteService.activateInviteLink(...)`는 유효한 초대 토큰 재사용을 위해 `PartyInvite.expiresAt`을 사용한다.
-- 신규 기획은 "실시간 파티 종료 여부와 관계없이 `liveStartAt`을 내려준다"고 되어 있고, `partyEnded`는 `createdAt + 7일` 기준이다.
+- 신규 기획은 "실시간 파티 종료 여부와 관계없이 `realtimeSchedule`을 내려준다"고 되어 있고, `partyEnded`는 `createdAt + 7일` 기준이다.
 - 초대장 조회 API는 `PartyInvite.expiresAt`이 지났어도 조회 가능하게 한다.
 
 구현 기준:
 
 - 조회 API는 `PartyInviteRepository.findByToken(...)`으로 token 존재 여부만 확인한다.
 - `PartyInvite.expiresAt`은 "초대 링크 발급/재사용 및 참여 가능성"에 쓰고, 초대장 요약 조회 자체를 막지는 않는다.
-- 만료된 토큰도 파티 요약을 보여줘야 프론트가 `realtimeStatus = ENDED` 또는 `partyEnded = true` 같은 상태 화면을 안정적으로 만들 수 있다.
+- 만료된 토큰도 파티 요약을 보여줘야 프론트가 `realtimeSchedule.liveEndAt` 또는 `partyEnded = true` 같은 기준으로 상태 화면을 안정적으로 만들 수 있다.
 - 없는 token은 기존 관례대로 `PARTY_NOT_FOUND`를 반환한다.
 
 기존 발급/재사용 정책과 분리하기 위해 조회 전용 `findByToken` 흐름을 둔다.
@@ -284,7 +291,7 @@ src/main/kotlin/com/team2/server/party/usecase/LookupPartyInviteUseCase.kt
 3. `party = invite.party`
 4. `partyEndAt = party.createdAt.plusDays(7)`
 5. `rollingPaperWritten` 계산
-6. `realtimeStatus` 계산
+6. `realtimeSchedule` 계산
 7. `PartyInviteLookupResponse` 반환
 
 의존성 제한:
@@ -328,12 +335,17 @@ Kotlin 타입:
 - `rollingPaperWritten: Boolean`
 - `partyStartDate: LocalDate`
 - `partyEndDate: LocalDate`
-- `realtimeStatus: RealtimeStatus?`
-- `liveStartAt: LocalDateTime?`
-- `liveDurationMinutes: Long?`
+- `realtimeSchedule: RealtimeSchedule?`
+
+`RealtimeSchedule` 타입:
+
+- `liveStartAt: LocalDateTime`
+- `enterableFrom: LocalDateTime`
+- `liveEndAt: LocalDateTime`
+- `liveDurationMinutes: Long`
 
 현재 엔티티 필드명도 `partyOption`이므로 DTO 필드명도 그대로 `partyOption`으로 둔다.
-`partyOption`과 `realtimeStatus`는 Swagger 필드 설명에 enum 값별 의미를 함께 적는다.
+`partyOption`은 Swagger 필드 설명에 enum 값별 의미를 함께 적는다.
 
 ### 7-5. SecurityConfig
 
@@ -363,11 +375,8 @@ src/test/kotlin/com/team2/server/party/controller/PartyInviteLookupControllerTes
 - 인증 없이 조회해도 participant count가 증가하지 않음
 - 인증 회원 participant가 있고 `hasWrittenPaper = true`이면 `rollingPaperWritten = true`
 - participant가 없으면 `rollingPaperWritten = false`
-- `PAPER_ONLY`는 `realtimeStatus`, `liveStartAt`, `liveDurationMinutes`가 null
-- `REALTIME`은 live 관련 필드가 내려감
-- `now < startedAt - 5분`이면 `NOT_ENTERABLE`
-- `startedAt - 5분 <= now < startedAt + 10분`이면 `ENTERABLE`
-- `now >= startedAt + 10분`이면 `ENDED`
+- `PAPER_ONLY`는 `realtimeSchedule`이 null
+- `REALTIME`은 `realtimeSchedule.liveStartAt`, `enterableFrom`, `liveEndAt`, `liveDurationMinutes`가 내려감
 - `createdAt + 7일` 이상이면 `partyEnded = true`
 - 없는 token이면 404 `PARTY_NOT_FOUND`
 
@@ -380,9 +389,9 @@ src/test/kotlin/com/team2/server/party/controller/PartyInviteLookupControllerTes
 - token 없음
 - token 존재 but no user
 - token 존재 and participant exists
-- date/status 경계값
+- date/schedule 경계값
 
-시간 경계 테스트는 `LocalDateTime.now()` 직접 호출 때문에 흔들릴 수 있다.
+`partyEnded` 경계 테스트는 `LocalDateTime.now()` 직접 호출 때문에 흔들릴 수 있다.
 
 구현 선택:
 
@@ -392,7 +401,7 @@ src/test/kotlin/com/team2/server/party/controller/PartyInviteLookupControllerTes
 구현 기준:
 
 - 이번 기능 범위에서는 새 시간 추상화는 만들지 않는다.
-- 경계 테스트는 `startedAt = now.plusMinutes(6)`, `now.plusMinutes(4)`, `now.minusMinutes(11)`처럼 여유를 둔다.
+- `realtimeSchedule` 테스트는 같은 `startedAt` 기준에서 `enterableFrom`, `liveEndAt` 기대값을 계산한다.
 
 ### 8-3. Security 테스트
 
@@ -416,7 +425,7 @@ src/test/kotlin/com/team2/server/party/controller/PartyInviteLookupControllerTes
 
 승인 후 진행 순서:
 
-1. `PartyInviteLookupResponse`, `RealtimeStatus` DTO 추가
+1. `PartyInviteLookupResponse`, `RealtimeSchedule` DTO 추가
 2. `ParticipantRepository.findByPartyIdAndUserId(...)` 추가
 3. `LookupPartyInviteUseCase` 추가
 4. `PartyInviteLookupApi`, `PartyInviteLookupController` 추가

--- a/docs/superpowers/specs/2026-05-04-party-invite-lookup-design.md
+++ b/docs/superpowers/specs/2026-05-04-party-invite-lookup-design.md
@@ -1,0 +1,438 @@
+# Party Invite Lookup API Design
+
+- 작성일: 2026-05-04
+- 기준 브랜치: `feature/party-invite-lookup`
+- 목적: 공유 링크 진입 시 `inviteToken`만으로 초대장/파티 요약을 조회하는 공개 API 추가
+- 구현 전 확인 상태: 이 문서는 구현 전 설계 확인용이며, 승인 전에는 Kotlin 코드를 변경하지 않는다.
+
+---
+
+## 1. 사용자 흐름
+
+1. 사용자가 공유 링크로 진입한다.
+2. 프론트가 링크의 `inviteToken`으로 초대장/파티 요약을 조회한다.
+3. 프론트가 `inviteToken`과 party summary를 `localStorage`에 저장한다.
+4. 이 시점에는 `participant`를 생성하지 않는다.
+5. `"롤페 작성하기"` 클릭 시 participant 생성/복원 후 rolling paper 작성 플로우로 이동한다.
+6. `"파티 입장하기"` 클릭 시 participant 생성/복원 후 realtime profile 설정/입장 플로우로 이동한다.
+
+핵심 경계:
+
+- 초대장 조회는 **공개 조회**다.
+- 초대장 조회는 **participant 생성/복원 side effect가 없어야 한다**.
+- participant 생성/복원은 이후 작성/입장 액션의 책임으로 남긴다.
+
+---
+
+## 2. 현재 코드 기준
+
+현재 `develop` 기준으로 확인한 구조:
+
+- 초대 링크 발급 API: `POST /api/v1/parties/{partyId}/invite-link`
+  - `PartyInviteController`
+  - `PartyInviteService.activateInviteLink(...)`
+- 현재 공개 허용:
+  - `GET /api/v1/characters`
+  - `GET /images/**`
+- 현재 `Party`는 abstract base entity이고 `RealtimeParty`, `PaperOnlyParty`가 joined inheritance로 분리되어 있다.
+- 현재 `Party`에는 `partyOption: PartyOption`, `startedAt`, `createdAt`가 있고 `endedAt` 전용 컬럼은 없다.
+- 현재 `party/usecase`에는 `GetCharactersUseCase`가 있으며, 조회 흐름을 컨트롤러에서 직접 조립하지 않고 유스케이스로 분리한 선례가 있다.
+
+이번 기획과 달라지는 지점:
+
+- 신규 조회 API 경로는 `GET /api/v1/party-invites/{inviteToken}`이다.
+- 응답은 초대장 조회 전용 응답이다.
+- `partyEnded`, `partyStartDate`, `partyEndDate`는 `endedAt` 전용 컬럼이 아니라 `createdAt + 7일` 기준으로 계산한다.
+- `realtimeStatus`는 기존 도메인 상태가 아니라 초대장 조회 응답 전용 상태다.
+
+---
+
+## 3. API 계약
+
+### 3-1. Endpoint
+
+```http
+GET /api/v1/party-invites/{inviteToken}
+```
+
+### 3-2. 인증
+
+- `permitAll`
+- Authorization header가 없어도 조회 가능
+- Authorization header가 유효하면 현재 회원의 `rollingPaperWritten` 계산에 사용
+- Authorization header가 없거나 현재 조회자 식별이 불가능하면 `rollingPaperWritten = false`
+
+주의:
+
+- 현재 JWT 필터는 잘못된 Bearer 토큰이 들어오면 request attribute에 인증 오류를 기록한다.
+- `permitAll` 경로라도 잘못된 Bearer 토큰은 기존 정책대로 401로 본다.
+- 이번 API도 "Authorization header 없음은 익명 허용, invalid token은 401" 정책을 따른다.
+
+### 3-3. Response
+
+```json
+{
+  "partyId": 1,
+  "celebrantNickname": "홍길동",
+  "partyOption": "REALTIME",
+  "partyEnded": false,
+  "rollingPaperWritten": false,
+  "partyStartDate": "2026-05-04",
+  "partyEndDate": "2026-05-11",
+  "realtimeStatus": "ENTERABLE",
+  "liveStartAt": "2026-05-04T20:00:00",
+  "liveDurationMinutes": 10
+}
+```
+
+`PAPER_ONLY` 응답:
+
+```json
+{
+  "partyId": 2,
+  "celebrantNickname": "홍길동",
+  "partyOption": "PAPER_ONLY",
+  "partyEnded": false,
+  "rollingPaperWritten": false,
+  "partyStartDate": "2026-05-04",
+  "partyEndDate": "2026-05-11",
+  "realtimeStatus": null,
+  "liveStartAt": null,
+  "liveDurationMinutes": null
+}
+```
+
+필드 매핑:
+
+| 응답 필드 | source | 계산 |
+|---|---|---|
+| `partyId` | `Party.id` | 그대로 |
+| `celebrantNickname` | `Party.celebrantNickname` | 컬럼명과 동일 의미 유지 |
+| `partyOption` | 현재 코드의 `Party.partyOption` | 그대로 |
+| `partyEnded` | `Party.createdAt` | `now >= createdAt.plusDays(7)` |
+| `rollingPaperWritten` | `Participant.hasWrittenPaper` | 식별 가능한 회원 participant가 있으면 해당 값, 없으면 false |
+| `partyStartDate` | `Party.createdAt` | `createdAt.toLocalDate()` |
+| `partyEndDate` | `Party.createdAt` | `createdAt.plusDays(7).toLocalDate()` |
+| `realtimeStatus` | 조회 응답 전용 계산 | `REALTIME`이면 계산, `PAPER_ONLY`이면 null |
+| `liveStartAt` | `Party.startedAt` | `REALTIME`이면 내려줌 |
+| `liveDurationMinutes` | 정책 상수 | `REALTIME`이면 `10` |
+
+---
+
+## 4. RealtimeStatus 설계
+
+응답 DTO 전용 enum:
+
+```kotlin
+enum class RealtimeStatus {
+    NOT_ENTERABLE,
+    ENTERABLE,
+    ENDED,
+}
+```
+
+계산 규칙:
+
+- `party.partyOption == PAPER_ONLY`이면 `realtimeStatus = null`
+- `REALTIME`일 때:
+  - `now < startedAt.minusMinutes(5)` -> `NOT_ENTERABLE`
+  - `startedAt.minusMinutes(5) <= now < startedAt.plusMinutes(10)` -> `ENTERABLE`
+  - `now >= startedAt.plusMinutes(10)` -> `ENDED`
+
+설계 판단:
+
+- 현재 `develop`에는 `RealtimeParty` 하위 타입이 있고 `RealtimeParty.status()`는 도메인 상태를 유지한다.
+- 초대장 조회에서는 `party is RealtimeParty`일 때만 응답 전용 `RealtimeStatus`를 계산한다.
+- 5분 전 입장 가능 정책은 `RealtimeParty.status()`에 넣지 않고 조회 유스케이스의 응답 계산으로 둔다.
+- `RealtimeParty.startedAt`은 non-null이므로 REALTIME 정상 데이터에서는 null 방어가 필요 없다.
+
+---
+
+## 5. 토큰 유효성 정책
+
+결정:
+
+- 기존 `PartyInviteService.activateInviteLink(...)`는 유효한 초대 토큰 재사용을 위해 `PartyInvite.expiresAt`을 사용한다.
+- 신규 기획은 "실시간 파티 종료 여부와 관계없이 `liveStartAt`을 내려준다"고 되어 있고, `partyEnded`는 `createdAt + 7일` 기준이다.
+- 초대장 조회 API는 `PartyInvite.expiresAt`이 지났어도 조회 가능하게 한다.
+
+구현 기준:
+
+- 조회 API는 `PartyInviteRepository.findByToken(...)`으로 token 존재 여부만 확인한다.
+- `PartyInvite.expiresAt`은 "초대 링크 발급/재사용 및 참여 가능성"에 쓰고, 초대장 요약 조회 자체를 막지는 않는다.
+- 만료된 토큰도 파티 요약을 보여줘야 프론트가 `realtimeStatus = ENDED` 또는 `partyEnded = true` 같은 상태 화면을 안정적으로 만들 수 있다.
+- 없는 token은 기존 관례대로 `PARTY_NOT_FOUND`를 반환한다.
+
+기존 발급/재사용 정책과 분리하기 위해 조회 전용 `findByToken` 흐름을 둔다.
+
+---
+
+## 6. 패키지/의존 설계
+
+현재 코드 패키지 구조:
+
+```text
+party/
+├── controller
+├── dto
+├── entity
+├── repository
+├── service
+└── usecase
+```
+
+결정:
+
+- 이번 변경은 **기존 코드 패키지 구조에 맞춰서 최소 추가**한다.
+- 새 `application.usecase` 패키지는 만들지 않는다.
+- 새 조회 흐름은 기존 `party/usecase/GetCharactersUseCase` 패턴을 따른다.
+- `PartyInviteService`는 초대 토큰 발급/재사용 행위를 계속 담당하고, 초대장 조회는 별도 `LookupPartyInviteUseCase`가 담당한다.
+
+추가 파일 위치:
+
+```text
+party/
+├── controller/
+│   ├── PartyInviteLookupApi.kt
+│   └── PartyInviteLookupController.kt
+├── dto/
+│   └── PartyInviteLookupResponse.kt
+└── usecase/
+    └── LookupPartyInviteUseCase.kt
+```
+
+의존 방향:
+
+```text
+controller -> usecase -> repository/entity/dto
+```
+
+지킬 것:
+
+- Controller는 Repository를 직접 보지 않는다.
+- Controller는 기존 `CharacterController`처럼 UseCase만 호출한다.
+- UseCase는 다른 Service를 주입하지 않는다.
+- UseCase는 필요한 Repository만 직접 주입한다.
+- UseCase는 HTTP 타입, `HttpServletRequest`, `AuthenticationPrincipal`을 모른다.
+- DTO 변환은 조회 전용 UseCase 내부에서만 수행한다. 단, Controller에 변환 로직을 두지 않는다.
+- 신규 조회 UseCase는 participant 생성/수정/save를 하지 않는다.
+- 신규 조회 UseCase는 `PartyInviteService.activateInviteLink(...)`를 호출하지 않는다.
+- 신규 조회 UseCase는 나중에 작성/입장 API가 생기더라도 participant 생성/복원 책임을 가져오지 않는다.
+
+트랜잭션:
+
+- 현재 `GetCharactersUseCase` 패턴에 맞춰 `LookupPartyInviteUseCase`의 조회 메서드에 `@Transactional(readOnly = true)`를 둔다.
+- 조회 유스케이스이므로 Repository write method는 호출하지 않는다.
+
+---
+
+## 7. 구현 상세안
+
+### 7-1. Controller
+
+새 컨트롤러:
+
+```text
+src/main/kotlin/com/team2/server/party/controller/PartyInviteLookupController.kt
+```
+
+역할:
+
+- `GET /api/v1/party-invites/{inviteToken}` 매핑
+- `@AuthenticationPrincipal principal: UserPrincipal?`를 optional로 받음
+- 유스케이스에 `inviteToken`, `principal?.userId` 전달
+- `ApiResponse.success(...)`로 감쌈
+
+기존 `PartyInviteController`는 유지:
+
+- `POST /api/v1/parties/{partyId}/invite-link`만 담당
+- 신규 조회 API를 여기에 섞지 않음
+
+### 7-2. Swagger API interface
+
+새 interface:
+
+```text
+src/main/kotlin/com/team2/server/party/controller/PartyInviteLookupApi.kt
+```
+
+문서화할 응답:
+
+- 200: REALTIME/PAPER_ONLY 예시
+- 404: `PARTY_NOT_FOUND`
+- 500: 공통 서버 오류
+
+만료된 토큰도 조회 가능하므로 `INVITE_LINK_EXPIRED`는 이 API의 Swagger 응답으로 문서화하지 않는다.
+
+### 7-3. UseCase
+
+새 유스케이스:
+
+```text
+src/main/kotlin/com/team2/server/party/usecase/LookupPartyInviteUseCase.kt
+```
+
+의존성:
+
+- `PartyInviteRepository`
+- `ParticipantRepository`
+
+흐름:
+
+1. `partyInviteRepository.findByToken(inviteToken)`
+2. 없으면 `BusinessException(ErrorCode.PARTY_NOT_FOUND)`
+3. `party = invite.party`
+4. `partyEndAt = party.createdAt.plusDays(7)`
+5. `rollingPaperWritten` 계산
+6. `realtimeStatus` 계산
+7. `PartyInviteLookupResponse` 반환
+
+의존성 제한:
+
+- `LookupPartyInviteUseCase`는 `PartyInviteRepository`, `ParticipantRepository`만 주입하는 것을 우선한다.
+- `rollingPaperWritten`은 `userId`만 있으면 `ParticipantRepository.findByPartyIdAndUserId(...)`로 계산 가능하므로 `UserRepository`를 주입하지 않는다.
+- 이렇게 하면 조회 흐름이 user aggregate를 직접 조회하지 않아도 되고, 의존성이 더 작아진다.
+- 단, 유효한 JWT인데 DB에서 user가 삭제된 케이스는 JWT 필터 단계에서 이미 `AUTH_USER_NOT_FOUND`로 처리되는 현재 구조를 따른다.
+
+`rollingPaperWritten` 계산:
+
+- `userId == null`이면 false
+- 회원이면 `ParticipantRepository.findByPartyIdAndUserId(party.id, userId)`를 추가해서 조회
+- participant가 없으면 false
+- participant가 있으면 `hasWrittenPaper`
+
+Repository 추가:
+
+```kotlin
+fun findByPartyIdAndUserId(
+    partyId: Long,
+    userId: Long,
+): Participant?
+```
+
+이 추가는 기존 `existsByPartyIdAndUserId`와 같은 축이라 자연스럽다.
+
+### 7-4. DTO
+
+새 DTO:
+
+```text
+src/main/kotlin/com/team2/server/party/dto/PartyInviteLookupResponse.kt
+```
+
+Kotlin 타입:
+
+- `partyId: Long`
+- `celebrantNickname: String?`
+- `partyOption: PartyOption`
+- `partyEnded: Boolean`
+- `rollingPaperWritten: Boolean`
+- `partyStartDate: LocalDate`
+- `partyEndDate: LocalDate`
+- `realtimeStatus: RealtimeStatus?`
+- `liveStartAt: LocalDateTime?`
+- `liveDurationMinutes: Long?`
+
+현재 엔티티 필드명도 `partyOption`이므로 DTO 필드명도 그대로 `partyOption`으로 둔다.
+
+### 7-5. SecurityConfig
+
+추가:
+
+```kotlin
+auth.requestMatchers(HttpMethod.GET, "/api/v1/party-invites/*").permitAll()
+```
+
+현재 `develop`에는 `GET /api/v1/parties/{inviteToken}`가 없다. Swagger 문서에도 이 API를 새로 유지하거나 복구하지 않는다.
+
+---
+
+## 8. 테스트 계획
+
+### 8-1. Controller 통합 테스트
+
+새 테스트:
+
+```text
+src/test/kotlin/com/team2/server/party/controller/PartyInviteLookupControllerTest.kt
+```
+
+검증:
+
+- 인증 없이 `PAPER_ONLY` 초대장 조회 성공
+- 인증 없이 조회해도 participant count가 증가하지 않음
+- 인증 회원 participant가 있고 `hasWrittenPaper = true`이면 `rollingPaperWritten = true`
+- participant가 없으면 `rollingPaperWritten = false`
+- `PAPER_ONLY`는 `realtimeStatus`, `liveStartAt`, `liveDurationMinutes`가 null
+- `REALTIME`은 live 관련 필드가 내려감
+- `now < startedAt - 5분`이면 `NOT_ENTERABLE`
+- `startedAt - 5분 <= now < startedAt + 10분`이면 `ENTERABLE`
+- `now >= startedAt + 10분`이면 `ENDED`
+- `createdAt + 7일` 이상이면 `partyEnded = true`
+- 없는 token이면 404 `PARTY_NOT_FOUND`
+
+### 8-2. UseCase 단위 테스트
+
+유스케이스 로직이 커지면 별도 단위 테스트를 둔다.
+
+검증:
+
+- token 없음
+- token 존재 but no user
+- token 존재 and participant exists
+- date/status 경계값
+
+시간 경계 테스트는 `LocalDateTime.now()` 직접 호출 때문에 흔들릴 수 있다.
+
+구현 선택:
+
+- 단순 구현: startedAt을 현재 기준으로 충분히 멀리 잡아 통합 테스트 안정화
+- 더 엄밀한 구현: `Clock` 주입 또는 `TimeProvider` 도입
+
+구현 기준:
+
+- 이번 기능 범위에서는 새 시간 추상화는 만들지 않는다.
+- 경계 테스트는 `startedAt = now.plusMinutes(6)`, `now.plusMinutes(4)`, `now.minusMinutes(11)`처럼 여유를 둔다.
+
+### 8-3. Security 테스트
+
+검증:
+
+- `GET /api/v1/party-invites/{inviteToken}`는 토큰 없이 200
+- 없는 token도 인증 없이 404까지 도달
+- invalid Bearer token은 기존 보안 정책대로 401
+
+### 8-4. 전체 테스트
+
+실행:
+
+```bash
+./gradlew test
+```
+
+---
+
+## 9. 구현 순서
+
+승인 후 진행 순서:
+
+1. `PartyInviteLookupResponse`, `RealtimeStatus` DTO 추가
+2. `ParticipantRepository.findByPartyIdAndUserId(...)` 추가
+3. `LookupPartyInviteUseCase` 추가
+4. `PartyInviteLookupApi`, `PartyInviteLookupController` 추가
+5. `SecurityConfig`에 `GET /api/v1/party-invites/*` permitAll 추가
+6. controller/usecase/security 테스트 추가
+7. 필요한 Swagger 예시 정리
+8. 검증 실행
+   - `./gradlew test --tests com.team2.server.party.controller.PartyInviteLookupControllerTest`
+   - 필요 시 `./gradlew test`
+
+---
+
+## 10. 확정 사항
+
+1. `PartyInvite.expiresAt`이 지난 token도 초대장 조회는 허용한다.
+2. 현재 `develop`에는 기존 `GET /api/v1/parties/{inviteToken}`가 없으므로 유지/삭제 대상이 아니다.
+3. 이번 기능은 기존 패키지 구조에 맞춰 작게 추가한다.
+4. invalid Bearer token이 들어온 공개 조회 요청은 기존 정책대로 401로 본다.
+5. `RealtimeParty.startedAt`은 현재 모델에서 non-null이므로 null 비정상 데이터 케이스는 별도 처리하지 않는다.

--- a/src/main/kotlin/com/team2/server/auth/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/team2/server/auth/config/SecurityConfig.kt
@@ -48,6 +48,7 @@ class SecurityConfig(
                         "/api/dev/**",
                     ).permitAll()
                 auth.requestMatchers(HttpMethod.GET, "/api/v1/characters").permitAll()
+                auth.requestMatchers(HttpMethod.GET, "/api/v1/party-invites/*").permitAll()
                 auth.requestMatchers(HttpMethod.GET, "/images/**").permitAll()
                 auth.anyRequest().authenticated()
             }.oauth2Login { oauth ->

--- a/src/main/kotlin/com/team2/server/auth/jwt/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/team2/server/auth/jwt/JwtAuthenticationFilter.kt
@@ -10,6 +10,7 @@ import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpHeaders
+import org.springframework.security.authentication.BadCredentialsException
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
@@ -21,6 +22,7 @@ private const val BEARER_PREFIX = "Bearer "
 class JwtAuthenticationFilter(
     private val jwtTokenProvider: JwtTokenProvider,
     private val userRepository: UserRepository,
+    private val jwtAuthenticationEntryPoint: JwtAuthenticationEntryPoint,
 ) : OncePerRequestFilter() {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -35,7 +37,10 @@ class JwtAuthenticationFilter(
             return
         }
 
-        authenticate(token, request)
+        if (!authenticate(token, request)) {
+            jwtAuthenticationEntryPoint.commence(request, response, BadCredentialsException("Invalid JWT"))
+            return
+        }
         filterChain.doFilter(request, response)
     }
 
@@ -47,18 +52,19 @@ class JwtAuthenticationFilter(
     private fun authenticate(
         token: String,
         request: HttpServletRequest,
-    ) {
+    ): Boolean {
         try {
             val claims = jwtTokenProvider.parse(token)
             val userId = claims.subject.toLong()
             val user = userRepository.findById(userId).orElse(null)
             if (user == null) {
                 request.setAttribute(AUTH_ERROR_REQUEST_ATTRIBUTE, ErrorCode.AUTH_USER_NOT_FOUND)
-                return
+                return false
             }
             val principal = UserPrincipal.from(user)
             SecurityContextHolder.getContext().authentication =
                 UsernamePasswordAuthenticationToken(principal, null, principal.authorities)
+            return true
         } catch (e: ExpiredJwtException) {
             log.debug("Expired JWT", e)
             request.setAttribute(AUTH_ERROR_REQUEST_ATTRIBUTE, ErrorCode.AUTH_EXPIRED_TOKEN)
@@ -69,5 +75,6 @@ class JwtAuthenticationFilter(
             log.debug("Malformed JWT", e)
             request.setAttribute(AUTH_ERROR_REQUEST_ATTRIBUTE, ErrorCode.AUTH_INVALID_TOKEN)
         }
+        return false
     }
 }

--- a/src/main/kotlin/com/team2/server/auth/jwt/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/team2/server/auth/jwt/JwtAuthenticationFilter.kt
@@ -53,18 +53,19 @@ class JwtAuthenticationFilter(
         token: String,
         request: HttpServletRequest,
     ): Boolean {
+        var authenticated = false
         try {
             val claims = jwtTokenProvider.parse(token)
             val userId = claims.subject.toLong()
             val user = userRepository.findById(userId).orElse(null)
             if (user == null) {
                 request.setAttribute(AUTH_ERROR_REQUEST_ATTRIBUTE, ErrorCode.AUTH_USER_NOT_FOUND)
-                return false
+            } else {
+                val principal = UserPrincipal.from(user)
+                SecurityContextHolder.getContext().authentication =
+                    UsernamePasswordAuthenticationToken(principal, null, principal.authorities)
+                authenticated = true
             }
-            val principal = UserPrincipal.from(user)
-            SecurityContextHolder.getContext().authentication =
-                UsernamePasswordAuthenticationToken(principal, null, principal.authorities)
-            return true
         } catch (e: ExpiredJwtException) {
             log.debug("Expired JWT", e)
             request.setAttribute(AUTH_ERROR_REQUEST_ATTRIBUTE, ErrorCode.AUTH_EXPIRED_TOKEN)
@@ -75,6 +76,6 @@ class JwtAuthenticationFilter(
             log.debug("Malformed JWT", e)
             request.setAttribute(AUTH_ERROR_REQUEST_ATTRIBUTE, ErrorCode.AUTH_INVALID_TOKEN)
         }
-        return false
+        return authenticated
     }
 }

--- a/src/main/kotlin/com/team2/server/party/controller/PartyInviteLookupApi.kt
+++ b/src/main/kotlin/com/team2/server/party/controller/PartyInviteLookupApi.kt
@@ -1,0 +1,61 @@
+package com.team2.server.party.controller
+
+import com.team2.server.auth.principal.UserPrincipal
+import com.team2.server.common.response.ApiResponse
+import com.team2.server.common.response.ErrorResponse
+import com.team2.server.common.swagger.InternalServerErrorResponse
+import com.team2.server.party.dto.PartyInviteLookupResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
+
+@Tag(name = "Party Invite", description = "파티 초대장 API")
+interface PartyInviteLookupApi {
+    @Operation(
+        summary = "초대장 조회",
+        description =
+            "공유 링크 진입 시 초대 토큰으로 파티 요약을 조회한다. " +
+                "조회 시 participant는 생성하지 않으며, 만료된 초대 토큰도 조회할 수 있다.",
+        security = [
+            SecurityRequirement(name = "Bearer Authentication"),
+            SecurityRequirement(name = ""),
+        ],
+    )
+    @SwaggerApiResponse(
+        responseCode = "200",
+        description = "초대장 조회 성공",
+    )
+    @SwaggerApiResponse(
+        responseCode = "404",
+        description = "존재하지 않는 초대 토큰",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = ErrorResponse::class),
+                examples = [
+                    ExampleObject(
+                        value = """
+                            {
+                              "status": 404,
+                              "error": {
+                                "code": "PARTY_NOT_FOUND",
+                                "message": "파티를 찾을 수 없습니다"
+                              }
+                            }
+                        """,
+                    ),
+                ],
+            ),
+        ],
+    )
+    @InternalServerErrorResponse
+    fun getPartyInvite(
+        @Parameter(hidden = true) principal: UserPrincipal?,
+        @Parameter(description = "초대 토큰", example = "exampletoken0000") inviteToken: String,
+    ): ApiResponse<PartyInviteLookupResponse>
+}

--- a/src/main/kotlin/com/team2/server/party/controller/PartyInviteLookupController.kt
+++ b/src/main/kotlin/com/team2/server/party/controller/PartyInviteLookupController.kt
@@ -1,0 +1,24 @@
+package com.team2.server.party.controller
+
+import com.team2.server.auth.principal.UserPrincipal
+import com.team2.server.common.response.ApiResponse
+import com.team2.server.party.dto.PartyInviteLookupResponse
+import com.team2.server.party.usecase.LookupPartyInviteUseCase
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/party-invites")
+class PartyInviteLookupController(
+    private val lookupPartyInviteUseCase: LookupPartyInviteUseCase,
+) : PartyInviteLookupApi {
+    @GetMapping("/{inviteToken}")
+    override fun getPartyInvite(
+        @AuthenticationPrincipal principal: UserPrincipal?,
+        @PathVariable inviteToken: String,
+    ): ApiResponse<PartyInviteLookupResponse> =
+        ApiResponse.success(lookupPartyInviteUseCase.lookup(inviteToken, principal?.userId))
+}

--- a/src/main/kotlin/com/team2/server/party/dto/PartyInviteLookupResponse.kt
+++ b/src/main/kotlin/com/team2/server/party/dto/PartyInviteLookupResponse.kt
@@ -1,0 +1,57 @@
+package com.team2.server.party.dto
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.team2.server.party.entity.PartyOption
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@JsonInclude(JsonInclude.Include.ALWAYS)
+@Schema(description = "초대장 조회 응답")
+data class PartyInviteLookupResponse(
+    @Schema(description = "파티 주인공 이름", example = "홍길동")
+    val celebrantNickname: String?,
+    @Schema(
+        description = "파티 옵션. REALTIME: 실시간 파티, PAPER_ONLY: 롤링페이퍼 전용 파티",
+        allowableValues = ["REALTIME", "PAPER_ONLY"],
+        example = "REALTIME",
+    )
+    val partyOption: PartyOption,
+    @Schema(description = "파티 자체 종료 여부", example = "false")
+    val partyEnded: Boolean,
+    @Schema(description = "현재 조회자의 롤링페이퍼 작성 여부", example = "false")
+    val rollingPaperWritten: Boolean,
+    @Schema(description = "파티 시작일", example = "2026-05-04")
+    val partyStartDate: LocalDate,
+    @Schema(description = "파티 종료일", example = "2026-05-11")
+    val partyEndDate: LocalDate,
+    @Schema(
+        description =
+            "실시간 파티 입장 상태. " +
+                "NOT_ENTERABLE: 입장 가능 시간 전, ENTERABLE: 입장 가능, ENDED: 실시간 진행 종료. " +
+                "PAPER_ONLY면 null",
+        allowableValues = ["NOT_ENTERABLE", "ENTERABLE", "ENDED"],
+        example = "ENTERABLE",
+    )
+    val realtimeStatus: RealtimeStatus?,
+    @Schema(description = "실시간 파티 시작 시각. PAPER_ONLY면 null", example = "2026-05-04T20:00:00")
+    val liveStartAt: LocalDateTime?,
+    @Schema(description = "실시간 파티 진행 시간. PAPER_ONLY면 null", example = "10")
+    val liveDurationMinutes: Long?,
+)
+
+@Schema(
+    description =
+        "초대장 조회 응답용 실시간 파티 입장 상태. " +
+            "NOT_ENTERABLE: 입장 가능 시간 전, ENTERABLE: 입장 가능, ENDED: 실시간 진행 종료",
+)
+enum class RealtimeStatus {
+    @Schema(description = "입장 가능 시간 전")
+    NOT_ENTERABLE,
+
+    @Schema(description = "입장 가능")
+    ENTERABLE,
+
+    @Schema(description = "실시간 진행 종료")
+    ENDED,
+}

--- a/src/main/kotlin/com/team2/server/party/dto/PartyInviteLookupResponse.kt
+++ b/src/main/kotlin/com/team2/server/party/dto/PartyInviteLookupResponse.kt
@@ -26,32 +26,20 @@ data class PartyInviteLookupResponse(
     @Schema(description = "파티 종료일", example = "2026-05-11")
     val partyEndDate: LocalDate,
     @Schema(
-        description =
-            "실시간 파티 입장 상태. " +
-                "NOT_ENTERABLE: 입장 가능 시간 전, ENTERABLE: 입장 가능, ENDED: 실시간 진행 종료. " +
-                "PAPER_ONLY면 null",
-        allowableValues = ["NOT_ENTERABLE", "ENTERABLE", "ENDED"],
-        example = "ENTERABLE",
+        description = "실시간 파티 일정 기준 시각. PAPER_ONLY면 null",
+        nullable = true,
     )
-    val realtimeStatus: RealtimeStatus?,
-    @Schema(description = "실시간 파티 시작 시각. PAPER_ONLY면 null", example = "2026-05-04T20:00:00")
-    val liveStartAt: LocalDateTime?,
-    @Schema(description = "실시간 파티 진행 시간. PAPER_ONLY면 null", example = "10")
-    val liveDurationMinutes: Long?,
+    val realtimeSchedule: RealtimeSchedule?,
 )
 
-@Schema(
-    description =
-        "초대장 조회 응답용 실시간 파티 입장 상태. " +
-            "NOT_ENTERABLE: 입장 가능 시간 전, ENTERABLE: 입장 가능, ENDED: 실시간 진행 종료",
+@Schema(description = "실시간 파티 일정 기준 시각")
+data class RealtimeSchedule(
+    @Schema(description = "실시간 파티 시작 시각", example = "2026-05-04T20:00:00")
+    val liveStartAt: LocalDateTime,
+    @Schema(description = "파티 입장 가능 시작 시각", example = "2026-05-04T19:55:00")
+    val enterableFrom: LocalDateTime,
+    @Schema(description = "실시간 파티 종료 시각", example = "2026-05-04T20:10:00")
+    val liveEndAt: LocalDateTime,
+    @Schema(description = "실시간 파티 진행 시간", example = "10")
+    val liveDurationMinutes: Long,
 )
-enum class RealtimeStatus {
-    @Schema(description = "입장 가능 시간 전")
-    NOT_ENTERABLE,
-
-    @Schema(description = "입장 가능")
-    ENTERABLE,
-
-    @Schema(description = "실시간 진행 종료")
-    ENDED,
-}

--- a/src/main/kotlin/com/team2/server/party/entity/PaperOnlyParty.kt
+++ b/src/main/kotlin/com/team2/server/party/entity/PaperOnlyParty.kt
@@ -15,16 +15,12 @@ class PaperOnlyParty(
 ) : Party(ownerId, name, celebrantNickname, startedAt, purpose, PartyOption.PAPER_ONLY) {
     fun status(now: LocalDateTime = LocalDateTime.now()): PaperOnlyPartyStatus {
         val openTime = startedAt
-        val closeTime = createdAt.plusDays(CLOSED_AFTER_DAYS)
+        val closeTime = createdAt.plusDays(Party.ENDED_AFTER_DAYS)
         return when {
             now >= closeTime -> PaperOnlyPartyStatus.CLOSED
             now >= openTime -> PaperOnlyPartyStatus.OPEN
             else -> PaperOnlyPartyStatus.READY
         }
-    }
-
-    companion object {
-        const val CLOSED_AFTER_DAYS: Long = 7
     }
 }
 

--- a/src/main/kotlin/com/team2/server/party/entity/Party.kt
+++ b/src/main/kotlin/com/team2/server/party/entity/Party.kt
@@ -28,7 +28,11 @@ abstract class Party(
     @Enumerated(EnumType.STRING)
     @Column(name = "party_option", nullable = false)
     val partyOption: PartyOption,
-) : BaseEntity()
+) : BaseEntity() {
+    companion object {
+        const val ENDED_AFTER_DAYS: Long = 7
+    }
+}
 
 enum class PartyOption {
     REALTIME,

--- a/src/main/kotlin/com/team2/server/party/entity/RealtimeParty.kt
+++ b/src/main/kotlin/com/team2/server/party/entity/RealtimeParty.kt
@@ -16,7 +16,7 @@ class RealtimeParty(
     fun status(now: LocalDateTime = LocalDateTime.now()): RealtimePartyStatus {
         val liveStart = startedAt
         val liveEnd = liveStart.plusMinutes(LIVE_DURATION_MINUTES)
-        val endedTime = createdAt.plusDays(ENDED_AFTER_DAYS)
+        val endedTime = createdAt.plusDays(Party.ENDED_AFTER_DAYS)
         return when {
             now >= endedTime -> RealtimePartyStatus.ROLLING_PAPER_CLOSED
             now >= liveEnd -> RealtimePartyStatus.LIVE_CLOSED
@@ -27,7 +27,7 @@ class RealtimeParty(
 
     companion object {
         const val LIVE_DURATION_MINUTES: Long = 10
-        const val ENDED_AFTER_DAYS: Long = 7
+        const val ENTERABLE_BEFORE_MINUTES: Long = 5
     }
 }
 

--- a/src/main/kotlin/com/team2/server/party/repository/ParticipantRepository.kt
+++ b/src/main/kotlin/com/team2/server/party/repository/ParticipantRepository.kt
@@ -20,4 +20,9 @@ interface ParticipantRepository : JpaRepository<Participant, Long> {
         partyId: Long,
         userId: Long,
     ): Boolean
+
+    fun findByPartyIdAndUserId(
+        partyId: Long,
+        userId: Long,
+    ): Participant?
 }

--- a/src/main/kotlin/com/team2/server/party/usecase/LookupPartyInviteUseCase.kt
+++ b/src/main/kotlin/com/team2/server/party/usecase/LookupPartyInviteUseCase.kt
@@ -3,7 +3,7 @@ package com.team2.server.party.usecase
 import com.team2.server.common.exception.BusinessException
 import com.team2.server.common.exception.ErrorCode
 import com.team2.server.party.dto.PartyInviteLookupResponse
-import com.team2.server.party.dto.RealtimeStatus
+import com.team2.server.party.dto.RealtimeSchedule
 import com.team2.server.party.entity.Party
 import com.team2.server.party.entity.PartyOption
 import com.team2.server.party.entity.RealtimeParty
@@ -38,9 +38,7 @@ class LookupPartyInviteUseCase(
             rollingPaperWritten = hasWrittenPaper(party, userId),
             partyStartDate = party.createdAt.toLocalDate(),
             partyEndDate = partyEndAt.toLocalDate(),
-            realtimeStatus = if (isRealtime) calculateRealtimeStatus(party, now) else null,
-            liveStartAt = if (isRealtime) party.startedAt else null,
-            liveDurationMinutes = if (isRealtime) RealtimeParty.LIVE_DURATION_MINUTES else null,
+            realtimeSchedule = if (isRealtime) createRealtimeSchedule(party) else null,
         )
     }
 
@@ -54,17 +52,11 @@ class LookupPartyInviteUseCase(
         return participantRepository.findByPartyIdAndUserId(party.id, userId)?.hasWrittenPaper ?: false
     }
 
-    private fun calculateRealtimeStatus(
-        party: Party,
-        now: LocalDateTime,
-    ): RealtimeStatus {
-        val enterableAt = party.startedAt.minusMinutes(RealtimeParty.ENTERABLE_BEFORE_MINUTES)
-        val liveEndAt = party.startedAt.plusMinutes(RealtimeParty.LIVE_DURATION_MINUTES)
-
-        return when {
-            now < enterableAt -> RealtimeStatus.NOT_ENTERABLE
-            now < liveEndAt -> RealtimeStatus.ENTERABLE
-            else -> RealtimeStatus.ENDED
-        }
-    }
+    private fun createRealtimeSchedule(party: Party): RealtimeSchedule =
+        RealtimeSchedule(
+            liveStartAt = party.startedAt,
+            enterableFrom = party.startedAt.minusMinutes(RealtimeParty.ENTERABLE_BEFORE_MINUTES),
+            liveEndAt = party.startedAt.plusMinutes(RealtimeParty.LIVE_DURATION_MINUTES),
+            liveDurationMinutes = RealtimeParty.LIVE_DURATION_MINUTES,
+        )
 }

--- a/src/main/kotlin/com/team2/server/party/usecase/LookupPartyInviteUseCase.kt
+++ b/src/main/kotlin/com/team2/server/party/usecase/LookupPartyInviteUseCase.kt
@@ -28,7 +28,7 @@ class LookupPartyInviteUseCase(
                 ?: throw BusinessException(ErrorCode.PARTY_NOT_FOUND)
 
         val now = LocalDateTime.now()
-        val partyEndAt = party.createdAt.plusDays(PARTY_DURATION_DAYS)
+        val partyEndAt = party.createdAt.plusDays(Party.ENDED_AFTER_DAYS)
         val isRealtime = party.partyOption == PartyOption.REALTIME
 
         return PartyInviteLookupResponse(
@@ -58,7 +58,7 @@ class LookupPartyInviteUseCase(
         party: Party,
         now: LocalDateTime,
     ): RealtimeStatus {
-        val enterableAt = party.startedAt.minusMinutes(ENTERABLE_BEFORE_MINUTES)
+        val enterableAt = party.startedAt.minusMinutes(RealtimeParty.ENTERABLE_BEFORE_MINUTES)
         val liveEndAt = party.startedAt.plusMinutes(RealtimeParty.LIVE_DURATION_MINUTES)
 
         return when {
@@ -66,10 +66,5 @@ class LookupPartyInviteUseCase(
             now < liveEndAt -> RealtimeStatus.ENTERABLE
             else -> RealtimeStatus.ENDED
         }
-    }
-
-    private companion object {
-        const val PARTY_DURATION_DAYS = 7L
-        const val ENTERABLE_BEFORE_MINUTES = 5L
     }
 }

--- a/src/main/kotlin/com/team2/server/party/usecase/LookupPartyInviteUseCase.kt
+++ b/src/main/kotlin/com/team2/server/party/usecase/LookupPartyInviteUseCase.kt
@@ -1,0 +1,75 @@
+package com.team2.server.party.usecase
+
+import com.team2.server.common.exception.BusinessException
+import com.team2.server.common.exception.ErrorCode
+import com.team2.server.party.dto.PartyInviteLookupResponse
+import com.team2.server.party.dto.RealtimeStatus
+import com.team2.server.party.entity.Party
+import com.team2.server.party.entity.PartyOption
+import com.team2.server.party.entity.RealtimeParty
+import com.team2.server.party.repository.ParticipantRepository
+import com.team2.server.party.repository.PartyInviteRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service
+class LookupPartyInviteUseCase(
+    private val partyInviteRepository: PartyInviteRepository,
+    private val participantRepository: ParticipantRepository,
+) {
+    @Transactional(readOnly = true)
+    fun lookup(
+        inviteToken: String,
+        userId: Long?,
+    ): PartyInviteLookupResponse {
+        val party =
+            partyInviteRepository.findByToken(inviteToken)?.party
+                ?: throw BusinessException(ErrorCode.PARTY_NOT_FOUND)
+
+        val now = LocalDateTime.now()
+        val partyEndAt = party.createdAt.plusDays(PARTY_DURATION_DAYS)
+        val isRealtime = party.partyOption == PartyOption.REALTIME
+
+        return PartyInviteLookupResponse(
+            celebrantNickname = party.celebrantNickname,
+            partyOption = party.partyOption,
+            partyEnded = !now.isBefore(partyEndAt),
+            rollingPaperWritten = hasWrittenPaper(party, userId),
+            partyStartDate = party.createdAt.toLocalDate(),
+            partyEndDate = partyEndAt.toLocalDate(),
+            realtimeStatus = if (isRealtime) calculateRealtimeStatus(party, now) else null,
+            liveStartAt = if (isRealtime) party.startedAt else null,
+            liveDurationMinutes = if (isRealtime) RealtimeParty.LIVE_DURATION_MINUTES else null,
+        )
+    }
+
+    private fun hasWrittenPaper(
+        party: Party,
+        userId: Long?,
+    ): Boolean {
+        if (userId == null) {
+            return false
+        }
+        return participantRepository.findByPartyIdAndUserId(party.id, userId)?.hasWrittenPaper ?: false
+    }
+
+    private fun calculateRealtimeStatus(
+        party: Party,
+        now: LocalDateTime,
+    ): RealtimeStatus {
+        val enterableAt = party.startedAt.minusMinutes(ENTERABLE_BEFORE_MINUTES)
+        val liveEndAt = party.startedAt.plusMinutes(RealtimeParty.LIVE_DURATION_MINUTES)
+
+        return when {
+            now < enterableAt -> RealtimeStatus.NOT_ENTERABLE
+            now < liveEndAt -> RealtimeStatus.ENTERABLE
+            else -> RealtimeStatus.ENDED
+        }
+    }
+
+    private companion object {
+        const val PARTY_DURATION_DAYS = 7L
+        const val ENTERABLE_BEFORE_MINUTES = 5L
+    }
+}

--- a/src/test/kotlin/com/team2/server/auth/jwt/JwtAuthenticationFilterTest.kt
+++ b/src/test/kotlin/com/team2/server/auth/jwt/JwtAuthenticationFilterTest.kt
@@ -51,6 +51,7 @@ class JwtAuthenticationFilterTest {
         JwtAuthenticationFilter(
             tokenProvider,
             repo,
+            mock(),
         )
 
     @AfterEach
@@ -76,7 +77,7 @@ class JwtAuthenticationFilterTest {
     }
 
     @Test
-    fun `만료 토큰은 인증 없이 체인 통과 + 요청 속성에 EXPIRED 코드`() {
+    fun `만료 토큰은 인증 없이 entry point 호출 + 요청 속성에 EXPIRED 코드`() {
         val user = userWithId(1L)
         val expiredProvider = JwtTokenProvider(JwtProperties(secret = secret, expirationHours = 0))
         val repo = mock<UserRepository>()
@@ -86,16 +87,18 @@ class JwtAuthenticationFilterTest {
         val req = MockHttpServletRequest().apply { addHeader("Authorization", "Bearer $expired") }
         val res = MockHttpServletResponse()
         val chain = mock<FilterChain>()
+        val entryPoint = mock<JwtAuthenticationEntryPoint>()
 
-        newFilter(repo).doFilter(req, res, chain)
+        JwtAuthenticationFilter(expiredProvider, repo, entryPoint).doFilter(req, res, chain)
 
         assertNull(SecurityContextHolder.getContext().authentication)
         assertEquals(ErrorCode.AUTH_EXPIRED_TOKEN, req.getAttribute(AUTH_ERROR_REQUEST_ATTRIBUTE))
-        verify(chain).doFilter(any<HttpServletRequest>(), any<HttpServletResponse>())
+        verify(chain, never()).doFilter(any<HttpServletRequest>(), any<HttpServletResponse>())
+        verify(entryPoint).commence(any(), any(), any())
     }
 
     @Test
-    fun `잘못된 시그니처는 인증 없이 체인 통과 + INVALID_TOKEN 속성`() {
+    fun `잘못된 시그니처는 인증 없이 entry point 호출 + INVALID_TOKEN 속성`() {
         val other =
             JwtTokenProvider(
                 JwtProperties(
@@ -109,16 +112,18 @@ class JwtAuthenticationFilterTest {
         val req = MockHttpServletRequest().apply { addHeader("Authorization", "Bearer $token") }
         val res = MockHttpServletResponse()
         val chain = mock<FilterChain>()
+        val entryPoint = mock<JwtAuthenticationEntryPoint>()
 
-        newFilter(repo).doFilter(req, res, chain)
+        JwtAuthenticationFilter(tokenProvider, repo, entryPoint).doFilter(req, res, chain)
 
         assertNull(SecurityContextHolder.getContext().authentication)
         assertEquals(ErrorCode.AUTH_INVALID_TOKEN, req.getAttribute(AUTH_ERROR_REQUEST_ATTRIBUTE))
-        verify(chain).doFilter(any<HttpServletRequest>(), any<HttpServletResponse>())
+        verify(chain, never()).doFilter(any<HttpServletRequest>(), any<HttpServletResponse>())
+        verify(entryPoint).commence(any(), any(), any())
     }
 
     @Test
-    fun `userId DB 미존재면 인증 없이 체인 통과 + USER_NOT_FOUND 속성`() {
+    fun `userId DB 미존재면 인증 없이 entry point 호출 + USER_NOT_FOUND 속성`() {
         val token = tokenProvider.issue(userWithId(99L))
         val repo = mock<UserRepository>()
         whenever(repo.findById(99L)).thenReturn(Optional.empty())
@@ -126,12 +131,14 @@ class JwtAuthenticationFilterTest {
         val req = MockHttpServletRequest().apply { addHeader("Authorization", "Bearer $token") }
         val res = MockHttpServletResponse()
         val chain = mock<FilterChain>()
+        val entryPoint = mock<JwtAuthenticationEntryPoint>()
 
-        newFilter(repo).doFilter(req, res, chain)
+        JwtAuthenticationFilter(tokenProvider, repo, entryPoint).doFilter(req, res, chain)
 
         assertNull(SecurityContextHolder.getContext().authentication)
         assertEquals(ErrorCode.AUTH_USER_NOT_FOUND, req.getAttribute(AUTH_ERROR_REQUEST_ATTRIBUTE))
-        verify(chain).doFilter(any<HttpServletRequest>(), any<HttpServletResponse>())
+        verify(chain, never()).doFilter(any<HttpServletRequest>(), any<HttpServletResponse>())
+        verify(entryPoint).commence(any(), any(), any())
     }
 
     @Test

--- a/src/test/kotlin/com/team2/server/auth/jwt/JwtAuthenticationFilterTest.kt
+++ b/src/test/kotlin/com/team2/server/auth/jwt/JwtAuthenticationFilterTest.kt
@@ -79,10 +79,9 @@ class JwtAuthenticationFilterTest {
     @Test
     fun `만료 토큰은 인증 없이 entry point 호출 + 요청 속성에 EXPIRED 코드`() {
         val user = userWithId(1L)
-        val expiredProvider = JwtTokenProvider(JwtProperties(secret = secret, expirationHours = 0))
+        val expiredProvider = JwtTokenProvider(JwtProperties(secret = secret, expirationHours = -1))
         val repo = mock<UserRepository>()
         val expired = expiredProvider.issue(user)
-        Thread.sleep(50)
 
         val req = MockHttpServletRequest().apply { addHeader("Authorization", "Bearer $expired") }
         val res = MockHttpServletResponse()

--- a/src/test/kotlin/com/team2/server/party/controller/PartyInviteLookupControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/party/controller/PartyInviteLookupControllerTest.kt
@@ -1,0 +1,281 @@
+package com.team2.server.party.controller
+
+import com.team2.server.auth.config.JwtProperties
+import com.team2.server.auth.jwt.JwtTokenProvider
+import com.team2.server.party.entity.PaperOnlyParty
+import com.team2.server.party.entity.Participant
+import com.team2.server.party.entity.Party
+import com.team2.server.party.entity.PartyInvite
+import com.team2.server.party.entity.RealtimeParty
+import com.team2.server.party.repository.ParticipantRepository
+import com.team2.server.party.repository.PartyInviteRepository
+import com.team2.server.party.repository.PartyRepository
+import com.team2.server.user.entity.AuthProvider
+import com.team2.server.user.entity.User
+import com.team2.server.user.repository.UserRepository
+import org.hamcrest.Matchers.nullValue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import java.time.LocalDateTime
+import kotlin.test.assertEquals
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class PartyInviteLookupControllerTest
+    @Autowired
+    constructor(
+        private val mockMvc: MockMvc,
+        private val partyRepository: PartyRepository,
+        private val partyInviteRepository: PartyInviteRepository,
+        private val participantRepository: ParticipantRepository,
+        private val userRepository: UserRepository,
+        private val jwtProperties: JwtProperties,
+    ) {
+        private val tokenProvider = JwtTokenProvider(jwtProperties)
+
+        @BeforeEach
+        fun setUp() {
+            partyInviteRepository.deleteAll()
+            participantRepository.deleteAll()
+            partyRepository.deleteAll()
+            userRepository.deleteAll()
+        }
+
+        @Test
+        fun `인증 없이 PAPER_ONLY 초대장 조회 성공 및 participant 미생성`() {
+            val createdAt = LocalDateTime.of(2026, 5, 4, 10, 0)
+            val party =
+                saveParty(
+                    PaperOnlyParty(
+                        ownerId = 1L,
+                        celebrantNickname = "홍길동",
+                        startedAt = createdAt.toLocalDate().atStartOfDay(),
+                    ),
+                    createdAt,
+                )
+            saveInvite(party, "paperlookup0001")
+
+            mockMvc.get("/api/v1/party-invites/paperlookup0001").andExpect {
+                status { isOk() }
+                jsonPath("$.status") { value(200) }
+                jsonPath("$.data.partyId") { doesNotExist() }
+                jsonPath("$.data.celebrantNickname") { value("홍길동") }
+                jsonPath("$.data.partyOption") { value("PAPER_ONLY") }
+                jsonPath("$.data.partyEnded") { value(false) }
+                jsonPath("$.data.rollingPaperWritten") { value(false) }
+                jsonPath("$.data.partyStartDate") { value("2026-05-04") }
+                jsonPath("$.data.partyEndDate") { value("2026-05-11") }
+                jsonPath("$.data.realtimeStatus") { value(nullValue()) }
+                jsonPath("$.data.liveStartAt") { value(nullValue()) }
+                jsonPath("$.data.liveDurationMinutes") { value(nullValue()) }
+            }
+
+            assertEquals(0, participantRepository.count())
+        }
+
+        @Test
+        fun `생성 후 7일이 지난 파티는 partyEnded true`() {
+            val party =
+                saveParty(
+                    PaperOnlyParty(
+                        ownerId = 1L,
+                        celebrantNickname = "홍길동",
+                        startedAt =
+                            LocalDateTime
+                                .now()
+                                .minusDays(8)
+                                .toLocalDate()
+                                .atStartOfDay(),
+                    ),
+                    LocalDateTime.now().minusDays(8),
+                )
+            saveInvite(party, "endedparty00001")
+
+            mockMvc.get("/api/v1/party-invites/endedparty00001").andExpect {
+                status { isOk() }
+                jsonPath("$.data.partyEnded") { value(true) }
+            }
+        }
+
+        @Test
+        fun `만료된 초대 토큰도 초대장 조회 가능`() {
+            val party =
+                saveParty(
+                    PaperOnlyParty(
+                        ownerId = 1L,
+                        celebrantNickname = "홍길동",
+                        startedAt = LocalDateTime.now().toLocalDate().atStartOfDay(),
+                    ),
+                    LocalDateTime.now().minusDays(1),
+                )
+            saveInvite(party, "expiredlookup1", LocalDateTime.now().minusHours(1))
+
+            mockMvc.get("/api/v1/party-invites/expiredlookup1").andExpect {
+                status { isOk() }
+                jsonPath("$.data.partyId") { doesNotExist() }
+            }
+        }
+
+        @Test
+        fun `인증 회원이 이미 롤페를 작성했으면 rollingPaperWritten true`() {
+            val user = saveUser("kakao-lookup-written", "lookup-written@kakao.local")
+            val party =
+                saveParty(
+                    PaperOnlyParty(
+                        ownerId = user.id,
+                        celebrantNickname = "홍길동",
+                        startedAt = LocalDateTime.now().toLocalDate().atStartOfDay(),
+                    ),
+                    LocalDateTime.now().minusDays(1),
+                )
+            participantRepository.save(
+                Participant(
+                    party = party,
+                    user = user,
+                    hasWrittenPaper = true,
+                ),
+            )
+            saveInvite(party, "writtenlookup01")
+            val accessToken = tokenProvider.issue(user)
+
+            mockMvc
+                .get("/api/v1/party-invites/writtenlookup01") {
+                    header("Authorization", "Bearer $accessToken")
+                }.andExpect {
+                    status { isOk() }
+                    jsonPath("$.data.rollingPaperWritten") { value(true) }
+                }
+        }
+
+        @Test
+        fun `REALTIME 초대장 조회는 5분 전부터 ENTERABLE`() {
+            val liveStartAt = LocalDateTime.now().plusMinutes(4)
+            val party =
+                saveParty(
+                    RealtimeParty(
+                        ownerId = 1L,
+                        celebrantNickname = "홍길동",
+                        startedAt = liveStartAt,
+                    ),
+                    LocalDateTime.now().minusDays(1),
+                )
+            saveInvite(party, "enterable000001")
+
+            mockMvc.get("/api/v1/party-invites/enterable000001").andExpect {
+                status { isOk() }
+                jsonPath("$.data.partyOption") { value("REALTIME") }
+                jsonPath("$.data.realtimeStatus") { value("ENTERABLE") }
+                jsonPath("$.data.liveStartAt") { value(liveStartAt.toString()) }
+                jsonPath("$.data.liveDurationMinutes") { value(10) }
+            }
+        }
+
+        @Test
+        fun `REALTIME 초대장 조회는 입장 가능 전이면 NOT_ENTERABLE`() {
+            val party =
+                saveParty(
+                    RealtimeParty(
+                        ownerId = 1L,
+                        celebrantNickname = "홍길동",
+                        startedAt = LocalDateTime.now().plusMinutes(6),
+                    ),
+                    LocalDateTime.now().minusDays(1),
+                )
+            saveInvite(party, "notenterable001")
+
+            mockMvc.get("/api/v1/party-invites/notenterable001").andExpect {
+                status { isOk() }
+                jsonPath("$.data.realtimeStatus") { value("NOT_ENTERABLE") }
+            }
+        }
+
+        @Test
+        fun `REALTIME 초대장 조회는 라이브 종료 이후 ENDED`() {
+            val party =
+                saveParty(
+                    RealtimeParty(
+                        ownerId = 1L,
+                        celebrantNickname = "홍길동",
+                        startedAt = LocalDateTime.now().minusMinutes(11),
+                    ),
+                    LocalDateTime.now().minusDays(1),
+                )
+            saveInvite(party, "realtimeended01")
+
+            mockMvc.get("/api/v1/party-invites/realtimeended01").andExpect {
+                status { isOk() }
+                jsonPath("$.data.realtimeStatus") { value("ENDED") }
+            }
+        }
+
+        @Test
+        fun `없는 초대 토큰이면 404`() {
+            mockMvc.get("/api/v1/party-invites/missingtoken000").andExpect {
+                status { isNotFound() }
+                jsonPath("$.error.code") { value("PARTY_NOT_FOUND") }
+            }
+        }
+
+        @Test
+        fun `잘못된 Bearer 토큰이면 공개 조회 API도 401`() {
+            val party =
+                saveParty(
+                    PaperOnlyParty(
+                        ownerId = 1L,
+                        celebrantNickname = "홍길동",
+                        startedAt = LocalDateTime.now().toLocalDate().atStartOfDay(),
+                    ),
+                    LocalDateTime.now().minusDays(1),
+                )
+            saveInvite(party, "invalidbearer01")
+
+            mockMvc
+                .get("/api/v1/party-invites/invalidbearer01") {
+                    header("Authorization", "Bearer not-a-jwt")
+                }.andExpect {
+                    status { isUnauthorized() }
+                    jsonPath("$.error.code") { value("AUTH_INVALID_TOKEN") }
+                }
+        }
+
+        private fun saveParty(
+            party: Party,
+            createdAt: LocalDateTime,
+        ): Party {
+            val saved = partyRepository.saveAndFlush(party)
+            saved.createdAt = createdAt
+            return partyRepository.saveAndFlush(saved)
+        }
+
+        private fun saveInvite(
+            party: Party,
+            token: String,
+            expiresAt: LocalDateTime = LocalDateTime.now().plusDays(1),
+        ): PartyInvite =
+            partyInviteRepository.save(
+                PartyInvite(
+                    party = party,
+                    token = token,
+                    expiresAt = expiresAt,
+                ),
+            )
+
+        private fun saveUser(
+            providerId: String,
+            email: String,
+        ): User =
+            userRepository.save(
+                User(
+                    name = "조회자",
+                    birthDay = "01-01",
+                    provider = AuthProvider.KAKAO,
+                    providerId = providerId,
+                    email = email,
+                ),
+            )
+    }

--- a/src/test/kotlin/com/team2/server/party/controller/PartyInviteLookupControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/party/controller/PartyInviteLookupControllerTest.kt
@@ -22,6 +22,8 @@ import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 import kotlin.test.assertEquals
 
 @SpringBootTest
@@ -48,7 +50,7 @@ class PartyInviteLookupControllerTest
 
         @Test
         fun `인증 없이 PAPER_ONLY 초대장 조회 성공 및 participant 미생성`() {
-            val createdAt = LocalDateTime.of(2026, 5, 4, 10, 0)
+            val createdAt = LocalDateTime.now().minusDays(1).truncatedTo(ChronoUnit.SECONDS)
             val party =
                 saveParty(
                     PaperOnlyParty(
@@ -68,8 +70,15 @@ class PartyInviteLookupControllerTest
                 jsonPath("$.data.partyOption") { value("PAPER_ONLY") }
                 jsonPath("$.data.partyEnded") { value(false) }
                 jsonPath("$.data.rollingPaperWritten") { value(false) }
-                jsonPath("$.data.partyStartDate") { value("2026-05-04") }
-                jsonPath("$.data.partyEndDate") { value("2026-05-11") }
+                jsonPath("$.data.partyStartDate") { value(createdAt.toLocalDate().toString()) }
+                jsonPath("$.data.partyEndDate") {
+                    value(
+                        createdAt
+                            .plusDays(Party.ENDED_AFTER_DAYS)
+                            .toLocalDate()
+                            .toString(),
+                    )
+                }
                 jsonPath("$.data.realtimeStatus") { value(nullValue()) }
                 jsonPath("$.data.liveStartAt") { value(nullValue()) }
                 jsonPath("$.data.liveDurationMinutes") { value(nullValue()) }
@@ -80,19 +89,15 @@ class PartyInviteLookupControllerTest
 
         @Test
         fun `생성 후 7일이 지난 파티는 partyEnded true`() {
+            val createdAt = LocalDateTime.now().minusDays(8).truncatedTo(ChronoUnit.SECONDS)
             val party =
                 saveParty(
                     PaperOnlyParty(
                         ownerId = 1L,
                         celebrantNickname = "홍길동",
-                        startedAt =
-                            LocalDateTime
-                                .now()
-                                .minusDays(8)
-                                .toLocalDate()
-                                .atStartOfDay(),
+                        startedAt = createdAt.toLocalDate().atStartOfDay(),
                     ),
-                    LocalDateTime.now().minusDays(8),
+                    createdAt,
                 )
             saveInvite(party, "endedparty00001")
 
@@ -154,7 +159,7 @@ class PartyInviteLookupControllerTest
 
         @Test
         fun `REALTIME 초대장 조회는 5분 전부터 ENTERABLE`() {
-            val liveStartAt = LocalDateTime.now().plusMinutes(4)
+            val liveStartAt = LocalDateTime.now().plusMinutes(4).truncatedTo(ChronoUnit.SECONDS)
             val party =
                 saveParty(
                     RealtimeParty(
@@ -170,8 +175,8 @@ class PartyInviteLookupControllerTest
                 status { isOk() }
                 jsonPath("$.data.partyOption") { value("REALTIME") }
                 jsonPath("$.data.realtimeStatus") { value("ENTERABLE") }
-                jsonPath("$.data.liveStartAt") { value(liveStartAt.toString()) }
-                jsonPath("$.data.liveDurationMinutes") { value(10) }
+                jsonPath("$.data.liveStartAt") { value(liveStartAt.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)) }
+                jsonPath("$.data.liveDurationMinutes") { value(RealtimeParty.LIVE_DURATION_MINUTES) }
             }
         }
 

--- a/src/test/kotlin/com/team2/server/party/controller/PartyInviteLookupControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/party/controller/PartyInviteLookupControllerTest.kt
@@ -79,9 +79,7 @@ class PartyInviteLookupControllerTest
                             .toString(),
                     )
                 }
-                jsonPath("$.data.realtimeStatus") { value(nullValue()) }
-                jsonPath("$.data.liveStartAt") { value(nullValue()) }
-                jsonPath("$.data.liveDurationMinutes") { value(nullValue()) }
+                jsonPath("$.data.realtimeSchedule") { value(nullValue()) }
             }
 
             assertEquals(0, participantRepository.count())
@@ -158,7 +156,7 @@ class PartyInviteLookupControllerTest
         }
 
         @Test
-        fun `REALTIME 초대장 조회는 5분 전부터 ENTERABLE`() {
+        fun `REALTIME 초대장 조회는 실시간 일정 기준 시각을 내려준다`() {
             val liveStartAt = LocalDateTime.now().plusMinutes(4).truncatedTo(ChronoUnit.SECONDS)
             val party =
                 saveParty(
@@ -174,47 +172,26 @@ class PartyInviteLookupControllerTest
             mockMvc.get("/api/v1/party-invites/enterable000001").andExpect {
                 status { isOk() }
                 jsonPath("$.data.partyOption") { value("REALTIME") }
-                jsonPath("$.data.realtimeStatus") { value("ENTERABLE") }
-                jsonPath("$.data.liveStartAt") { value(liveStartAt.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)) }
-                jsonPath("$.data.liveDurationMinutes") { value(RealtimeParty.LIVE_DURATION_MINUTES) }
-            }
-        }
-
-        @Test
-        fun `REALTIME 초대장 조회는 입장 가능 전이면 NOT_ENTERABLE`() {
-            val party =
-                saveParty(
-                    RealtimeParty(
-                        ownerId = 1L,
-                        celebrantNickname = "홍길동",
-                        startedAt = LocalDateTime.now().plusMinutes(6),
-                    ),
-                    LocalDateTime.now().minusDays(1),
-                )
-            saveInvite(party, "notenterable001")
-
-            mockMvc.get("/api/v1/party-invites/notenterable001").andExpect {
-                status { isOk() }
-                jsonPath("$.data.realtimeStatus") { value("NOT_ENTERABLE") }
-            }
-        }
-
-        @Test
-        fun `REALTIME 초대장 조회는 라이브 종료 이후 ENDED`() {
-            val party =
-                saveParty(
-                    RealtimeParty(
-                        ownerId = 1L,
-                        celebrantNickname = "홍길동",
-                        startedAt = LocalDateTime.now().minusMinutes(11),
-                    ),
-                    LocalDateTime.now().minusDays(1),
-                )
-            saveInvite(party, "realtimeended01")
-
-            mockMvc.get("/api/v1/party-invites/realtimeended01").andExpect {
-                status { isOk() }
-                jsonPath("$.data.realtimeStatus") { value("ENDED") }
+                jsonPath("$.data.realtimeSchedule.liveStartAt") {
+                    value(liveStartAt.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+                }
+                jsonPath("$.data.realtimeSchedule.enterableFrom") {
+                    value(
+                        liveStartAt
+                            .minusMinutes(RealtimeParty.ENTERABLE_BEFORE_MINUTES)
+                            .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
+                    )
+                }
+                jsonPath("$.data.realtimeSchedule.liveEndAt") {
+                    value(
+                        liveStartAt
+                            .plusMinutes(RealtimeParty.LIVE_DURATION_MINUTES)
+                            .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
+                    )
+                }
+                jsonPath("$.data.realtimeSchedule.liveDurationMinutes") {
+                    value(RealtimeParty.LIVE_DURATION_MINUTES)
+                }
             }
         }
 


### PR DESCRIPTION
## 🔗 Issue
- closes #90

## 💬 Context
공유 링크 진입 시 inviteToken으로 초대장/파티 요약을 먼저 조회하고, 이 단계에서는 participant를 생성하지 않도록 조회 계약을 분리합니다. 롤링페이퍼 작성/파티 입장 같은 후속 액션은 inviteToken을 기준으로 participant 생성/복원을 진행할 수 있도록 초대장 조회 응답에서는 partyId를 노출하지 않습니다.

## 🛠 Changes
- `GET /api/v1/party-invites/{inviteToken}` 공개 조회 API 추가
- 초대장 조회 전용 `LookupPartyInviteUseCase`, 응답 DTO, Swagger 문서 추가
- 조회 시 participant 생성 없이 `rollingPaperWritten`만 기존 participant 기준으로 계산
- REALTIME 파티의 조회 응답용 `realtimeStatus` 계산 추가
- invalid Bearer token이 permitAll API에서도 401로 끝나도록 JWT 필터 보정
- 설계 문서와 통합/JWT 필터 테스트 추가

## 👀 Review Focus
- 초대장 조회 API에서 partyId를 노출하지 않고 inviteToken 흐름으로 유지하는 계약이 적절한지
- 만료된 초대 토큰도 초대장 조회는 허용하고, 발급/재사용 정책과 분리한 방향이 맞는지
- permitAll 경로에서도 invalid Bearer token을 401로 처리하도록 JWT 필터를 보정한 영향 범위

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

## Verification
- `./gradlew test --tests com.team2.server.party.controller.PartyInviteLookupControllerTest`
- `./gradlew test --tests com.team2.server.auth.jwt.JwtAuthenticationFilterTest`
- `./gradlew test`
- `./gradlew ktlintCheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 공개 파티 초대 조회 엔드포인트(GET /api/v1/party-invites/{token}) 추가 — 인증 없이 초대/파티 요약 조회 가능
  * 실시간 파티의 일정 정보(liveStartAt, enterableFrom, liveEndAt, liveDurationMinutes) 조건부 제공
  * 인증 없을 땐 롤링페이퍼 작성 여부를 false로 처리; 잘못된 토큰은 401 응답 유지

* **문서**
  * 파티 초대 조회 공개 API 설계 문서 추가

* **테스트**
  * 통합 및 보안 테스트(조회 시나리오, 만료/존재하지 않는 토큰 등) 추가/업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->