### PR TITLE
[Feat] 롤링페이퍼 작성 API 추가

### DIFF
--- a/docs/superpowers/plans/2026-05-04-rolling-paper-write.md
+++ b/docs/superpowers/plans/2026-05-04-rolling-paper-write.md
@@ -19,7 +19,7 @@
 - `RollingPaper.theme` / `theme_id`는 `wrapper` / `wrapper_id`로 변경한다.
 - 주최자/주인공 participant도 롤링페이퍼를 작성할 수 있다.
 - 요청 DTO는 `@NotBlank`, `@Size` 기준으로 검증하고, 저장 전 `writerNickname`, `content`를 trim한다.
-- 닉네임 대소문자는 서로 다른 값으로 취급한다.
+- 닉네임 대소문자는 같은 값으로 취급한다.
 
 ---
 
@@ -80,9 +80,10 @@
 
 - [ ] `RollingPaper.theme`을 `wrapper`로, `theme_id`를 `wrapper_id`로 변경한다.
 - [ ] `writerNickname`을 nullable false, length 10으로 변경한다.
+- [ ] 대소문자 무시 중복 제약용 `writerNicknameKey`를 추가한다.
 - [ ] `content` length를 100으로 변경한다.
-- [ ] `rolling_paper`에 `uk_rolling_paper_party_writer_nickname`, `uk_rolling_paper_writer_participant` unique constraint를 추가한다.
-- [ ] `RollingPaperRepository`에 `existsByPartyAndWriterNickname(...)`와 `saveAndFlush(...)` 사용 경로를 준비한다.
+- [ ] `rolling_paper`에 `(party_id, writer_nickname_key)`, `writer_participant_id` unique constraint를 추가한다.
+- [ ] `RollingPaperRepository`에 `existsByPartyAndWriterNicknameKey(...)`와 `saveAndFlush(...)` 사용 경로를 준비한다.
 - [ ] `RollingPaperWrapperRepository`를 추가한다.
 - [ ] `ImageRepository`에 `findByTargetTypeAndTargetIdInOrderByTargetIdAscSortOrderAsc(...)` 형태의 bulk 조회 메서드를 추가한다.
 - [ ] 기존 테스트의 `RollingPaper(theme = ...)` 생성자를 `wrapper = ...`로 갱신한다.
@@ -169,7 +170,7 @@ Run:
 - [ ] 비회원이면 새 participant를 생성한다.
 - [ ] `isCelebrant = true` participant도 작성 가능하게 둔다.
 - [ ] `writerNickname`, `content`는 저장 전 trim한다.
-- [ ] 같은 파티의 같은 닉네임은 대소문자 구분 사전 검증으로 막는다.
+- [ ] 같은 파티의 같은 닉네임은 대소문자 무시 사전 검증과 DB 정규화 키 unique constraint로 막는다.
 - [ ] `RollingPaper`는 `saveAndFlush`로 저장해서 unique constraint 위반을 UseCase 안에서 변환한다.
 - [ ] 작성 성공 시 participant의 `hasWrittenPaper`를 `true`로 갱신한다.
 - [ ] `uk_participant_party_user` 충돌은 기존 participant 재조회로 복구한다.
@@ -206,7 +207,7 @@ Test cases:
 - [ ] `wrapperId` 누락/없는 값 실패
 - [ ] 같은 파티 내 같은 닉네임 실패
 - [ ] trim 전후 같은 닉네임 실패
-- [ ] 대소문자만 다른 닉네임 작성 성공
+- [ ] 대소문자만 다른 닉네임 중복 실패
 - [ ] 다른 파티에서는 같은 닉네임 작성 성공
 - [ ] 회원 participant가 이미 작성했으면 실패
 - [ ] 작성 성공 시 participant `hasWrittenPaper = true`

--- a/docs/superpowers/specs/2026-05-04-rolling-paper-write-design.md
+++ b/docs/superpowers/specs/2026-05-04-rolling-paper-write-design.md
@@ -66,17 +66,18 @@
 - 한국어, 영어, 숫자, 특수문자를 모두 허용한다.
 - 정규식으로 문자 종류를 제한하지 않는다.
 - 파티 기준으로 롤링페이퍼 작성자 닉네임은 중복 불가
-- 중복 기준은 `rolling_paper.party_id + rolling_paper.writer_nickname`
+- 중복 기준은 `rolling_paper.party_id + rolling_paper.writer_nickname_key`
 
 저장 정책:
 
 - 요청 DTO는 `@NotBlank`, `@Size(max = 10)` 기준으로 검증한다.
 - 서버는 앞뒤 공백을 제거한 닉네임을 `writer_nickname`에 저장한다.
+- `writer_nickname_key`는 파티 식별자를 포함하지 않는 닉네임 정규화 값이며, `writer_nickname.trim().lowercase(Locale.ROOT)`로 생성한다.
 - 내부 공백은 유지한다.
 - 작성 후 실시간 프로필 닉네임이 바뀌어도 롤링페이퍼 리스트에는 `writer_nickname` 스냅샷을 사용한다.
-- 중복 검증과 DB unique constraint는 trim된 저장값 기준으로 동작한다.
+- 중복 검증과 DB unique constraint는 `party_id`와 `writer_nickname_key` 조합 기준으로 동작한다.
 - trim 이후 길이가 10자 이하여도, trim 전 요청 문자열이 10자를 초과하면 `@Size(max = 10)` 검증 실패로 처리한다.
-- 닉네임 대소문자는 같은 값으로 취급한다. 예를 들어 `abc`와 `ABC`는 중복이다.
+- 닉네임 대소문자는 `writer_nickname_key` 생성 시 소문자로 정규화하므로 같은 값으로 취급한다. 예를 들어 같은 파티의 `abc`와 `ABC`는 중복이다.
 
 ### 3-2. 내용
 
@@ -213,7 +214,7 @@ UseCase 진입 이후:
 8. 비회원이면 새 participant를 생성한다.
 9. 회원 participant가 이미 `hasWrittenPaper = true`이면 `ROLLING_PAPER_ALREADY_WRITTEN`.
 10. `writerNickname`, `content`를 trim한다.
-11. 같은 파티에 같은 `writerNickname` 롤링페이퍼가 있으면 `ROLLING_PAPER_NICKNAME_DUPLICATED`.
+11. 같은 파티에 같은 `writer_nickname_key` 롤링페이퍼가 있으면 `ROLLING_PAPER_NICKNAME_DUPLICATED`.
 12. `RollingPaper`를 저장한다.
 13. participant의 `hasWrittenPaper`를 `true`로 갱신한다.
 14. 생성된 롤링페이퍼 ID를 반환한다.
@@ -292,8 +293,8 @@ DB 기준:
 
 - 현재 애플리케이션 기본 Hibernate dialect는 `MySQLDialect`이고, 테스트는 H2를 사용한다.
 - 닉네임 중복 정책은 DB collation의 trailing-space 비교 방식에 기대지 않는다.
-- 애플리케이션에서 trim한 값을 저장하고, 중복 사전 검증과 unique constraint 모두 저장값 기준으로 처리한다.
-- 대소문자 무시 중복 정책은 DB collation에만 기대지 않는다. 저장 전 중복 사전 검증도 대소문자를 무시해서 수행한다.
+- 애플리케이션에서 trim한 값을 `writer_nickname`에 저장하고, 중복 사전 검증과 unique constraint는 `writer_nickname_key` 기준으로 처리한다.
+- 대소문자 무시 중복 정책은 DB collation에만 기대지 않는다. 저장 전 중복 사전 검증도 `writer_nickname_key`로 수행한다.
 
 `RollingPaperWrapper`는 현재 `name`만 가진다. 이미지는 공통 `image` 테이블에서 조회한다.
 
@@ -459,7 +460,7 @@ auth.requestMatchers(HttpMethod.POST, "/api/v1/party-invites/*/rolling-papers").
 
 동시성/DB 제약:
 
-- 같은 파티에 같은 `writerNickname`이 동시에 저장되면 unique constraint로 막힌다.
+- 같은 파티에 같은 `writer_nickname_key`가 동시에 저장되면 unique constraint로 막힌다.
 - constraint 위반은 `ROLLING_PAPER_NICKNAME_DUPLICATED`로 응답한다.
 - 같은 `writer_participant_id`가 동시에 저장되면 unique constraint로 막힌다.
 - constraint 위반은 `ROLLING_PAPER_ALREADY_WRITTEN`으로 응답한다.

--- a/docs/superpowers/specs/2026-05-04-rolling-paper-write-design.md
+++ b/docs/superpowers/specs/2026-05-04-rolling-paper-write-design.md
@@ -263,7 +263,7 @@ var wrapper: RollingPaperWrapper
 @Column(name = "writer_nickname", nullable = false, length = 10)
 var writerNickname: String
 
-@Column(name = "writer_nickname_key", nullable = false, length = 32)
+@Column(name = "writer_nickname_key", nullable = false, length = 10)
 var writerNicknameKey: String
 
 @Column(nullable = false, length = 100)

--- a/docs/superpowers/specs/2026-05-04-rolling-paper-write-design.md
+++ b/docs/superpowers/specs/2026-05-04-rolling-paper-write-design.md
@@ -76,7 +76,7 @@
 - 작성 후 실시간 프로필 닉네임이 바뀌어도 롤링페이퍼 리스트에는 `writer_nickname` 스냅샷을 사용한다.
 - 중복 검증과 DB unique constraint는 trim된 저장값 기준으로 동작한다.
 - trim 이후 길이가 10자 이하여도, trim 전 요청 문자열이 10자를 초과하면 `@Size(max = 10)` 검증 실패로 처리한다.
-- 닉네임 대소문자는 서로 다른 값으로 취급한다. 예를 들어 `abc`와 `ABC`는 중복이 아니다.
+- 닉네임 대소문자는 같은 값으로 취급한다. 예를 들어 `abc`와 `ABC`는 중복이다.
 
 ### 3-2. 내용
 
@@ -227,7 +227,7 @@ UseCase 진입 이후:
 동시성:
 
 - 애플리케이션 레벨 중복 체크만으로는 동시에 같은 닉네임을 제출하는 요청을 완전히 막을 수 없다.
-- DB에 `(party_id, writer_nickname)` unique constraint를 둔다.
+- DB에 대소문자 무시 정규화 값인 `writer_nickname_key`를 저장하고 `(party_id, writer_nickname_key)` unique constraint를 둔다.
 - unique constraint 위반은 `ROLLING_PAPER_NICKNAME_DUPLICATED`로 변환한다.
 - 회원의 동시 이중 제출도 애플리케이션 레벨의 `hasWrittenPaper` 확인만으로는 완전히 막을 수 없다.
 - DB에 `writer_participant_id` unique constraint를 둬서 같은 participant가 두 장 이상 작성하지 못하게 한다.
