### PR TITLE
[Fix] Claude Code Review 설치 경로 오류 수정

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Prepare Claude Code install directory
+        run: mkdir -p "$HOME/.local/bin"
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
## 🔗 Issue
- closes #99

## 💬 Context
Claude Code Review 액션에서 Claude CLI 설치 경로인 `/home/runner/.local/bin/claude`를 찾지 못해 plugin marketplace 추가 단계가 실패했습니다.

## 🛠 Changes
- Claude Code Review 워크플로 실행 전 `/Users/goorm/.local/bin` 디렉터리 생성 step 추가

## 👀 Review Focus
- GitHub Actions runner에서 Claude Code 설치 경로 준비 방식이 적절한지

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [ ] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견