@@ -262,6 +262,9 @@ var wrapper: RollingPaperWrapper
 @Column(name = "writer_nickname", nullable = false, length = 10)
 var writerNickname: String
 
+@Column(name = "writer_nickname_key", nullable = false, length = 32)
+var writerNicknameKey: String
+
 @Column(nullable = false, length = 100)
 var content: String
 ```
@@ -271,7 +274,7 @@ var content: String
 `rolling_paper` 테이블 제약 추가:
 
 ```text
-uk_rolling_paper_party_writer_nickname (party_id, writer_nickname)
+uk_rolling_paper_party_writer_nickname (party_id, writer_nickname_key)
 uk_rolling_paper_writer_participant (writer_participant_id)
 ```
 
@@ -290,7 +293,7 @@ DB 기준:
 - 현재 애플리케이션 기본 Hibernate dialect는 `MySQLDialect`이고, 테스트는 H2를 사용한다.
 - 닉네임 중복 정책은 DB collation의 trailing-space 비교 방식에 기대지 않는다.
 - 애플리케이션에서 trim한 값을 저장하고, 중복 사전 검증과 unique constraint 모두 저장값 기준으로 처리한다.
-- 대소문자 구분 중복 정책은 DB collation에 기대지 않는다. 저장 전 중복 사전 검증은 대소문자를 구분해서 수행한다.
+- 대소문자 무시 중복 정책은 DB collation에만 기대지 않는다. 저장 전 중복 사전 검증도 대소문자를 무시해서 수행한다.
 
 `RollingPaperWrapper`는 현재 `name`만 가진다. 이미지는 공통 `image` 테이블에서 조회한다.
 
@@ -445,7 +448,7 @@ auth.requestMatchers(HttpMethod.POST, "/api/v1/party-invites/*/rolling-papers").
 - 없는 `wrapperId` 실패
 - 같은 파티 내 같은 닉네임 중복 실패
 - trim 전후 동일한 닉네임 중복 실패
-- 대소문자만 다른 닉네임은 중복으로 보지 않음
+- 대소문자만 다른 닉네임도 중복으로 처리
 - 다른 파티에서는 같은 닉네임 작성 가능
 - 회원 participant가 이미 작성했으면 실패
 - 같은 회원이 동시에 두 번 작성하면 한 건만 성공

--- a/src/main/kotlin/com/team2/server/auth/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/team2/server/auth/config/SecurityConfig.kt
@@ -50,6 +50,7 @@ class SecurityConfig(
                 auth.requestMatchers(HttpMethod.GET, "/api/v1/characters").permitAll()
                 auth.requestMatchers(HttpMethod.GET, "/api/v1/rolling-paper-wrappers").permitAll()
                 auth.requestMatchers(HttpMethod.GET, "/api/v1/party-invites/*").permitAll()
+                auth.requestMatchers(HttpMethod.POST, "/api/v1/party-invites/*/rolling-papers").permitAll()
                 auth.requestMatchers(HttpMethod.GET, "/images/**").permitAll()
                 auth.anyRequest().authenticated()
             }.oauth2Login { oauth ->

--- a/src/main/kotlin/com/team2/server/common/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/team2/server/common/config/SwaggerConfig.kt
@@ -1,11 +1,17 @@
 package com.team2.server.common.config
 
+import com.team2.server.common.swagger.OptionalAuth
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType
 import io.swagger.v3.oas.annotations.security.SecurityScheme
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.security.SecurityRequirement
+import org.springdoc.core.customizers.OperationCustomizer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.annotation.AnnotatedElementUtils
+import org.springframework.web.method.HandlerMethod
+import java.lang.reflect.Method
 
 @Configuration
 @SecurityScheme(
@@ -23,4 +29,29 @@ class SwaggerConfig {
                 .version("v1")
                 .description("Team2 REST API"),
         )
+
+    @Bean
+    fun optionalAuthCustomizer(): OperationCustomizer =
+        OperationCustomizer { operation, handlerMethod ->
+            if (!handlerMethod.hasOptionalAuth()) {
+                return@OperationCustomizer operation
+            }
+
+            val security = operation.security ?: mutableListOf()
+            if (security.none { it.isEmpty() }) {
+                security.add(SecurityRequirement())
+            }
+            operation.security = security
+            operation
+        }
+
+    private fun HandlerMethod.hasOptionalAuth(): Boolean =
+        method.hasOptionalAuth() ||
+            beanType.interfaces.any { type ->
+                runCatching {
+                    type.getMethod(method.name, *method.parameterTypes)
+                }.getOrNull()?.hasOptionalAuth() == true
+            }
+
+    private fun Method.hasOptionalAuth(): Boolean = AnnotatedElementUtils.hasAnnotation(this, OptionalAuth::class.java)
 }

--- a/src/main/kotlin/com/team2/server/common/exception/DataIntegrityViolationExceptionExtensions.kt
+++ b/src/main/kotlin/com/team2/server/common/exception/DataIntegrityViolationExceptionExtensions.kt
@@ -1,0 +1,13 @@
+package com.team2.server.common.exception
+
+import org.springframework.dao.DataIntegrityViolationException
+
+fun DataIntegrityViolationException.isConstraintViolation(constraintName: String): Boolean {
+    val message =
+        listOfNotNull(
+            message,
+            rootCause?.message,
+            mostSpecificCause.message,
+        ).joinToString(" ")
+    return message.contains(constraintName, ignoreCase = true)
+}

--- a/src/main/kotlin/com/team2/server/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/team2/server/common/exception/ErrorCode.kt
@@ -25,4 +25,7 @@ enum class ErrorCode(
     CHARACTER_NOT_FOUND(HttpStatus.NOT_FOUND, "캐릭터를 찾을 수 없습니다"),
     CHARACTER_REQUIRED(HttpStatus.BAD_REQUEST, "채팅 허용 파티는 캐릭터 선택이 필수입니다"),
     CHARACTER_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "채팅 비허용 파티는 캐릭터를 선택할 수 없습니다"),
+    ROLLING_PAPER_WRAPPER_NOT_FOUND(HttpStatus.NOT_FOUND, "롤링페이퍼 래퍼를 찾을 수 없습니다"),
+    ROLLING_PAPER_NICKNAME_DUPLICATED(HttpStatus.CONFLICT, "이미 사용 중인 롤링페이퍼 닉네임입니다"),
+    ROLLING_PAPER_ALREADY_WRITTEN(HttpStatus.CONFLICT, "이미 롤링페이퍼를 작성했습니다"),
 }

--- a/src/main/kotlin/com/team2/server/common/swagger/OptionalAuth.kt
+++ b/src/main/kotlin/com/team2/server/common/swagger/OptionalAuth.kt
@@ -1,0 +1,5 @@
+package com.team2.server.common.swagger
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class OptionalAuth

--- a/src/main/kotlin/com/team2/server/party/controller/PartyInviteLookupApi.kt
+++ b/src/main/kotlin/com/team2/server/party/controller/PartyInviteLookupApi.kt
@@ -4,6 +4,7 @@ import com.team2.server.auth.principal.UserPrincipal
 import com.team2.server.common.response.ApiResponse
 import com.team2.server.common.response.ErrorResponse
 import com.team2.server.common.swagger.InternalServerErrorResponse
+import com.team2.server.common.swagger.OptionalAuth
 import com.team2.server.party.dto.PartyInviteLookupResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -23,9 +24,9 @@ interface PartyInviteLookupApi {
                 "조회 시 participant는 생성하지 않으며, 만료된 초대 토큰도 조회할 수 있다.",
         security = [
             SecurityRequirement(name = "Bearer Authentication"),
-            SecurityRequirement(name = ""),
         ],
     )
+    @OptionalAuth
     @SwaggerApiResponse(
         responseCode = "200",
         description = "초대장 조회 성공",

--- a/src/main/kotlin/com/team2/server/rollingpaper/controller/RollingPaperApi.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/controller/RollingPaperApi.kt
@@ -1,0 +1,88 @@
+package com.team2.server.rollingpaper.controller
+
+import com.team2.server.auth.principal.UserPrincipal
+import com.team2.server.common.response.ApiResponse
+import com.team2.server.common.response.ErrorResponse
+import com.team2.server.common.swagger.AuthErrorResponses
+import com.team2.server.common.swagger.InternalServerErrorResponse
+import com.team2.server.common.swagger.ValidationErrorResponse
+import com.team2.server.rollingpaper.dto.CreateRollingPaperRequest
+import com.team2.server.rollingpaper.dto.CreateRollingPaperResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
+
+@Tag(name = "Rolling Paper", description = "롤링페이퍼 API")
+interface RollingPaperApi {
+    @Operation(
+        summary = "롤링페이퍼 작성",
+        description = "초대 토큰으로 롤링페이퍼를 작성한다. 인증 없이도 작성 가능하다.",
+        security = [
+            SecurityRequirement(name = "Bearer Authentication"),
+            SecurityRequirement(name = ""),
+        ],
+    )
+    @SwaggerApiResponse(
+        responseCode = "201",
+        description = "롤링페이퍼 작성 성공",
+    )
+    @ValidationErrorResponse
+    @AuthErrorResponses
+    @SwaggerApiResponse(
+        responseCode = "404",
+        description = "파티 또는 래퍼 없음",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = ErrorResponse::class),
+                examples = [
+                    ExampleObject(
+                        value = """
+                            {
+                              "status": 404,
+                              "error": {
+                                "code": "ROLLING_PAPER_WRAPPER_NOT_FOUND",
+                                "message": "롤링페이퍼 래퍼를 찾을 수 없습니다"
+                              }
+                            }
+                        """,
+                    ),
+                ],
+            ),
+        ],
+    )
+    @SwaggerApiResponse(
+        responseCode = "409",
+        description = "닉네임 중복 또는 이미 작성함",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = ErrorResponse::class),
+                examples = [
+                    ExampleObject(
+                        value = """
+                            {
+                              "status": 409,
+                              "error": {
+                                "code": "ROLLING_PAPER_NICKNAME_DUPLICATED",
+                                "message": "이미 사용 중인 롤링페이퍼 닉네임입니다"
+                              }
+                            }
+                        """,
+                    ),
+                ],
+            ),
+        ],
+    )
+    @InternalServerErrorResponse
+    fun createRollingPaper(
+        @Parameter(hidden = true) principal: UserPrincipal?,
+        @Parameter(description = "초대 토큰", example = "exampletoken0000") inviteToken: String,
+        request: CreateRollingPaperRequest,
+    ): ApiResponse<CreateRollingPaperResponse>
+}

--- a/src/main/kotlin/com/team2/server/rollingpaper/controller/RollingPaperApi.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/controller/RollingPaperApi.kt
@@ -21,7 +21,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
 interface RollingPaperApi {
     @Operation(
         summary = "롤링페이퍼 작성",
-        description = "초대 토큰으로 롤링페이퍼를 작성한다. 인증 없이도 작성 가능하다.",
+        description =
+            "초대 토큰으로 롤링페이퍼를 작성한다. 인증 없이도 작성 가능하다. " +
+                "Authorization header를 보낼 경우 유효한 Bearer token이어야 한다.",
         security = [
             SecurityRequirement(name = "Bearer Authentication"),
             SecurityRequirement(name = ""),
@@ -65,12 +67,25 @@ interface RollingPaperApi {
                 schema = Schema(implementation = ErrorResponse::class),
                 examples = [
                     ExampleObject(
+                        name = "닉네임 중복",
                         value = """
                             {
                               "status": 409,
                               "error": {
                                 "code": "ROLLING_PAPER_NICKNAME_DUPLICATED",
                                 "message": "이미 사용 중인 롤링페이퍼 닉네임입니다"
+                              }
+                            }
+                        """,
+                    ),
+                    ExampleObject(
+                        name = "이미 작성함",
+                        value = """
+                            {
+                              "status": 409,
+                              "error": {
+                                "code": "ROLLING_PAPER_ALREADY_WRITTEN",
+                                "message": "이미 롤링페이퍼를 작성했습니다"
                               }
                             }
                         """,

--- a/src/main/kotlin/com/team2/server/rollingpaper/controller/RollingPaperApi.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/controller/RollingPaperApi.kt
@@ -5,6 +5,7 @@ import com.team2.server.common.response.ApiResponse
 import com.team2.server.common.response.ErrorResponse
 import com.team2.server.common.swagger.AuthErrorResponses
 import com.team2.server.common.swagger.InternalServerErrorResponse
+import com.team2.server.common.swagger.OptionalAuth
 import com.team2.server.rollingpaper.dto.CreateRollingPaperRequest
 import com.team2.server.rollingpaper.dto.CreateRollingPaperResponse
 import io.swagger.v3.oas.annotations.Operation
@@ -25,9 +26,9 @@ interface RollingPaperApi {
                 "Authorization header를 보낼 경우 유효한 Bearer token이어야 한다.",
         security = [
             SecurityRequirement(name = "Bearer Authentication"),
-            SecurityRequirement(name = ""),
         ],
     )
+    @OptionalAuth
     @SwaggerApiResponse(
         responseCode = "201",
         description = "롤링페이퍼 작성 성공",

--- a/src/main/kotlin/com/team2/server/rollingpaper/controller/RollingPaperApi.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/controller/RollingPaperApi.kt
@@ -5,7 +5,6 @@ import com.team2.server.common.response.ApiResponse
 import com.team2.server.common.response.ErrorResponse
 import com.team2.server.common.swagger.AuthErrorResponses
 import com.team2.server.common.swagger.InternalServerErrorResponse
-import com.team2.server.common.swagger.ValidationErrorResponse
 import com.team2.server.rollingpaper.dto.CreateRollingPaperRequest
 import com.team2.server.rollingpaper.dto.CreateRollingPaperResponse
 import io.swagger.v3.oas.annotations.Operation
@@ -33,8 +32,55 @@ interface RollingPaperApi {
         responseCode = "201",
         description = "롤링페이퍼 작성 성공",
     )
-    @ValidationErrorResponse
     @AuthErrorResponses
+    @SwaggerApiResponse(
+        responseCode = "400",
+        description = "입력값 검증 실패, 만료된 초대 토큰 또는 종료된 파티",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = ErrorResponse::class),
+                examples = [
+                    ExampleObject(
+                        name = "입력값 검증 실패",
+                        value = """
+                            {
+                              "status": 400,
+                              "error": {
+                                "code": "VALIDATION_ERROR",
+                                "message": "writerNickname: 닉네임은 필수입니다"
+                              }
+                            }
+                        """,
+                    ),
+                    ExampleObject(
+                        name = "만료된 초대 토큰",
+                        value = """
+                            {
+                              "status": 400,
+                              "error": {
+                                "code": "INVITE_LINK_EXPIRED",
+                                "message": "만료된 초대링크입니다"
+                              }
+                            }
+                        """,
+                    ),
+                    ExampleObject(
+                        name = "종료된 파티",
+                        value = """
+                            {
+                              "status": 400,
+                              "error": {
+                                "code": "PARTY_ENDED",
+                                "message": "이미 종료된 파티입니다"
+                              }
+                            }
+                        """,
+                    ),
+                ],
+            ),
+        ],
+    )
     @SwaggerApiResponse(
         responseCode = "404",
         description = "파티 또는 래퍼 없음",
@@ -44,6 +90,19 @@ interface RollingPaperApi {
                 schema = Schema(implementation = ErrorResponse::class),
                 examples = [
                     ExampleObject(
+                        name = "파티 없음",
+                        value = """
+                            {
+                              "status": 404,
+                              "error": {
+                                "code": "PARTY_NOT_FOUND",
+                                "message": "파티를 찾을 수 없습니다"
+                              }
+                            }
+                        """,
+                    ),
+                    ExampleObject(
+                        name = "래퍼 없음",
                         value = """
                             {
                               "status": 404,

--- a/src/main/kotlin/com/team2/server/rollingpaper/controller/RollingPaperController.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/controller/RollingPaperController.kt
@@ -1,0 +1,34 @@
+package com.team2.server.rollingpaper.controller
+
+import com.team2.server.auth.principal.UserPrincipal
+import com.team2.server.common.response.ApiResponse
+import com.team2.server.rollingpaper.dto.CreateRollingPaperRequest
+import com.team2.server.rollingpaper.dto.CreateRollingPaperResponse
+import com.team2.server.rollingpaper.usecase.CreateRollingPaperUseCase
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/party-invites")
+class RollingPaperController(
+    private val createRollingPaperUseCase: CreateRollingPaperUseCase,
+) : RollingPaperApi {
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping("/{inviteToken}/rolling-papers")
+    override fun createRollingPaper(
+        @AuthenticationPrincipal principal: UserPrincipal?,
+        @PathVariable inviteToken: String,
+        @Valid @RequestBody request: CreateRollingPaperRequest,
+    ): ApiResponse<CreateRollingPaperResponse> =
+        ApiResponse.success(
+            HttpStatus.CREATED,
+            createRollingPaperUseCase.create(inviteToken, principal?.userId, request),
+        )
+}

--- a/src/main/kotlin/com/team2/server/rollingpaper/dto/CreateRollingPaperRequest.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/dto/CreateRollingPaperRequest.kt
@@ -1,0 +1,29 @@
+package com.team2.server.rollingpaper.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
+import jakarta.validation.constraints.Size
+
+@Schema(description = "롤링페이퍼 작성 요청")
+data class CreateRollingPaperRequest(
+    @field:NotBlank(message = "작성자 닉네임은 필수입니다")
+    @field:Size(max = 10, message = "작성자 닉네임은 10자 이하여야 합니다")
+    @Schema(description = "작성자 닉네임", example = "축하요정")
+    val writerNickname: String?,
+    @field:NotBlank(message = "내용은 필수입니다")
+    @field:Size(max = 100, message = "내용은 100자 이하여야 합니다")
+    @Schema(description = "롤링페이퍼 내용", example = "생일 축하해!")
+    val content: String?,
+    @field:NotNull(message = "래퍼 선택은 필수입니다")
+    @field:Positive(message = "래퍼 ID는 양수여야 합니다")
+    @Schema(description = "래퍼 ID", example = "1")
+    val wrapperId: Long?,
+) {
+    fun trimmedWriterNickname(): String = requireNotNull(writerNickname).trim()
+
+    fun trimmedContent(): String = requireNotNull(content).trim()
+
+    fun requiredWrapperId(): Long = requireNotNull(wrapperId)
+}

--- a/src/main/kotlin/com/team2/server/rollingpaper/dto/CreateRollingPaperResponse.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/dto/CreateRollingPaperResponse.kt
@@ -1,0 +1,9 @@
+package com.team2.server.rollingpaper.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "롤링페이퍼 작성 응답")
+data class CreateRollingPaperResponse(
+    @Schema(description = "생성된 롤링페이퍼 ID", example = "10")
+    val rollingPaperId: Long,
+)

--- a/src/main/kotlin/com/team2/server/rollingpaper/entity/RollingPaper.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/entity/RollingPaper.kt
@@ -9,9 +9,22 @@ import jakarta.persistence.FetchType
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
 
 @Entity
-@Table(name = "rolling_paper")
+@Table(
+    name = "rolling_paper",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_rolling_paper_party_writer_nickname",
+            columnNames = ["party_id", "writer_nickname"],
+        ),
+        UniqueConstraint(
+            name = "uk_rolling_paper_writer_participant",
+            columnNames = ["writer_participant_id"],
+        ),
+    ],
+)
 class RollingPaper(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "wrapper_id", nullable = false)
@@ -22,9 +35,9 @@ class RollingPaper(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "party_id", nullable = false)
     var party: Party,
-    @Column(name = "writer_nickname", length = 20)
-    var writerNickname: String? = null,
-    @Column(nullable = false, length = 1000)
+    @Column(name = "writer_nickname", nullable = false, length = 10)
+    var writerNickname: String,
+    @Column(nullable = false, length = 100)
     var content: String,
     @Column(name = "is_read", nullable = false)
     var isRead: Boolean = false,

--- a/src/main/kotlin/com/team2/server/rollingpaper/entity/RollingPaper.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/entity/RollingPaper.kt
@@ -36,14 +36,19 @@ class RollingPaper(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "party_id", nullable = false)
     var party: Party,
-    @Column(name = "writer_nickname", nullable = false, length = 10)
-    var writerNickname: String,
-    @Column(name = "writer_nickname_key", nullable = false, length = 32)
-    var writerNicknameKey: String = writerNickname.toWriterNicknameKey(),
+    writerNickname: String,
     @Column(nullable = false, length = 100)
     var content: String,
     @Column(name = "is_read", nullable = false)
     var isRead: Boolean = false,
-) : BaseEntity()
+) : BaseEntity() {
+    @Column(name = "writer_nickname", nullable = false, length = 10)
+    var writerNickname: String = writerNickname
+        protected set
+
+    @Column(name = "writer_nickname_key", nullable = false, length = 32)
+    var writerNicknameKey: String = writerNickname.toWriterNicknameKey()
+        protected set
+}
 
 fun String.toWriterNicknameKey(): String = trim().lowercase(Locale.ROOT)

--- a/src/main/kotlin/com/team2/server/rollingpaper/entity/RollingPaper.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/entity/RollingPaper.kt
@@ -43,11 +43,11 @@ class RollingPaper(
     var isRead: Boolean = false,
 ) : BaseEntity() {
     @Column(name = "writer_nickname", nullable = false, length = 10)
-    var writerNickname: String = writerNickname
+    var writerNickname: String = writerNickname.trim()
         protected set
 
-    @Column(name = "writer_nickname_key", nullable = false, length = 32)
-    var writerNicknameKey: String = writerNickname.toWriterNicknameKey()
+    @Column(name = "writer_nickname_key", nullable = false, length = 10)
+    var writerNicknameKey: String = this.writerNickname.toWriterNicknameKey()
         protected set
 }
 

--- a/src/main/kotlin/com/team2/server/rollingpaper/entity/RollingPaper.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/entity/RollingPaper.kt
@@ -10,6 +10,7 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
+import java.util.Locale
 
 @Entity
 @Table(
@@ -17,7 +18,7 @@ import jakarta.persistence.UniqueConstraint
     uniqueConstraints = [
         UniqueConstraint(
             name = "uk_rolling_paper_party_writer_nickname",
-            columnNames = ["party_id", "writer_nickname"],
+            columnNames = ["party_id", "writer_nickname_key"],
         ),
         UniqueConstraint(
             name = "uk_rolling_paper_writer_participant",
@@ -37,8 +38,12 @@ class RollingPaper(
     var party: Party,
     @Column(name = "writer_nickname", nullable = false, length = 10)
     var writerNickname: String,
+    @Column(name = "writer_nickname_key", nullable = false, length = 32)
+    var writerNicknameKey: String = writerNickname.toWriterNicknameKey(),
     @Column(nullable = false, length = 100)
     var content: String,
     @Column(name = "is_read", nullable = false)
     var isRead: Boolean = false,
 ) : BaseEntity()
+
+fun String.toWriterNicknameKey(): String = trim().lowercase(Locale.ROOT)

--- a/src/main/kotlin/com/team2/server/rollingpaper/repository/RollingPaperRepository.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/repository/RollingPaperRepository.kt
@@ -3,17 +3,10 @@ package com.team2.server.rollingpaper.repository
 import com.team2.server.party.entity.Party
 import com.team2.server.rollingpaper.entity.RollingPaper
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
-import org.springframework.data.repository.query.Param
 
 interface RollingPaperRepository : JpaRepository<RollingPaper, Long> {
     fun existsByPartyAndWriterNickname(
         party: Party,
         writerNickname: String,
     ): Boolean
-
-    @Query("select r.writerNickname from RollingPaper r where r.party.id = :partyId")
-    fun findWriterNicknamesByPartyId(
-        @Param("partyId") partyId: Long,
-    ): List<String>
 }

--- a/src/main/kotlin/com/team2/server/rollingpaper/repository/RollingPaperRepository.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/repository/RollingPaperRepository.kt
@@ -5,8 +5,8 @@ import com.team2.server.rollingpaper.entity.RollingPaper
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface RollingPaperRepository : JpaRepository<RollingPaper, Long> {
-    fun existsByPartyAndWriterNicknameIgnoreCase(
+    fun existsByPartyAndWriterNicknameKey(
         party: Party,
-        writerNickname: String,
+        writerNicknameKey: String,
     ): Boolean
 }

--- a/src/main/kotlin/com/team2/server/rollingpaper/repository/RollingPaperRepository.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/repository/RollingPaperRepository.kt
@@ -1,0 +1,19 @@
+package com.team2.server.rollingpaper.repository
+
+import com.team2.server.party.entity.Party
+import com.team2.server.rollingpaper.entity.RollingPaper
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+
+interface RollingPaperRepository : JpaRepository<RollingPaper, Long> {
+    fun existsByPartyAndWriterNickname(
+        party: Party,
+        writerNickname: String,
+    ): Boolean
+
+    @Query("select r.writerNickname from RollingPaper r where r.party.id = :partyId")
+    fun findWriterNicknamesByPartyId(
+        @Param("partyId") partyId: Long,
+    ): List<String>
+}

--- a/src/main/kotlin/com/team2/server/rollingpaper/repository/RollingPaperRepository.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/repository/RollingPaperRepository.kt
@@ -5,7 +5,7 @@ import com.team2.server.rollingpaper.entity.RollingPaper
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface RollingPaperRepository : JpaRepository<RollingPaper, Long> {
-    fun existsByPartyAndWriterNickname(
+    fun existsByPartyAndWriterNicknameIgnoreCase(
         party: Party,
         writerNickname: String,
     ): Boolean

--- a/src/main/kotlin/com/team2/server/rollingpaper/service/DefaultRollingPaperWrapperInitializer.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/service/DefaultRollingPaperWrapperInitializer.kt
@@ -2,6 +2,7 @@ package com.team2.server.rollingpaper.service
 
 import com.team2.server.common.entity.Image
 import com.team2.server.common.entity.ImageTargetType
+import com.team2.server.common.exception.isConstraintViolation
 import com.team2.server.common.repository.ImageRepository
 import com.team2.server.rollingpaper.entity.RollingPaperWrapper
 import com.team2.server.rollingpaper.repository.RollingPaperWrapperRepository
@@ -77,16 +78,6 @@ class DefaultRollingPaperWrapperInitializer(
                 }
             }
         }
-    }
-
-    private fun DataIntegrityViolationException.isConstraintViolation(constraintName: String): Boolean {
-        val message =
-            listOfNotNull(
-                message,
-                rootCause?.message,
-                mostSpecificCause.message,
-            ).joinToString(" ")
-        return message.contains(constraintName, ignoreCase = true)
     }
 
     private data class DefaultWrapper(

--- a/src/main/kotlin/com/team2/server/rollingpaper/usecase/CreateRollingPaperUseCase.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/usecase/CreateRollingPaperUseCase.kt
@@ -1,0 +1,149 @@
+package com.team2.server.rollingpaper.usecase
+
+import com.team2.server.common.exception.BusinessException
+import com.team2.server.common.exception.ErrorCode
+import com.team2.server.party.entity.Participant
+import com.team2.server.party.entity.Party
+import com.team2.server.party.repository.ParticipantRepository
+import com.team2.server.party.repository.PartyInviteRepository
+import com.team2.server.rollingpaper.dto.CreateRollingPaperRequest
+import com.team2.server.rollingpaper.dto.CreateRollingPaperResponse
+import com.team2.server.rollingpaper.entity.RollingPaper
+import com.team2.server.rollingpaper.repository.RollingPaperRepository
+import com.team2.server.rollingpaper.repository.RollingPaperWrapperRepository
+import com.team2.server.user.entity.User
+import com.team2.server.user.repository.UserRepository
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service
+class CreateRollingPaperUseCase(
+    private val partyInviteRepository: PartyInviteRepository,
+    private val rollingPaperWrapperRepository: RollingPaperWrapperRepository,
+    private val participantRepository: ParticipantRepository,
+    private val rollingPaperRepository: RollingPaperRepository,
+    private val userRepository: UserRepository,
+) {
+    @Transactional
+    fun create(
+        inviteToken: String,
+        userId: Long?,
+        request: CreateRollingPaperRequest,
+    ): CreateRollingPaperResponse {
+        val invite =
+            partyInviteRepository.findByToken(inviteToken)
+                ?: throw BusinessException(ErrorCode.PARTY_NOT_FOUND)
+        val now = LocalDateTime.now()
+        if (!invite.expiresAt.isAfter(now)) {
+            throw BusinessException(ErrorCode.INVITE_LINK_EXPIRED)
+        }
+
+        val party = invite.party
+        if (!now.isBefore(party.createdAt.plusDays(Party.ENDED_AFTER_DAYS))) {
+            throw BusinessException(ErrorCode.PARTY_ENDED)
+        }
+
+        val wrapper =
+            rollingPaperWrapperRepository.findByIdOrNull(request.requiredWrapperId())
+                ?: throw BusinessException(ErrorCode.ROLLING_PAPER_WRAPPER_NOT_FOUND)
+        val participant = findOrCreateParticipant(party, userId)
+        if (participant.hasWrittenPaper) {
+            throw BusinessException(ErrorCode.ROLLING_PAPER_ALREADY_WRITTEN)
+        }
+
+        val writerNickname = request.trimmedWriterNickname()
+        val content = request.trimmedContent()
+        if (isWriterNicknameDuplicated(party, writerNickname)) {
+            throw BusinessException(ErrorCode.ROLLING_PAPER_NICKNAME_DUPLICATED)
+        }
+
+        val rollingPaper =
+            try {
+                rollingPaperRepository.saveAndFlush(
+                    RollingPaper(
+                        wrapper = wrapper,
+                        writer = participant,
+                        party = party,
+                        writerNickname = writerNickname,
+                        content = content,
+                    ),
+                )
+            } catch (e: DataIntegrityViolationException) {
+                throw e.toRollingPaperBusinessException()
+            }
+
+        participant.hasWrittenPaper = true
+        return CreateRollingPaperResponse(rollingPaperId = rollingPaper.id)
+    }
+
+    private fun findOrCreateParticipant(
+        party: Party,
+        userId: Long?,
+    ): Participant {
+        if (userId == null) {
+            return participantRepository.save(Participant(party = party))
+        }
+
+        val user =
+            userRepository
+                .findById(userId)
+                .orElseThrow { BusinessException(ErrorCode.AUTH_USER_NOT_FOUND) }
+        return participantRepository.findByPartyAndUser(party, user) ?: createMemberParticipant(party, user)
+    }
+
+    private fun createMemberParticipant(
+        party: Party,
+        user: User,
+    ): Participant =
+        try {
+            participantRepository.saveAndFlush(
+                Participant(
+                    party = party,
+                    user = user,
+                ),
+            )
+        } catch (e: DataIntegrityViolationException) {
+            if (!e.isConstraintViolation(PARTICIPANT_PARTY_USER_UNIQUE_CONSTRAINT)) {
+                throw e
+            }
+            participantRepository.findByPartyAndUser(party, user) ?: throw e
+        }
+
+    private fun isWriterNicknameDuplicated(
+        party: Party,
+        writerNickname: String,
+    ): Boolean =
+        rollingPaperRepository
+            .findWriterNicknamesByPartyId(party.id)
+            .any { it == writerNickname }
+
+    private fun DataIntegrityViolationException.toRollingPaperBusinessException(): BusinessException =
+        when {
+            isConstraintViolation(ROLLING_PAPER_PARTY_WRITER_NICKNAME_UNIQUE_CONSTRAINT) ->
+                BusinessException(ErrorCode.ROLLING_PAPER_NICKNAME_DUPLICATED)
+            isConstraintViolation(ROLLING_PAPER_WRITER_PARTICIPANT_UNIQUE_CONSTRAINT) ->
+                BusinessException(ErrorCode.ROLLING_PAPER_ALREADY_WRITTEN)
+            else -> throw this
+        }
+
+    private fun DataIntegrityViolationException.isConstraintViolation(constraintName: String): Boolean {
+        val message =
+            listOfNotNull(
+                message,
+                rootCause?.message,
+                mostSpecificCause.message,
+            ).joinToString(" ")
+        return message.contains(constraintName, ignoreCase = true)
+    }
+
+    companion object {
+        private const val PARTICIPANT_PARTY_USER_UNIQUE_CONSTRAINT = "uk_participant_party_user"
+        private const val ROLLING_PAPER_PARTY_WRITER_NICKNAME_UNIQUE_CONSTRAINT =
+            "uk_rolling_paper_party_writer_nickname"
+        private const val ROLLING_PAPER_WRITER_PARTICIPANT_UNIQUE_CONSTRAINT =
+            "uk_rolling_paper_writer_participant"
+    }
+}

--- a/src/main/kotlin/com/team2/server/rollingpaper/usecase/CreateRollingPaperUseCase.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/usecase/CreateRollingPaperUseCase.kt
@@ -5,11 +5,13 @@ import com.team2.server.common.exception.ErrorCode
 import com.team2.server.common.exception.isConstraintViolation
 import com.team2.server.party.entity.Participant
 import com.team2.server.party.entity.Party
+import com.team2.server.party.entity.PartyInvite
 import com.team2.server.party.repository.ParticipantRepository
 import com.team2.server.party.repository.PartyInviteRepository
 import com.team2.server.rollingpaper.dto.CreateRollingPaperRequest
 import com.team2.server.rollingpaper.dto.CreateRollingPaperResponse
 import com.team2.server.rollingpaper.entity.RollingPaper
+import com.team2.server.rollingpaper.entity.RollingPaperWrapper
 import com.team2.server.rollingpaper.repository.RollingPaperRepository
 import com.team2.server.rollingpaper.repository.RollingPaperWrapperRepository
 import com.team2.server.user.entity.User
@@ -34,50 +36,55 @@ class CreateRollingPaperUseCase(
         userId: Long?,
         request: CreateRollingPaperRequest,
     ): CreateRollingPaperResponse {
-        val invite =
-            partyInviteRepository.findByToken(inviteToken)
-                ?: throw BusinessException(ErrorCode.PARTY_NOT_FOUND)
+        val invite = findInvite(inviteToken)
         val now = LocalDateTime.now()
-        if (!invite.expiresAt.isAfter(now)) {
-            throw BusinessException(ErrorCode.INVITE_LINK_EXPIRED)
-        }
-
+        validateInvite(invite, now)
         val party = invite.party
-        if (party.isEnded(now)) {
-            throw BusinessException(ErrorCode.PARTY_ENDED)
-        }
+        validatePartyWritable(party, now)
 
-        val wrapper =
-            rollingPaperWrapperRepository.findByIdOrNull(request.requiredWrapperId())
-                ?: throw BusinessException(ErrorCode.ROLLING_PAPER_WRAPPER_NOT_FOUND)
+        val wrapper = findWrapper(request.requiredWrapperId())
         val participant = findOrCreateParticipant(party, userId)
-        if (participant.hasWrittenPaper) {
-            throw BusinessException(ErrorCode.ROLLING_PAPER_ALREADY_WRITTEN)
-        }
+        validateParticipantWritable(participant)
 
         val writerNickname = request.trimmedWriterNickname()
         val content = request.trimmedContent()
-        if (isWriterNicknameDuplicated(party, writerNickname)) {
-            throw BusinessException(ErrorCode.ROLLING_PAPER_NICKNAME_DUPLICATED)
-        }
+        validateWriterNicknameAvailable(party, writerNickname)
 
-        val rollingPaper =
-            try {
-                rollingPaperRepository.saveAndFlush(
-                    RollingPaper(
-                        wrapper = wrapper,
-                        writer = participant,
-                        party = party,
-                        writerNickname = writerNickname,
-                        content = content,
-                    ),
-                )
-            } catch (e: DataIntegrityViolationException) {
-                throw e.toRollingPaperBusinessException()
-            }
-
+        val rollingPaper = saveRollingPaper(wrapper, participant, party, writerNickname, content)
         participant.hasWrittenPaper = true
         return CreateRollingPaperResponse(rollingPaperId = rollingPaper.id)
+    }
+
+    private fun findInvite(inviteToken: String): PartyInvite =
+        partyInviteRepository.findByToken(inviteToken)
+            ?: throw BusinessException(ErrorCode.PARTY_NOT_FOUND)
+
+    private fun validateInvite(
+        invite: PartyInvite,
+        now: LocalDateTime,
+    ) {
+        if (!invite.expiresAt.isAfter(now)) {
+            throw BusinessException(ErrorCode.INVITE_LINK_EXPIRED)
+        }
+    }
+
+    private fun validatePartyWritable(
+        party: Party,
+        now: LocalDateTime,
+    ) {
+        if (party.isEnded(now)) {
+            throw BusinessException(ErrorCode.PARTY_ENDED)
+        }
+    }
+
+    private fun findWrapper(wrapperId: Long): RollingPaperWrapper =
+        rollingPaperWrapperRepository.findByIdOrNull(wrapperId)
+            ?: throw BusinessException(ErrorCode.ROLLING_PAPER_WRAPPER_NOT_FOUND)
+
+    private fun validateParticipantWritable(participant: Participant) {
+        if (participant.hasWrittenPaper) {
+            throw BusinessException(ErrorCode.ROLLING_PAPER_ALREADY_WRITTEN)
+        }
     }
 
     private fun findOrCreateParticipant(
@@ -107,31 +114,48 @@ class CreateRollingPaperUseCase(
                 ),
             )
         } catch (e: DataIntegrityViolationException) {
-            if (!e.isConstraintViolation(PARTICIPANT_PARTY_USER_UNIQUE_CONSTRAINT)) {
+            if (!e.isConstraintViolation("uk_participant_party_user")) {
                 throw e
             }
             participantRepository.findByPartyAndUser(party, user) ?: throw e
         }
 
-    private fun isWriterNicknameDuplicated(
+    private fun validateWriterNicknameAvailable(
         party: Party,
         writerNickname: String,
-    ): Boolean = rollingPaperRepository.existsByPartyAndWriterNickname(party, writerNickname)
+    ) {
+        if (rollingPaperRepository.existsByPartyAndWriterNicknameIgnoreCase(party, writerNickname)) {
+            throw BusinessException(ErrorCode.ROLLING_PAPER_NICKNAME_DUPLICATED)
+        }
+    }
+
+    private fun saveRollingPaper(
+        wrapper: RollingPaperWrapper,
+        participant: Participant,
+        party: Party,
+        writerNickname: String,
+        content: String,
+    ): RollingPaper =
+        try {
+            rollingPaperRepository.saveAndFlush(
+                RollingPaper(
+                    wrapper = wrapper,
+                    writer = participant,
+                    party = party,
+                    writerNickname = writerNickname,
+                    content = content,
+                ),
+            )
+        } catch (e: DataIntegrityViolationException) {
+            throw e.toRollingPaperBusinessException()
+        }
 
     private fun DataIntegrityViolationException.toRollingPaperBusinessException(): BusinessException =
         when {
-            isConstraintViolation(ROLLING_PAPER_PARTY_WRITER_NICKNAME_UNIQUE_CONSTRAINT) ->
+            isConstraintViolation("uk_rolling_paper_party_writer_nickname") ->
                 BusinessException(ErrorCode.ROLLING_PAPER_NICKNAME_DUPLICATED)
-            isConstraintViolation(ROLLING_PAPER_WRITER_PARTICIPANT_UNIQUE_CONSTRAINT) ->
+            isConstraintViolation("uk_rolling_paper_writer_participant") ->
                 BusinessException(ErrorCode.ROLLING_PAPER_ALREADY_WRITTEN)
             else -> throw this
         }
-
-    companion object {
-        private const val PARTICIPANT_PARTY_USER_UNIQUE_CONSTRAINT = "uk_participant_party_user"
-        private const val ROLLING_PAPER_PARTY_WRITER_NICKNAME_UNIQUE_CONSTRAINT =
-            "uk_rolling_paper_party_writer_nickname"
-        private const val ROLLING_PAPER_WRITER_PARTICIPANT_UNIQUE_CONSTRAINT =
-            "uk_rolling_paper_writer_participant"
-    }
 }

--- a/src/main/kotlin/com/team2/server/rollingpaper/usecase/CreateRollingPaperUseCase.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/usecase/CreateRollingPaperUseCase.kt
@@ -97,9 +97,8 @@ class CreateRollingPaperUseCase(
         }
 
         val user =
-            userRepository
-                .findById(userId)
-                .orElseThrow { BusinessException(ErrorCode.AUTH_USER_NOT_FOUND) }
+            userRepository.findByIdOrNull(userId)
+                ?: throw BusinessException(ErrorCode.AUTH_USER_NOT_FOUND)
         return participantRepository.findByPartyAndUser(party, user) ?: createMemberParticipant(party, user)
     }
 
@@ -148,15 +147,12 @@ class CreateRollingPaperUseCase(
                 ),
             )
         } catch (e: DataIntegrityViolationException) {
-            throw e.toRollingPaperBusinessException()
-        }
-
-    private fun DataIntegrityViolationException.toRollingPaperBusinessException(): BusinessException =
-        when {
-            isConstraintViolation("uk_rolling_paper_party_writer_nickname") ->
-                BusinessException(ErrorCode.ROLLING_PAPER_NICKNAME_DUPLICATED)
-            isConstraintViolation("uk_rolling_paper_writer_participant") ->
-                BusinessException(ErrorCode.ROLLING_PAPER_ALREADY_WRITTEN)
-            else -> throw this
+            when {
+                e.isConstraintViolation("uk_rolling_paper_party_writer_nickname") ->
+                    throw BusinessException(ErrorCode.ROLLING_PAPER_NICKNAME_DUPLICATED)
+                e.isConstraintViolation("uk_rolling_paper_writer_participant") ->
+                    throw BusinessException(ErrorCode.ROLLING_PAPER_ALREADY_WRITTEN)
+                else -> throw e
+            }
         }
 }

--- a/src/main/kotlin/com/team2/server/rollingpaper/usecase/CreateRollingPaperUseCase.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/usecase/CreateRollingPaperUseCase.kt
@@ -2,6 +2,7 @@ package com.team2.server.rollingpaper.usecase
 
 import com.team2.server.common.exception.BusinessException
 import com.team2.server.common.exception.ErrorCode
+import com.team2.server.common.exception.isConstraintViolation
 import com.team2.server.party.entity.Participant
 import com.team2.server.party.entity.Party
 import com.team2.server.party.repository.ParticipantRepository
@@ -125,16 +126,6 @@ class CreateRollingPaperUseCase(
                 BusinessException(ErrorCode.ROLLING_PAPER_ALREADY_WRITTEN)
             else -> throw this
         }
-
-    private fun DataIntegrityViolationException.isConstraintViolation(constraintName: String): Boolean {
-        val message =
-            listOfNotNull(
-                message,
-                rootCause?.message,
-                mostSpecificCause.message,
-            ).joinToString(" ")
-        return message.contains(constraintName, ignoreCase = true)
-    }
 
     companion object {
         private const val PARTICIPANT_PARTY_USER_UNIQUE_CONSTRAINT = "uk_participant_party_user"

--- a/src/main/kotlin/com/team2/server/rollingpaper/usecase/CreateRollingPaperUseCase.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/usecase/CreateRollingPaperUseCase.kt
@@ -12,6 +12,7 @@ import com.team2.server.rollingpaper.dto.CreateRollingPaperRequest
 import com.team2.server.rollingpaper.dto.CreateRollingPaperResponse
 import com.team2.server.rollingpaper.entity.RollingPaper
 import com.team2.server.rollingpaper.entity.RollingPaperWrapper
+import com.team2.server.rollingpaper.entity.toWriterNicknameKey
 import com.team2.server.rollingpaper.repository.RollingPaperRepository
 import com.team2.server.rollingpaper.repository.RollingPaperWrapperRepository
 import com.team2.server.user.entity.User
@@ -124,7 +125,7 @@ class CreateRollingPaperUseCase(
         party: Party,
         writerNickname: String,
     ) {
-        if (rollingPaperRepository.existsByPartyAndWriterNicknameIgnoreCase(party, writerNickname)) {
+        if (rollingPaperRepository.existsByPartyAndWriterNicknameKey(party, writerNickname.toWriterNicknameKey())) {
             throw BusinessException(ErrorCode.ROLLING_PAPER_NICKNAME_DUPLICATED)
         }
     }

--- a/src/main/kotlin/com/team2/server/rollingpaper/usecase/CreateRollingPaperUseCase.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/usecase/CreateRollingPaperUseCase.kt
@@ -43,7 +43,7 @@ class CreateRollingPaperUseCase(
         }
 
         val party = invite.party
-        if (!now.isBefore(party.createdAt.plusDays(Party.ENDED_AFTER_DAYS))) {
+        if (party.isEnded(now)) {
             throw BusinessException(ErrorCode.PARTY_ENDED)
         }
 

--- a/src/main/kotlin/com/team2/server/rollingpaper/usecase/CreateRollingPaperUseCase.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/usecase/CreateRollingPaperUseCase.kt
@@ -115,10 +115,7 @@ class CreateRollingPaperUseCase(
     private fun isWriterNicknameDuplicated(
         party: Party,
         writerNickname: String,
-    ): Boolean =
-        rollingPaperRepository
-            .findWriterNicknamesByPartyId(party.id)
-            .any { it == writerNickname }
+    ): Boolean = rollingPaperRepository.existsByPartyAndWriterNickname(party, writerNickname)
 
     private fun DataIntegrityViolationException.toRollingPaperBusinessException(): BusinessException =
         when {

--- a/src/test/kotlin/com/team2/server/common/config/SwaggerConfigTest.kt
+++ b/src/test/kotlin/com/team2/server/common/config/SwaggerConfigTest.kt
@@ -1,0 +1,52 @@
+package com.team2.server.common.config
+
+import com.jayway.jsonpath.JsonPath
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class SwaggerConfigTest
+    @Autowired
+    constructor(
+        private val mockMvc: MockMvc,
+    ) {
+        @Test
+        fun `선택 인증 API는 OpenAPI security에 bearer와 익명 인증을 함께 노출한다`() {
+            val apiDocs =
+                mockMvc
+                    .get("/v3/api-docs")
+                    .andExpect {
+                        status { isOk() }
+                    }.andReturn()
+                    .response
+                    .contentAsString
+
+            assertOptionalAuthSecurity(
+                apiDocs,
+                "$.paths['/api/v1/party-invites/{inviteToken}'].get.security",
+            )
+            assertOptionalAuthSecurity(
+                apiDocs,
+                "$.paths['/api/v1/party-invites/{inviteToken}/rolling-papers'].post.security",
+            )
+        }
+
+        private fun assertOptionalAuthSecurity(
+            apiDocs: String,
+            jsonPath: String,
+        ) {
+            val security: List<Map<String, List<String>>> = JsonPath.read(apiDocs, jsonPath)
+
+            assertEquals(2, security.size)
+            assertTrue(security[0].containsKey("Bearer Authentication"))
+            assertTrue(security[0].getValue("Bearer Authentication").isEmpty())
+            assertTrue(security[1].isEmpty())
+        }
+    }

--- a/src/test/kotlin/com/team2/server/rollingpaper/controller/RollingPaperControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/rollingpaper/controller/RollingPaperControllerTest.kt
@@ -155,7 +155,7 @@ class RollingPaperControllerTest
         }
 
         @Test
-        fun `대소문자만 다른 닉네임은 작성 성공`() {
+        fun `대소문자만 다른 닉네임도 중복 실패`() {
             val party = saveParty()
             val invite = saveInvite(party, "casewrite000001")
             val wrapper = saveWrapper()
@@ -166,7 +166,8 @@ class RollingPaperControllerTest
                     contentType = MediaType.APPLICATION_JSON
                     content = requestBody("ABC", "다른 내용", wrapper.id)
                 }.andExpect {
-                    status { isCreated() }
+                    status { isConflict() }
+                    jsonPath("$.error.code") { value("ROLLING_PAPER_NICKNAME_DUPLICATED") }
                 }
         }
 

--- a/src/test/kotlin/com/team2/server/rollingpaper/controller/RollingPaperControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/rollingpaper/controller/RollingPaperControllerTest.kt
@@ -21,11 +21,13 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.post
 import java.time.LocalDateTime
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -169,6 +171,26 @@ class RollingPaperControllerTest
                     status { isConflict() }
                     jsonPath("$.error.code") { value("ROLLING_PAPER_NICKNAME_DUPLICATED") }
                 }
+        }
+
+        @Test
+        fun `대소문자만 다른 닉네임은 DB 제약으로도 중복 실패`() {
+            val party = saveParty()
+            val wrapper = saveWrapper()
+            saveRollingPaper(party, wrapper, "abc")
+            val participant = participantRepository.save(Participant(party = party))
+
+            assertFailsWith<DataIntegrityViolationException> {
+                rollingPaperRepository.saveAndFlush(
+                    RollingPaper(
+                        wrapper = wrapper,
+                        writer = participant,
+                        party = party,
+                        writerNickname = "ABC",
+                        content = "다른 내용",
+                    ),
+                )
+            }
         }
 
         @Test

--- a/src/test/kotlin/com/team2/server/rollingpaper/controller/RollingPaperControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/rollingpaper/controller/RollingPaperControllerTest.kt
@@ -1,0 +1,344 @@
+package com.team2.server.rollingpaper.controller
+
+import com.team2.server.auth.config.JwtProperties
+import com.team2.server.auth.jwt.JwtTokenProvider
+import com.team2.server.party.entity.PaperOnlyParty
+import com.team2.server.party.entity.Participant
+import com.team2.server.party.entity.Party
+import com.team2.server.party.entity.PartyInvite
+import com.team2.server.party.repository.ParticipantRepository
+import com.team2.server.party.repository.PartyInviteRepository
+import com.team2.server.party.repository.PartyRepository
+import com.team2.server.rollingpaper.entity.RollingPaper
+import com.team2.server.rollingpaper.entity.RollingPaperWrapper
+import com.team2.server.rollingpaper.repository.RollingPaperRepository
+import com.team2.server.rollingpaper.repository.RollingPaperWrapperRepository
+import com.team2.server.user.entity.AuthProvider
+import com.team2.server.user.entity.User
+import com.team2.server.user.repository.UserRepository
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.post
+import java.time.LocalDateTime
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class RollingPaperControllerTest
+    @Autowired
+    constructor(
+        private val mockMvc: MockMvc,
+        private val rollingPaperRepository: RollingPaperRepository,
+        private val rollingPaperWrapperRepository: RollingPaperWrapperRepository,
+        private val partyInviteRepository: PartyInviteRepository,
+        private val participantRepository: ParticipantRepository,
+        private val partyRepository: PartyRepository,
+        private val userRepository: UserRepository,
+        private val jwtProperties: JwtProperties,
+    ) {
+        private val tokenProvider = JwtTokenProvider(jwtProperties)
+
+        @BeforeEach
+        fun setUp() {
+            rollingPaperRepository.deleteAll()
+            partyInviteRepository.deleteAll()
+            participantRepository.deleteAll()
+            partyRepository.deleteAll()
+            userRepository.deleteAll()
+            rollingPaperWrapperRepository.deleteAll()
+        }
+
+        @Test
+        fun `인증 없이 롤링페이퍼 작성 성공`() {
+            val party = saveParty()
+            val invite = saveInvite(party, "guestwrite000001")
+            val wrapper = saveWrapper()
+
+            mockMvc
+                .post("/api/v1/party-invites/${invite.token}/rolling-papers") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = requestBody("축하요정", "생일 축하해!", wrapper.id)
+                }.andExpect {
+                    status { isCreated() }
+                    jsonPath("$.status") { value(201) }
+                    jsonPath("$.data.rollingPaperId") { exists() }
+                }
+
+            val rollingPaper = rollingPaperRepository.findAll().single()
+            assertEquals("축하요정", rollingPaper.writerNickname)
+            assertEquals("생일 축하해!", rollingPaper.content)
+            assertTrue(participantRepository.findAll().single().hasWrittenPaper)
+        }
+
+        @Test
+        fun `인증 회원 롤링페이퍼 작성 성공`() {
+            val user = saveUser("member-write")
+            val party = saveParty(ownerId = user.id)
+            val invite = saveInvite(party, "memberwrite0001")
+            val wrapper = saveWrapper()
+            val token = tokenProvider.issue(user)
+
+            mockMvc
+                .post("/api/v1/party-invites/${invite.token}/rolling-papers") {
+                    header("Authorization", "Bearer $token")
+                    contentType = MediaType.APPLICATION_JSON
+                    content = requestBody("회원작성자", "축하해요", wrapper.id)
+                }.andExpect {
+                    status { isCreated() }
+                    jsonPath("$.data.rollingPaperId") { exists() }
+                }
+
+            val participant = assertNotNull(participantRepository.findByPartyAndUser(party, user))
+            assertTrue(participant.hasWrittenPaper)
+        }
+
+        @Test
+        fun `주최자 participant도 롤링페이퍼 작성 성공`() {
+            val user = saveUser("host-write")
+            val party = saveParty(ownerId = user.id)
+            participantRepository.save(Participant(party = party, user = user, isCelebrant = true))
+            val invite = saveInvite(party, "hostwrite000001")
+            val wrapper = saveWrapper()
+            val token = tokenProvider.issue(user)
+
+            mockMvc
+                .post("/api/v1/party-invites/${invite.token}/rolling-papers") {
+                    header("Authorization", "Bearer $token")
+                    contentType = MediaType.APPLICATION_JSON
+                    content = requestBody("주인공", "나도 축하", wrapper.id)
+                }.andExpect {
+                    status { isCreated() }
+                }
+        }
+
+        @Test
+        fun `닉네임과 내용은 trim 후 저장`() {
+            val party = saveParty()
+            val invite = saveInvite(party, "trimwrite000001")
+            val wrapper = saveWrapper()
+
+            mockMvc
+                .post("/api/v1/party-invites/${invite.token}/rolling-papers") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = requestBody("  축하요정  ", "  생일 축하해!  ", wrapper.id)
+                }.andExpect {
+                    status { isCreated() }
+                }
+
+            val rollingPaper = rollingPaperRepository.findAll().single()
+            assertEquals("축하요정", rollingPaper.writerNickname)
+            assertEquals("생일 축하해!", rollingPaper.content)
+        }
+
+        @Test
+        fun `같은 파티 같은 닉네임은 중복 실패`() {
+            val party = saveParty()
+            val invite = saveInvite(party, "dupwrite0000001")
+            val wrapper = saveWrapper()
+            saveRollingPaper(party, wrapper, "축하요정")
+
+            mockMvc
+                .post("/api/v1/party-invites/${invite.token}/rolling-papers") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = requestBody("축하요정", "다른 내용", wrapper.id)
+                }.andExpect {
+                    status { isConflict() }
+                    jsonPath("$.error.code") { value("ROLLING_PAPER_NICKNAME_DUPLICATED") }
+                }
+        }
+
+        @Test
+        fun `대소문자만 다른 닉네임은 작성 성공`() {
+            val party = saveParty()
+            val invite = saveInvite(party, "casewrite000001")
+            val wrapper = saveWrapper()
+            saveRollingPaper(party, wrapper, "abc")
+
+            mockMvc
+                .post("/api/v1/party-invites/${invite.token}/rolling-papers") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = requestBody("ABC", "다른 내용", wrapper.id)
+                }.andExpect {
+                    status { isCreated() }
+                }
+        }
+
+        @Test
+        fun `회원 participant가 이미 작성했으면 실패`() {
+            val user = saveUser("already-write")
+            val party = saveParty(ownerId = user.id)
+            participantRepository.save(Participant(party = party, user = user, hasWrittenPaper = true))
+            val invite = saveInvite(party, "alreadywrite001")
+            val wrapper = saveWrapper()
+            val token = tokenProvider.issue(user)
+
+            mockMvc
+                .post("/api/v1/party-invites/${invite.token}/rolling-papers") {
+                    header("Authorization", "Bearer $token")
+                    contentType = MediaType.APPLICATION_JSON
+                    content = requestBody("이미작성", "축하해요", wrapper.id)
+                }.andExpect {
+                    status { isConflict() }
+                    jsonPath("$.error.code") { value("ROLLING_PAPER_ALREADY_WRITTEN") }
+                }
+        }
+
+        @Test
+        fun `요청 validation 실패`() {
+            val party = saveParty()
+            val invite = saveInvite(party, "invalidwrite001")
+
+            mockMvc
+                .post("/api/v1/party-invites/${invite.token}/rolling-papers") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = """{"writerNickname":"","content":"","wrapperId":null}"""
+                }.andExpect {
+                    status { isBadRequest() }
+                    jsonPath("$.error.code") { value("VALIDATION_ERROR") }
+                }
+        }
+
+        @Test
+        fun `없는 wrapperId면 실패`() {
+            val party = saveParty()
+            val invite = saveInvite(party, "missingwrap0001")
+
+            mockMvc
+                .post("/api/v1/party-invites/${invite.token}/rolling-papers") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = requestBody("축하요정", "생일 축하해!", 9999L)
+                }.andExpect {
+                    status { isNotFound() }
+                    jsonPath("$.error.code") { value("ROLLING_PAPER_WRAPPER_NOT_FOUND") }
+                }
+        }
+
+        @Test
+        fun `만료된 초대 토큰이면 실패`() {
+            val party = saveParty()
+            val invite = saveInvite(party, "expiredwrite001", LocalDateTime.now().minusMinutes(1))
+            val wrapper = saveWrapper()
+
+            mockMvc
+                .post("/api/v1/party-invites/${invite.token}/rolling-papers") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = requestBody("축하요정", "생일 축하해!", wrapper.id)
+                }.andExpect {
+                    status { isBadRequest() }
+                    jsonPath("$.error.code") { value("INVITE_LINK_EXPIRED") }
+                }
+        }
+
+        @Test
+        fun `생성 후 7일 지난 파티면 실패`() {
+            val party = saveParty(createdAt = LocalDateTime.now().minusDays(8))
+            val invite = saveInvite(party, "endedwrite00001")
+            val wrapper = saveWrapper()
+
+            mockMvc
+                .post("/api/v1/party-invites/${invite.token}/rolling-papers") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = requestBody("축하요정", "생일 축하해!", wrapper.id)
+                }.andExpect {
+                    status { isBadRequest() }
+                    jsonPath("$.error.code") { value("PARTY_ENDED") }
+                }
+        }
+
+        @Test
+        fun `잘못된 Bearer 토큰이면 공개 작성 API도 401`() {
+            val party = saveParty()
+            val invite = saveInvite(party, "invalidjwt00001")
+            val wrapper = saveWrapper()
+
+            mockMvc
+                .post("/api/v1/party-invites/${invite.token}/rolling-papers") {
+                    header("Authorization", "Bearer not-a-jwt")
+                    contentType = MediaType.APPLICATION_JSON
+                    content = requestBody("축하요정", "생일 축하해!", wrapper.id)
+                }.andExpect {
+                    status { isUnauthorized() }
+                    jsonPath("$.error.code") { value("AUTH_INVALID_TOKEN") }
+                }
+        }
+
+        private fun saveParty(
+            ownerId: Long = 1L,
+            createdAt: LocalDateTime = LocalDateTime.now().minusDays(1),
+        ): Party {
+            val saved =
+                partyRepository.saveAndFlush(
+                    PaperOnlyParty(
+                        ownerId = ownerId,
+                        celebrantNickname = "홍길동",
+                        startedAt = createdAt.toLocalDate().atStartOfDay(),
+                    ),
+                )
+            saved.createdAt = createdAt
+            return partyRepository.saveAndFlush(saved)
+        }
+
+        private fun saveInvite(
+            party: Party,
+            token: String,
+            expiresAt: LocalDateTime = LocalDateTime.now().plusDays(1),
+        ): PartyInvite =
+            partyInviteRepository.save(
+                PartyInvite(
+                    party = party,
+                    token = token,
+                    expiresAt = expiresAt,
+                ),
+            )
+
+        private fun saveWrapper(): RollingPaperWrapper =
+            rollingPaperWrapperRepository.save(RollingPaperWrapper(name = "Topping_Candle"))
+
+        private fun saveRollingPaper(
+            party: Party,
+            wrapper: RollingPaperWrapper,
+            writerNickname: String,
+        ): RollingPaper {
+            val participant = participantRepository.save(Participant(party = party, hasWrittenPaper = true))
+            return rollingPaperRepository.save(
+                RollingPaper(
+                    wrapper = wrapper,
+                    writer = participant,
+                    party = party,
+                    writerNickname = writerNickname,
+                    content = "이미 작성한 내용",
+                ),
+            )
+        }
+
+        private fun saveUser(providerId: String): User =
+            userRepository.save(
+                User(
+                    name = "작성자",
+                    birthDay = "01-01",
+                    provider = AuthProvider.KAKAO,
+                    providerId = providerId,
+                    email = "$providerId@kakao.local",
+                ),
+            )
+
+        private fun requestBody(
+            writerNickname: String,
+            content: String,
+            wrapperId: Long,
+        ): String =
+            """
+            {
+              "writerNickname": "$writerNickname",
+              "content": "$content",
+              "wrapperId": $wrapperId
+            }
+            """.trimIndent()
+    }

--- a/src/test/kotlin/com/team2/server/rollingpaper/controller/RollingPaperControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/rollingpaper/controller/RollingPaperControllerTest.kt
@@ -154,6 +154,8 @@ class RollingPaperControllerTest
                     status { isConflict() }
                     jsonPath("$.error.code") { value("ROLLING_PAPER_NICKNAME_DUPLICATED") }
                 }
+
+            assertEquals(1, participantRepository.count())
         }
 
         @Test

--- a/src/test/kotlin/com/team2/server/rollingpaper/controller/RollingPaperWrapperControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/rollingpaper/controller/RollingPaperWrapperControllerTest.kt
@@ -5,6 +5,7 @@ import com.team2.server.common.entity.ImageTargetType
 import com.team2.server.common.repository.ImageRepository
 import com.team2.server.party.repository.ParticipantRepository
 import com.team2.server.rollingpaper.entity.RollingPaperWrapper
+import com.team2.server.rollingpaper.repository.RollingPaperRepository
 import com.team2.server.rollingpaper.repository.RollingPaperWrapperRepository
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -21,11 +22,13 @@ class RollingPaperWrapperControllerTest
     constructor(
         private val mockMvc: MockMvc,
         private val rollingPaperWrapperRepository: RollingPaperWrapperRepository,
+        private val rollingPaperRepository: RollingPaperRepository,
         private val participantRepository: ParticipantRepository,
         private val imageRepository: ImageRepository,
     ) {
         @BeforeEach
         fun setUp() {
+            rollingPaperRepository.deleteAll()
             participantRepository.deleteAll()
             imageRepository.deleteAll()
             rollingPaperWrapperRepository.deleteAll()

--- a/src/test/kotlin/com/team2/server/rollingpaper/dto/CreateRollingPaperRequestTest.kt
+++ b/src/test/kotlin/com/team2/server/rollingpaper/dto/CreateRollingPaperRequestTest.kt
@@ -1,0 +1,74 @@
+package com.team2.server.rollingpaper.dto
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class CreateRollingPaperRequestTest {
+    @Test
+    fun `작성자 닉네임과 내용은 trim해서 반환한다`() {
+        val request =
+            CreateRollingPaperRequest(
+                writerNickname = "  축하요정  ",
+                content = "  생일 축하해!  ",
+                wrapperId = 1L,
+            )
+
+        assertEquals("축하요정", request.trimmedWriterNickname())
+        assertEquals("생일 축하해!", request.trimmedContent())
+    }
+
+    @Test
+    fun `wrapperId는 필수 값으로 반환한다`() {
+        val request =
+            CreateRollingPaperRequest(
+                writerNickname = "축하요정",
+                content = "생일 축하해!",
+                wrapperId = 10L,
+            )
+
+        assertEquals(10L, request.requiredWrapperId())
+    }
+
+    @Test
+    fun `작성자 닉네임이 null이면 trim 반환에 실패한다`() {
+        val request =
+            CreateRollingPaperRequest(
+                writerNickname = null,
+                content = "생일 축하해!",
+                wrapperId = 1L,
+            )
+
+        assertFailsWith<IllegalArgumentException> {
+            request.trimmedWriterNickname()
+        }
+    }
+
+    @Test
+    fun `내용이 null이면 trim 반환에 실패한다`() {
+        val request =
+            CreateRollingPaperRequest(
+                writerNickname = "축하요정",
+                content = null,
+                wrapperId = 1L,
+            )
+
+        assertFailsWith<IllegalArgumentException> {
+            request.trimmedContent()
+        }
+    }
+
+    @Test
+    fun `wrapperId가 null이면 필수 값 반환에 실패한다`() {
+        val request =
+            CreateRollingPaperRequest(
+                writerNickname = "축하요정",
+                content = "생일 축하해!",
+                wrapperId = null,
+            )
+
+        assertFailsWith<IllegalArgumentException> {
+            request.requiredWrapperId()
+        }
+    }
+}

--- a/src/test/kotlin/com/team2/server/rollingpaper/entity/RollingPaperDomainTest.kt
+++ b/src/test/kotlin/com/team2/server/rollingpaper/entity/RollingPaperDomainTest.kt
@@ -67,7 +67,7 @@ class RollingPaperDomainTest {
     }
 
     @Test
-    fun `작성자 닉네임 정규화 키는 생성 시점 닉네임 기준으로 저장된다`() {
+    fun `작성자 닉네임은 trim 후 정규화 키와 함께 저장된다`() {
         val party = newParty()
         val rollingPaper =
             RollingPaper(
@@ -78,7 +78,7 @@ class RollingPaperDomainTest {
                 content = "축하해요",
             )
 
-        assertEquals(" ABC ", rollingPaper.writerNickname)
+        assertEquals("ABC", rollingPaper.writerNickname)
         assertEquals("abc", rollingPaper.writerNicknameKey)
     }
 

--- a/src/test/kotlin/com/team2/server/rollingpaper/entity/RollingPaperDomainTest.kt
+++ b/src/test/kotlin/com/team2/server/rollingpaper/entity/RollingPaperDomainTest.kt
@@ -7,13 +7,12 @@ import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class RollingPaperDomainTest {
     @Test
-    fun `롤링페이퍼는 기본 작성자 닉네임과 읽음 상태를 가진다`() {
+    fun `롤링페이퍼는 작성자 닉네임과 읽음 상태를 가진다`() {
         val party = newParty()
         val writer = Participant(party = party)
         val wrapper = RollingPaperWrapper(name = "기본테마")
@@ -22,13 +21,14 @@ class RollingPaperDomainTest {
                 wrapper = wrapper,
                 writer = writer,
                 party = party,
+                writerNickname = "작성자",
                 content = "축하해요",
             )
 
         assertSame(wrapper, rollingPaper.wrapper)
         assertSame(writer, rollingPaper.writer)
         assertSame(party, rollingPaper.party)
-        assertNull(rollingPaper.writerNickname)
+        assertEquals("작성자", rollingPaper.writerNickname)
         assertEquals("축하해요", rollingPaper.content)
         assertFalse(rollingPaper.isRead)
     }

--- a/src/test/kotlin/com/team2/server/rollingpaper/entity/RollingPaperDomainTest.kt
+++ b/src/test/kotlin/com/team2/server/rollingpaper/entity/RollingPaperDomainTest.kt
@@ -29,12 +29,13 @@ class RollingPaperDomainTest {
         assertSame(writer, rollingPaper.writer)
         assertSame(party, rollingPaper.party)
         assertEquals("작성자", rollingPaper.writerNickname)
+        assertEquals("작성자", rollingPaper.writerNicknameKey)
         assertEquals("축하해요", rollingPaper.content)
         assertFalse(rollingPaper.isRead)
     }
 
     @Test
-    fun `롤링페이퍼 작성 정보는 변경할 수 있다`() {
+    fun `롤링페이퍼 작성 정보는 닉네임 스냅샷을 제외하고 변경할 수 있다`() {
         val originalParty = newParty()
         val changedParty = newParty()
         val originalWriter = Participant(party = originalParty)
@@ -53,16 +54,32 @@ class RollingPaperDomainTest {
         rollingPaper.wrapper = changedWrapper
         rollingPaper.writer = changedWriter
         rollingPaper.party = changedParty
-        rollingPaper.writerNickname = "변경작성자"
         rollingPaper.content = "다시 축하해요"
         rollingPaper.isRead = true
 
         assertSame(changedWrapper, rollingPaper.wrapper)
         assertSame(changedWriter, rollingPaper.writer)
         assertSame(changedParty, rollingPaper.party)
-        assertEquals("변경작성자", rollingPaper.writerNickname)
+        assertEquals("작성자", rollingPaper.writerNickname)
+        assertEquals("작성자", rollingPaper.writerNicknameKey)
         assertEquals("다시 축하해요", rollingPaper.content)
         assertTrue(rollingPaper.isRead)
+    }
+
+    @Test
+    fun `작성자 닉네임 정규화 키는 생성 시점 닉네임 기준으로 저장된다`() {
+        val party = newParty()
+        val rollingPaper =
+            RollingPaper(
+                wrapper = RollingPaperWrapper(name = "기본테마"),
+                writer = Participant(party = party),
+                party = party,
+                writerNickname = " ABC ",
+                content = "축하해요",
+            )
+
+        assertEquals(" ABC ", rollingPaper.writerNickname)
+        assertEquals("abc", rollingPaper.writerNicknameKey)
     }
 
     private fun newParty(): Party =


### PR DESCRIPTION
## 🔗 Issue
- closes #96

## 💬 Context
초대 토큰으로 롤링페이퍼를 작성하는 공개 API를 추가합니다. 비회원은 새 participant로 작성하고, 회원은 기존 participant를 재사용하거나 생성합니다.

닉네임 중복은 대소문자 무시하여 writer_nickname_key 정규화 컬럼과 DB unique constraint로 동시 요청까지 방어합니다. 작성 가능 시간은 초대 토큰 유효성과 파티 생성 후 7일 기준을 함께 확인합니다.

## 🛠 Changes
- 롤링페이퍼 작성 요청/응답 DTO와 POST /api/v1/party-invites/{inviteToken}/rolling-papers API 추가
- writer_nickname, writer_nickname_key, wrapper_id, writer_participant_id 제약을 반영한 RollingPaper 도메인 변경
- 회원/비회원 participant 생성, 작성 여부 갱신, 닉네임 중복, 이미 작성 예외 처리 추가
- DB unique constraint 위반을 롤링페이퍼 도메인 에러로 변환
- 공개 작성 API SecurityConfig allowlist 및 Swagger 오류 예시 보강
- 롤링페이퍼 작성 테스트와 설계/계획 문서 갱신

## 👀 Review Focus
- writer_nickname_key 기반 대소문자 무시 닉네임 중복 정책이 기획 의도와 맞는지
- 회원 participant 재사용/비회원 participant 신규 생성 흐름이 기대 동작과 맞는지
- 공개 API에서 Authorization header가 있으면 유효한 JWT여야 하는 정책이 프론트 계약과 맞는지

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

## Local Verification
- [x] ./gradlew test --tests com.team2.server.rollingpaper.controller.RollingPaperWrapperControllerTest --tests com.team2.server.rollingpaper.controller.RollingPaperControllerTest --tests com.team2.server.rollingpaper.service.DefaultRollingPaperWrapperInitializerTest --tests com.team2.server.party.service.PartyInviteServiceTest
- [x] ./gradlew test
- [x] ./gradlew ktlintCheck
- [x] git status --short
- [x] git diff --stat

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 롤링페이퍼 작성 API 및 관련 공개 작성 흐름 추가 (초대 링크로 인증 없이 작성 가능)

* **개선사항**
  * 작성자 닉네임 중복 판정을 대소문자 구분 없이 처리하도록 변경
  * 닉네임/내용 앞뒤 공백 자동 제거 및 길이/유효성 검증 강화
  * 중복 판정에 따른 DB 제약 및 오류 응답 정비

* **테스트**
  * 대소문자 포함 중복, 인증/유효성, 공개 작성 및 OpenAPI 보안 동작 검증 통합·단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->