### PR TITLE
[Feat] 롤링페이퍼 목록 조회 API 추가

### DIFF
--- a/docs/superpowers/plans/2026-05-06-rolling-paper-list.md
+++ b/docs/superpowers/plans/2026-05-06-rolling-paper-list.md
@@ -79,7 +79,8 @@ Response data:
    - `Party.hostViewableAt()`을 하위 타입별로 구현한다.
    - `Party.canHostViewRollingPapers(now)`는 `now == hostViewableAt()`을 열람 가능으로 본다.
    - `RealtimeParty.hostViewableAt()`은 `startedAt + LIVE_DURATION_MINUTES`다.
-   - `PaperOnlyParty.hostViewableAt()`은 `startedAt.toLocalDate().atTime(22, 0)`이다.
+   - `PaperOnlyParty.hostViewableAt()`은 `startedAt` 날짜의 22:00이다.
+   - 단, `startedAt`이 해당 날짜 22:00 이상이면 다음날 22:00으로 계산한다.
 
 2. 시간 계산 정책을 적용한다.
    - 프로젝트 기존 스타일에 맞춰 별도 `Clock` bean은 추가하지 않는다.

--- a/docs/superpowers/plans/2026-05-06-rolling-paper-list.md
+++ b/docs/superpowers/plans/2026-05-06-rolling-paper-list.md
@@ -86,8 +86,7 @@ Response data:
    - 목록 UseCase는 열람 검증 시점에 `LocalDateTime.now()`를 사용한다.
 
 3. 목록 조회 기반을 추가한다.
-   - `RollingPaperRepository.countByParty(...)`를 추가한다.
-   - `RollingPaperRepository.findAllByParty(..., Pageable)`을 추가한다.
+   - `RollingPaperRepository.findAllByParty(..., Pageable): Page<RollingPaper>`를 추가한다.
    - 정렬은 `createdAt DESC, id DESC`, 페이지 크기는 7로 고정한다.
    - `page < 1`은 1로 보정한다.
    - `totalCount = 0`이면 `totalPages = 0`, `items = []`, `hasNext = false`다.

--- a/docs/superpowers/plans/2026-05-06-rolling-paper-list.md
+++ b/docs/superpowers/plans/2026-05-06-rolling-paper-list.md
@@ -1,0 +1,139 @@
+# Rolling Paper List API Implementation Plan
+
+## Summary
+
+롤링페이퍼 목록 조회 API를 참가자용과 주최자용으로 분리해 추가한다.
+
+- 참가자용은 초대 토큰 기반 공개 조회다.
+- 주최자용은 인증된 파티 소유자만 조회할 수 있다.
+- 두 API는 공통 목록 item을 사용한다.
+- 목록은 표준 page 기반 페이지네이션으로 조회하고, 응답 시각은 기존 API와 맞춰 KST 기준 `LocalDateTime` 문자열을 유지한다.
+
+Spec: `docs/superpowers/specs/2026-05-05-rolling-paper-list-design.md`
+
+## API Contract
+
+### Participant List
+
+`GET /api/v1/party-invites/{inviteToken}/rolling-papers?page=1`
+
+- 인증 없이 조회할 수 있다.
+- 유효한 Bearer token이 있으면 인증 사용자로 통과한다.
+- 잘못된 Bearer token이면 `AUTH_INVALID_TOKEN`, 401로 응답한다.
+- 초대 토큰이 없으면 `PARTY_NOT_FOUND`, 404로 응답한다.
+- 초대 토큰 만료 여부와 파티 자체 종료 여부는 목록 조회를 막지 않는다.
+- `PAPER_ONLY`는 `liveEndAt = null`로 응답한다.
+- 참가자 응답에는 `totalCount`, `pageSize`, `partyEndAt`을 포함하지 않는다.
+
+Response data:
+
+```json
+{
+  "partyOption": "REALTIME",
+  "liveEndAt": "2026-05-05T22:10:00",
+  "page": 1,
+  "totalPages": 2,
+  "hasNext": true,
+  "items": [
+    {
+      "rollingPaperId": 10,
+      "writerNickname": "축하요정",
+      "wrapperImageUrl": "/images/rolling-paper-wrappers/Topping_Candle.svg"
+    }
+  ]
+}
+```
+
+### Owner List
+
+`GET /api/v1/parties/{partyId}/rolling-papers?page=1`
+
+- 인증 필수다.
+- `party.ownerId == principal.userId`가 아니면 `PARTY_FORBIDDEN`, 403으로 응답한다.
+- 주최자 열람 가능 시각 전이면 `ROLLING_PAPER_NOT_VIEWABLE`, 403으로 응답한다.
+- `partyEndAt`은 `Party.endedAt()` 기준으로 응답한다.
+
+Response data:
+
+```json
+{
+  "celebrantNickname": "홍길동",
+  "partyEndAt": "2026-05-12T14:30:00",
+  "page": 1,
+  "totalCount": 8,
+  "totalPages": 2,
+  "hasNext": true,
+  "items": [
+    {
+      "rollingPaperId": 10,
+      "writerNickname": "축하요정",
+      "wrapperImageUrl": "/images/rolling-paper-wrappers/Topping_Candle.svg"
+    }
+  ]
+}
+```
+
+## Implementation Steps
+
+1. 도메인 시간 정책을 정리한다.
+   - `Party.hostViewableAt()`을 하위 타입별로 구현한다.
+   - `Party.canHostViewRollingPapers(now)`는 `now == hostViewableAt()`을 열람 가능으로 본다.
+   - `RealtimeParty.hostViewableAt()`은 `startedAt + LIVE_DURATION_MINUTES`다.
+   - `PaperOnlyParty.hostViewableAt()`은 `startedAt.toLocalDate().atTime(22, 0)`이다.
+
+2. 시간 계산 정책을 적용한다.
+   - 프로젝트 기존 스타일에 맞춰 별도 `Clock` bean은 추가하지 않는다.
+   - 목록 UseCase는 열람 검증 시점에 `LocalDateTime.now()`를 사용한다.
+
+3. 목록 조회 기반을 추가한다.
+   - `RollingPaperRepository.countByParty(...)`를 추가한다.
+   - `RollingPaperRepository.findAllByParty(..., Pageable)`을 추가한다.
+   - 정렬은 `createdAt DESC, id DESC`, 페이지 크기는 7로 고정한다.
+   - `page < 1`은 1로 보정한다.
+   - `totalCount = 0`이면 `totalPages = 0`, `items = []`, `hasNext = false`다.
+   - `page > totalPages`이면 요청 page를 유지하고 `items = []`, `hasNext = false`다.
+   - wrapper 이미지는 bulk 조회 후 `sortOrder ASC` 첫 번째 이미지를 매핑한다.
+
+4. DTO, UseCase, Controller를 추가한다.
+   - 참가자용 GET 경로는 `SecurityConfig`에 method/path-specific `permitAll`로 추가한다.
+   - 주최자용 GET 경로는 기본 authenticated 정책을 사용한다.
+   - Swagger에는 200, 401, 403, 404, 500과 주요 ErrorCode 예시를 명시한다.
+
+## Test Plan
+
+- 참가자용 목록
+  - 인증 없이 조회 성공
+  - 유효 Bearer token 포함 조회 성공
+  - invalid Bearer token 401
+  - 없는 inviteToken 404
+  - `REALTIME`이면 `liveEndAt = startedAt + LIVE_DURATION_MINUTES`
+  - `PAPER_ONLY`이면 `liveEndAt = null`
+  - 파티 자체 종료 후에도 조회 성공
+  - `totalCount`는 응답하지 않음
+
+- 주최자용 목록
+  - 소유자 조회 성공
+  - 소유자가 아니면 403 `PARTY_FORBIDDEN`
+  - 열람 가능 전이면 403 `ROLLING_PAPER_NOT_VIEWABLE`
+  - `now == hostViewableAt()`이면 조회 성공
+  - `PAPER_ONLY`는 22:00 기준 열람 가능
+  - `REALTIME`은 live 종료 시각 기준 열람 가능
+  - `celebrantNickname`, `partyEndAt`, `totalCount`, `totalPages` 응답 확인
+
+- 공통 목록/페이지네이션
+  - 최신순 `createdAt DESC, id DESC`
+  - 7개 고정 페이지
+  - `page < 1`은 1로 보정
+  - 빈 목록: `totalPages = 0`, `items = []`
+  - 초과 페이지: 요청 page 유지, `items = []`, `hasNext = false`
+  - wrapper 이미지는 bulk 조회 결과 중 `sortOrder ASC` 첫 번째 URL 사용
+  - 이미지 없으면 `wrapperImageUrl = null`
+
+## Verification
+
+```bash
+./gradlew test --tests com.team2.server.rollingpaper.controller.RollingPaperListControllerTest
+./gradlew test --tests com.team2.server.party.entity.PartyStatusTest
+./gradlew test
+./gradlew ktlintCheck
+```

--- a/docs/superpowers/specs/2026-05-05-rolling-paper-list-design.md
+++ b/docs/superpowers/specs/2026-05-05-rolling-paper-list-design.md
@@ -262,7 +262,8 @@ fun canHostViewRollingPapers(now: LocalDateTime): Boolean =
 RealtimeParty.hostViewableAt() = startedAt + RealtimeParty.LIVE_DURATION_MINUTES
 ```
 
-롤링페이퍼 전용 파티 공개 시각은 `startedAt.toLocalDate().atTime(22, 0)`으로 계산한다.
+롤링페이퍼 전용 파티 공개 시각은 기본적으로 `startedAt` 날짜의 22:00으로 계산한다.
+단, `startedAt`이 해당 날짜 22:00 이상이면 이미 공개 기준 시각을 지난 상태이므로 다음날 22:00으로 계산한다.
 
 현재 코드:
 
@@ -279,12 +280,15 @@ RealtimeParty.hostViewableAt() = startedAt + RealtimeParty.LIVE_DURATION_MINUTES
 
 - `startedAt`은 기존 생성 계약대로 00:00을 유지한다.
 - `PaperOnlyParty.status()`의 `OPEN`은 파티 open 상태이므로 주최자 롤링페이퍼 열람 가능 여부로 재사용하지 않는다.
-- `PaperOnlyParty.hostViewableAt()`은 `startedAt.toLocalDate().atTime(22, 0)`을 반환한다.
+- `PaperOnlyParty.hostViewableAt()`은 `startedAt` 날짜의 22:00을 반환한다.
+- `startedAt`이 해당 날짜 22:00 이상이면 다음날 22:00을 반환한다.
 - 주최자 목록 API는 `Party.canHostViewRollingPapers(now)`만 사용해 열람 가능 여부를 검증한다.
 
 ```kotlin
 override fun hostViewableAt(): LocalDateTime =
-    startedAt.toLocalDate().atTime(22, 0)
+    startedAt.toLocalDate().atTime(22, 0).let { targetTime ->
+        if (startedAt.isBefore(targetTime)) targetTime else targetTime.plusDays(1)
+    }
 ```
 
 향후 파티 open 상태와 롤링페이퍼 열람 상태가 더 많은 화면에서 함께 필요해지면, 파티 상태와 롤링페이퍼 열람 상태를 별도 도메인 개념으로 분리한다.

--- a/docs/superpowers/specs/2026-05-05-rolling-paper-list-design.md
+++ b/docs/superpowers/specs/2026-05-05-rolling-paper-list-design.md
@@ -1,0 +1,450 @@
+# Rolling Paper List API Design
+
+- 작성일: 2026-05-05
+- 기준 브랜치: `feature/rolling-paper-list-api`
+- 목적: 롤링페이퍼 목록 리스트 조회 API의 참가자용/주최자용 계약과 화면 요구사항 정리
+- 구현 전 확인 상태: 이 문서는 구현 전 설계 확인용이며, 승인 전에는 Kotlin 코드를 변경하지 않는다.
+
+---
+
+## 1. 결정 요약
+
+롤링페이퍼 목록 조회 API는 참가자용과 주최자용을 분리한다.
+
+이유:
+
+- 참가자 화면은 초대 링크 기반 흐름이고, 주최자 화면은 인증된 파티 소유자 흐름이다.
+- 두 화면은 목록 카드 필드는 같지만, 열람 조건과 화면 메타가 다르다.
+- 주최자 화면은 아직 열람 가능 시간이 아니면 예외로 처리하는 편이 자연스럽다.
+- `isOwner`, `viewerRole` 같은 분기 필드를 하나의 응답에 섞지 않아도 된다.
+
+목록 item 응답은 두 API에서 공통으로 사용한다.
+
+공통 item:
+
+- `rollingPaperId`
+- `writerNickname`
+- `wrapperImageUrl`
+
+정렬과 페이지네이션도 두 API가 같은 규칙을 사용한다.
+
+- 최신순
+- 한 페이지 기준 7개
+- 표준 페이지네이션을 사용한다.
+
+---
+
+## 2. 사용자 흐름
+
+### 2-1. 참가자용 목록
+
+1. 사용자가 초대 링크로 진입한다.
+2. 사용자가 롤링페이퍼를 작성하거나, 이미 작성한 이후 받은 롤링페이퍼 목록 화면으로 이동한다.
+3. 프론트는 `inviteToken`으로 참가자용 목록 API를 호출한다.
+4. 프론트는 목록 item을 최신순으로 렌더링한다.
+
+참가자용 화면에서는 파티 자체 종료 후에도 롤링페이퍼 조회를 허용한다.
+다만 이 정책은 확정 요구사항이 바뀌면 조정될 수 있다.
+
+이유:
+
+- 현재 파티 상태 문서 기준으로 파티 종료 후에는 작성은 불가능하지만 조회는 가능하다.
+- 파티 종료 후 목록까지 막으면 사용자가 받은 롤링페이퍼를 다시 볼 수 없는 정책이 된다.
+
+### 2-2. 주최자용 목록
+
+1. 주최자가 파티 상세 또는 생성 후 관리 화면에서 롤링페이퍼 목록 화면으로 진입한다.
+2. 프론트는 인증 토큰과 `partyId`로 주최자용 목록 API를 호출한다.
+3. 서버는 현재 사용자가 해당 파티의 소유자인지 검증한다.
+4. 서버는 주최자가 롤링페이퍼를 열람할 수 있는 시점인지 검증한다.
+5. 열람 가능하면 목록과 `partyEndAt`을 내려준다.
+6. 열람 불가하면 예외로 응답한다.
+
+주최자용 화면의 공유하기 버튼은 목록 API에 포함하지 않는다.
+
+공유하기 버튼 클릭 시 기존 초대 링크 API를 별도로 호출한다.
+
+```http
+POST /api/v1/parties/{partyId}/invite-link
+```
+
+이 API는 현재 유효한 초대 토큰이 있으면 재사용하고, 없으면 새로 생성해 `token`을 반환한다.
+
+---
+
+## 3. API 계약
+
+아래 JSON 예시는 `ApiResponse.data` payload 기준이다.
+실제 HTTP 응답은 기존 컨트롤러 관례대로 공통 `ApiResponse`로 감싼다.
+
+### 3-1. 참가자용 목록 조회
+
+```http
+GET /api/v1/party-invites/{inviteToken}/rolling-papers?page=1
+```
+
+인증:
+
+- 공개 조회를 허용한다.
+- Authorization header가 없어도 조회 가능하다.
+- 유효한 Bearer token이 있으면 인증 사용자로 처리한다.
+- 잘못된 Bearer token은 `AUTH_INVALID_TOKEN`, 401로 처리한다.
+
+응답:
+
+```json
+{
+  "partyOption": "REALTIME",
+  "liveEndAt": "2026-05-05T22:10:00",
+  "page": 1,
+  "totalPages": 2,
+  "hasNext": true,
+  "items": [
+    {
+      "rollingPaperId": 10,
+      "writerNickname": "축하요정",
+      "wrapperImageUrl": "/images/rolling-paper-wrappers/Topping_Candle.svg"
+    }
+  ]
+}
+```
+
+`PAPER_ONLY` 응답:
+
+```json
+{
+  "partyOption": "PAPER_ONLY",
+  "liveEndAt": null,
+  "page": 1,
+  "totalPages": 2,
+  "hasNext": true,
+  "items": [
+    {
+      "rollingPaperId": 10,
+      "writerNickname": "축하요정",
+      "wrapperImageUrl": "/images/rolling-paper-wrappers/Topping_Candle.svg"
+    }
+  ]
+}
+```
+
+필드:
+
+| 필드 | 설명 |
+|---|---|
+| `partyOption` | `REALTIME`, `PAPER_ONLY`. `liveEndAt = null`의 의미를 명확히 하기 위해 유지한다. |
+| `liveEndAt` | 실시간 파티 종료 시각. `PAPER_ONLY`이면 `null`. |
+| `page` | 요청한 페이지 번호. 1부터 시작한다. |
+| `totalPages` | 페이지 번호 UI 계산용 전체 페이지 수. |
+| `hasNext` | 다음 페이지 존재 여부. |
+| `items` | 롤링페이퍼 카드 목록. |
+| `items[].rollingPaperId` | 롤링페이퍼 식별자. |
+| `items[].writerNickname` | 롤링페이퍼 작성 당시 닉네임 스냅샷. |
+| `items[].wrapperImageUrl` | 카드 렌더링용 래퍼 이미지 URL. 이미지가 없으면 `null`. |
+
+응답에서 제외하는 필드:
+
+| 제외 필드 | 제외 이유 |
+|---|---|
+| `totalCount` | 참가자 화면에서 총 개수를 표시하지 않는다. 서버는 `totalPages` 계산을 위해 내부적으로만 count를 사용한다. |
+| `pageSize` | 한 페이지 기준은 7개로 고정이므로 응답에 반복해서 내려주지 않는다. |
+| `partyEndAt` | 참가자용 목록 화면에서는 파티 자체 종료 시각을 표시하지 않는다. |
+
+참가자용은 실시간 파티 종료 여부 boolean 대신 `liveEndAt`을 내려준다.
+
+이유:
+
+- `liveEndAt`은 서버 응답 시점의 boolean보다 캐시와 시간 경과에 덜 취약하다.
+- 프론트는 화면 진입 시 한 번 현재 시각과 `liveEndAt`을 비교해 필요한 분기를 계산할 수 있다.
+- 기존 초대장 조회 API도 실시간 파티 종료 판단 기준으로 `realtimeSchedule.liveEndAt`을 내려준다.
+
+### 3-2. 주최자용 목록 조회
+
+```http
+GET /api/v1/parties/{partyId}/rolling-papers?page=1
+```
+
+인증:
+
+- 인증 필수.
+- `party.ownerId == principal.userId`가 아니면 403.
+- 주최자와 참가자 개념을 응답 boolean으로 섞지 않는다.
+
+응답:
+
+```json
+{
+  "celebrantNickname": "홍길동",
+  "partyEndAt": "2026-05-12T14:30:00",
+  "page": 1,
+  "totalCount": 8,
+  "totalPages": 2,
+  "hasNext": true,
+  "items": [
+    {
+      "rollingPaperId": 10,
+      "writerNickname": "축하요정",
+      "wrapperImageUrl": "/images/rolling-paper-wrappers/Topping_Candle.svg"
+    }
+  ]
+}
+```
+
+필드:
+
+| 필드 | 설명 |
+|---|---|
+| `celebrantNickname` | 파티 주인공 이름. 현재 `Party.celebrantNickname` 기준. |
+| `partyEndAt` | 파티 자체 종료 시각. `Party.endedAt()` 기준. |
+| `page` | 요청한 페이지 번호. 1부터 시작한다. |
+| `totalCount` | 주최자 화면에서 표시할 전체 롤링페이퍼 개수. |
+| `totalPages` | 페이지 번호 UI 계산용 전체 페이지 수. |
+| `hasNext` | 다음 페이지 존재 여부. |
+| `items` | 롤링페이퍼 카드 목록. |
+| `items[].rollingPaperId` | 롤링페이퍼 식별자. |
+| `items[].writerNickname` | 롤링페이퍼 작성 당시 닉네임 스냅샷. |
+| `items[].wrapperImageUrl` | 카드 렌더링용 래퍼 이미지 URL. 이미지가 없으면 `null`. |
+
+응답에서 제외하는 필드:
+
+| 제외 필드 | 제외 이유 |
+|---|---|
+| `partyOption` | 주최자 목록 화면의 응답 요구사항에는 필요하지 않다. 열람 가능 여부는 서버가 검증한다. |
+| `pageSize` | 한 페이지 기준은 7개로 고정이므로 응답에 반복해서 내려주지 않는다. |
+| `inviteToken`, `shareLink` | 공유하기 버튼 클릭 시 기존 초대 링크 API를 별도로 호출한다. |
+
+---
+
+## 4. 열람 조건
+
+### 4-1. 참가자용
+
+참가자용 목록은 파티 자체 종료 후에도 조회 가능하다.
+
+조회 가능 여부를 파티 종료 시각으로 막지 않는다.
+
+없는 초대 토큰이면 `PARTY_NOT_FOUND`를 반환한다.
+
+### 4-2. 주최자용
+
+주최자용 목록은 주최자가 롤링페이퍼를 열람할 수 있는 시점 이후에만 조회 가능하다.
+
+열람 가능 전이면 403 예외로 처리한다.
+
+```text
+ROLLING_PAPER_NOT_VIEWABLE
+```
+
+주최자 열람 가능 시점:
+
+| 파티 타입 | 조건 |
+|---|---|
+| `REALTIME` | 실시간 파티 종료 이후 |
+| `PAPER_ONLY` | 롤링페이퍼 전용 파티 공개 시각 이후 |
+
+`Party` 추상 타입에 주최자 열람 가능 시각과 검증 메서드를 둔다.
+
+```kotlin
+abstract fun hostViewableAt(): LocalDateTime
+
+fun canHostViewRollingPapers(now: LocalDateTime): Boolean =
+    !hostViewableAt().isAfter(now)
+```
+
+경계값은 inclusive로 처리한다. 즉 `now == hostViewableAt()`이면 열람 가능하다.
+
+동일 요청 안에서는 `now`를 한 번만 계산해 열람 검증과 응답 계산에 같은 값을 사용한다.
+구현 시 프로젝트 기존 스타일에 맞춰 별도 `Clock` bean은 추가하지 않고, 목록 UseCase에서 `LocalDateTime.now()`를 사용한다.
+
+실시간 파티 종료 시각:
+
+```text
+RealtimeParty.hostViewableAt() = startedAt + RealtimeParty.LIVE_DURATION_MINUTES
+```
+
+롤링페이퍼 전용 파티 공개 시각은 `startedAt.toLocalDate().atTime(22, 0)`으로 계산한다.
+
+현재 코드:
+
+- `PaperOnlyParty.startedAt = startedDate.atStartOfDay()`
+- `PaperOnlyParty.status()` 내부의 `openTime`은 현재 `startedAt`을 그대로 사용한다.
+- 이 `openTime`은 롤링페이퍼 전용 파티 자체가 열리는 시각이다.
+- 주최자가 받은 롤링페이퍼 목록을 열람할 수 있는 시각과는 별도 정책이다.
+
+기획 요구:
+
+- 롤링페이퍼 전용 파티는 생성 당일 밤 10시부터 주최자가 열람 가능
+
+결정:
+
+- `startedAt`은 기존 생성 계약대로 00:00을 유지한다.
+- `PaperOnlyParty.status()`의 `OPEN`은 파티 open 상태이므로 주최자 롤링페이퍼 열람 가능 여부로 재사용하지 않는다.
+- `PaperOnlyParty.hostViewableAt()`은 `startedAt.toLocalDate().atTime(22, 0)`을 반환한다.
+- 주최자 목록 API는 `Party.canHostViewRollingPapers(now)`만 사용해 열람 가능 여부를 검증한다.
+
+```kotlin
+override fun hostViewableAt(): LocalDateTime =
+    startedAt.toLocalDate().atTime(22, 0)
+```
+
+향후 파티 open 상태와 롤링페이퍼 열람 상태가 더 많은 화면에서 함께 필요해지면, 파티 상태와 롤링페이퍼 열람 상태를 별도 도메인 개념으로 분리한다.
+
+---
+
+## 5. 페이지네이션 규칙
+
+페이지 요청은 1부터 시작하고, `page`가 1보다 작으면 서버에서 1로 보정한다.
+한 페이지 기준 개수는 7개 고정이며, 정렬은 `createdAt DESC, id DESC`다.
+
+서버는 `totalPages` 계산을 위해 내부적으로 `totalCount`를 조회한다.
+참가자용 응답에는 `totalCount`를 내려주지 않고, 주최자용 응답에는 전체 개수 표시를 위해 `totalCount`를 내려준다.
+
+응답 invariant:
+
+- `totalCount = 0`이면 `totalPages = 0`, `hasNext = false`, `items = []`로 응답한다.
+- 빈 목록이어도 `page`는 보정된 요청 page를 그대로 응답한다.
+- `page > totalPages`이면 `page`는 요청값 그대로 응답하고, `items = []`, `hasNext = false`로 응답한다.
+- 서버는 상한 초과 page를 마지막 페이지로 보정하지 않는다.
+
+커서 기반 페이지네이션은 이번 API 계약에서는 사용하지 않는다.
+
+- 커서 방식은 새 롤링페이퍼가 계속 추가되는 피드에서 중복/누락을 줄이는 데 유리하다.
+- 하지만 이번 화면은 페이지 번호와 `totalPages`를 보여주므로, `1, 2, 3` 같은 임의 페이지 이동과 전체 페이지 수 표시가 가능한 page 기반 조회가 더 맞다.
+- 따라서 이번 목록은 표준 page 기반 조회를 사용한다.
+- 새 데이터 유입에 따른 offset 방식의 중복/누락 가능성은 남지만, 롤링페이퍼 목록은 파티 단위 목록이고 페이지 번호 UI가 필요하므로 이 tradeoff를 수용한다.
+
+---
+
+## 6. 시간 정책
+
+응답의 시간 필드는 KST 기준 `LocalDateTime` 문자열로 내려준다.
+
+예:
+
+```json
+{
+  "liveEndAt": "2026-05-05T22:10:00",
+  "partyEndAt": "2026-05-12T14:30:00"
+}
+```
+
+정책:
+
+- 서버와 클라이언트는 timezone offset이 없는 시간 문자열을 KST로 해석한다.
+- 이번 API는 기존 API의 `LocalDateTime` 직렬화 방식과 맞춘다.
+- 추후 시간 API를 전역 기준으로 정리할 경우 `OffsetDateTime(+09:00)` 또는 UTC `Instant`로 전환하는 것을 별도 과제로 다룬다.
+
+파티 자체 종료 시각은 `Party.endedAt()`을 사용한다.
+
+```text
+Party.endedAt() = Party.createdAt + Party.ENDED_AFTER_DAYS
+```
+
+`Party.ENDED_AFTER_DAYS`의 현재 값은 7일이다.
+
+---
+
+## 7. 이미지 URL 정책
+
+목록 item은 `wrapperImageUrl`을 내려준다.
+
+이유:
+
+- 목록 화면은 카드를 렌더링하는 화면이므로 프론트가 별도 래퍼 캐시를 강제하지 않는 편이 좋다.
+- 이미 래퍼 조회 API도 `wrapperId`, `wrapperImageUrl`을 내려주는 계약이다.
+- 작성 API는 `wrapperId`를 받고, 목록 API는 렌더링용 이미지 URL을 내려주는 역할 분리가 명확하다.
+
+조회 기준:
+
+```text
+image.target_type = ROLLING_PAPER_WRAPPER
+image.target_id = rolling_paper.wrapper_id
+sort_order ASC 첫 번째 이미지
+```
+
+래퍼 이미지가 없으면 `wrapperImageUrl = null`로 응답한다.
+
+구현 기준:
+
+- 페이지에 포함된 롤링페이퍼의 `wrapper_id` 목록을 모은다.
+- `ImageTargetType.ROLLING_PAPER_WRAPPER`와 `wrapper_id IN (...)` 조건으로 이미지를 한 번에 조회한다.
+- 같은 래퍼에 이미지가 여러 개 있으면 `sort_order ASC` 첫 번째 이미지만 사용한다.
+- 롤링페이퍼 item마다 이미지를 개별 조회하지 않는다.
+
+---
+
+## 8. ErrorCode
+
+추가 후보:
+
+```kotlin
+ROLLING_PAPER_NOT_VIEWABLE(HttpStatus.FORBIDDEN, "아직 롤링페이퍼를 확인할 수 없습니다")
+```
+
+기존 ErrorCode 재사용:
+
+| 상황 | ErrorCode | HTTP status |
+|---|---|---|
+| 초대 토큰 없음 | `PARTY_NOT_FOUND` | 404 |
+| 파티 없음 | `PARTY_NOT_FOUND` | 404 |
+| 주최자용 목록을 소유자가 아닌 사용자가 조회 | `PARTY_FORBIDDEN` | 403 |
+| 주최자용 목록 열람 가능 전 | `ROLLING_PAPER_NOT_VIEWABLE` | 403 |
+| invalid Bearer token | `AUTH_INVALID_TOKEN` | 401 |
+
+---
+
+## 9. 테스트 계획
+
+참가자용 목록:
+
+- 초대 토큰으로 목록 조회 성공
+- `partyOption`, `liveEndAt`, `page`, `totalPages`, `hasNext`, `items` 응답
+- `totalCount`는 응답하지 않음
+- `PAPER_ONLY`이면 `liveEndAt = null`
+- `REALTIME`이면 `liveEndAt = startedAt + RealtimeParty.LIVE_DURATION_MINUTES`
+- 파티 자체 종료 이후에도 목록 조회 성공. 단, 정책 변경 가능성이 있음을 문서에 남김
+- 없는 초대 토큰이면 404
+- invalid Bearer token이면 401
+
+주최자용 목록:
+
+- 파티 소유자가 목록 조회 성공
+- 파티 소유자가 아니면 403
+- 주최자 열람 가능 전이면 403 `ROLLING_PAPER_NOT_VIEWABLE`
+- 주최자 열람 가능 후이면 목록 조회 성공
+- `celebrantNickname`, `partyEndAt`, `page`, `totalCount`, `totalPages`, `hasNext`, `items` 응답
+- `PAPER_ONLY` 주최자 열람 가능 시각은 `PaperOnlyParty.hostViewableAt()` 기준
+- `REALTIME` 주최자 열람 가능 시각은 `RealtimeParty.hostViewableAt()` 기준
+- `now == hostViewableAt()`이면 열람 가능
+- 공유 링크 토큰이나 URL은 응답에 포함하지 않음
+
+공통 목록 item:
+
+- 최신순 정렬
+- 같은 `createdAt`이면 `id DESC` 정렬
+- `rollingPaperId`, `writerNickname`, `wrapperImageUrl` 응답
+- 이미지가 없으면 `wrapperImageUrl = null`
+- 여러 이미지가 있으면 `sort_order ASC` 첫 번째 이미지 사용
+- 래퍼 이미지는 `wrapper_id IN (...)`으로 bulk 조회해 N+1을 방지
+
+페이지네이션:
+
+- totalCount 0이면 `totalPages = 0`, `items = []`
+- totalCount 7이면 1페이지 7개
+- totalCount 8이면 1페이지 7개, 2페이지 1개
+- totalCount 14이면 1페이지 7개, 2페이지 7개
+- totalCount 15이면 1페이지 7개, 2페이지 7개, 3페이지 1개
+- `page`가 1보다 작으면 1페이지로 보정
+- 존재하지 않는 페이지 요청 시 `page`는 요청값 그대로, `items = []`, `hasNext = false`
+
+시간:
+
+- `liveEndAt`, `partyEndAt`은 KST 기준 `LocalDateTime` 문자열로 응답
+- `partyEndAt`은 `Party.endedAt()` 기준
+- 동일 요청 내 열람 검증과 응답 계산은 같은 `now` 값을 사용
+
+---
+
+## 10. 미확정 사항
+
+1. 참가자용 파티 자체 종료 후 조회 허용 정책은 현재 논의안이다. 기획 변경 시 종료 후 조회를 막을 수 있다.

--- a/src/main/kotlin/com/team2/server/auth/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/team2/server/auth/config/SecurityConfig.kt
@@ -50,6 +50,7 @@ class SecurityConfig(
                 auth.requestMatchers(HttpMethod.GET, "/api/v1/characters").permitAll()
                 auth.requestMatchers(HttpMethod.GET, "/api/v1/rolling-paper-wrappers").permitAll()
                 auth.requestMatchers(HttpMethod.GET, "/api/v1/party-invites/*").permitAll()
+                auth.requestMatchers(HttpMethod.GET, "/api/v1/party-invites/*/rolling-papers").permitAll()
                 auth.requestMatchers(HttpMethod.POST, "/api/v1/party-invites/*/rolling-papers").permitAll()
                 auth.requestMatchers(HttpMethod.GET, "/images/**").permitAll()
                 auth.anyRequest().authenticated()

--- a/src/main/kotlin/com/team2/server/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/team2/server/common/exception/ErrorCode.kt
@@ -29,4 +29,5 @@ enum class ErrorCode(
     ROLLING_PAPER_WRAPPER_NOT_FOUND(HttpStatus.NOT_FOUND, "롤링페이퍼 래퍼를 찾을 수 없습니다"),
     ROLLING_PAPER_NICKNAME_DUPLICATED(HttpStatus.CONFLICT, "이미 사용 중인 롤링페이퍼 닉네임입니다"),
     ROLLING_PAPER_ALREADY_WRITTEN(HttpStatus.CONFLICT, "이미 롤링페이퍼를 작성했습니다"),
+    ROLLING_PAPER_NOT_VIEWABLE(HttpStatus.FORBIDDEN, "아직 롤링페이퍼를 확인할 수 없습니다"),
 }

--- a/src/main/kotlin/com/team2/server/common/service/ImageQueryService.kt
+++ b/src/main/kotlin/com/team2/server/common/service/ImageQueryService.kt
@@ -1,0 +1,26 @@
+package com.team2.server.common.service
+
+import com.team2.server.common.entity.ImageTargetType
+import com.team2.server.common.repository.ImageRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class ImageQueryService(
+    private val imageRepository: ImageRepository,
+) {
+    @Transactional(readOnly = true)
+    fun findFirstImageUrlByTargetIds(
+        targetType: ImageTargetType,
+        targetIds: Collection<Long>,
+    ): Map<Long, String> {
+        if (targetIds.isEmpty()) {
+            return emptyMap()
+        }
+
+        return imageRepository
+            .findAllByTargetTypeAndTargetIdsOrderByTargetIdAndSortOrder(targetType, targetIds.distinct())
+            .distinctBy { it.targetId }
+            .associate { it.targetId to it.imageUrl }
+    }
+}

--- a/src/main/kotlin/com/team2/server/party/entity/PaperOnlyParty.kt
+++ b/src/main/kotlin/com/team2/server/party/entity/PaperOnlyParty.kt
@@ -17,7 +17,14 @@ class PaperOnlyParty(
 ) : Party(ownerId, name, celebrantNickname, startedAt, purpose) {
     override val partyOption: PartyOption get() = PartyOption.PAPER_ONLY
 
-    override fun hostViewableAt(): LocalDateTime = startedAt.toLocalDate().atTime(HOST_VIEWABLE_HOUR, 0)
+    override fun hostViewableAt(): LocalDateTime {
+        val targetTime = startedAt.toLocalDate().atTime(HOST_VIEWABLE_HOUR, 0)
+        return if (startedAt.isBefore(targetTime)) {
+            targetTime
+        } else {
+            targetTime.plusDays(1)
+        }
+    }
 
     fun status(now: LocalDateTime = LocalDateTime.now()): PaperOnlyPartyStatus {
         val openTime = startedAt

--- a/src/main/kotlin/com/team2/server/party/entity/PaperOnlyParty.kt
+++ b/src/main/kotlin/com/team2/server/party/entity/PaperOnlyParty.kt
@@ -17,6 +17,8 @@ class PaperOnlyParty(
 ) : Party(ownerId, name, celebrantNickname, startedAt, purpose) {
     override val partyOption: PartyOption get() = PartyOption.PAPER_ONLY
 
+    override fun hostViewableAt(): LocalDateTime = startedAt.toLocalDate().atTime(HOST_VIEWABLE_HOUR, 0)
+
     fun status(now: LocalDateTime = LocalDateTime.now()): PaperOnlyPartyStatus {
         val openTime = startedAt
         return when {
@@ -24,6 +26,10 @@ class PaperOnlyParty(
             now >= openTime -> PaperOnlyPartyStatus.OPEN
             else -> PaperOnlyPartyStatus.READY
         }
+    }
+
+    companion object {
+        const val HOST_VIEWABLE_HOUR: Int = 22
     }
 }
 

--- a/src/main/kotlin/com/team2/server/party/entity/Party.kt
+++ b/src/main/kotlin/com/team2/server/party/entity/Party.kt
@@ -37,6 +37,10 @@ abstract class Party(
     @get:Transient
     abstract val partyOption: PartyOption
 
+    abstract fun hostViewableAt(): LocalDateTime
+
+    fun canHostViewRollingPapers(now: LocalDateTime): Boolean = !hostViewableAt().isAfter(now)
+
     fun endedAt(): LocalDateTime = createdAt.plusDays(ENDED_AFTER_DAYS)
 
     fun isEnded(now: LocalDateTime = LocalDateTime.now()): Boolean = !endedAt().isAfter(now)

--- a/src/main/kotlin/com/team2/server/party/entity/RealtimeParty.kt
+++ b/src/main/kotlin/com/team2/server/party/entity/RealtimeParty.kt
@@ -17,6 +17,8 @@ class RealtimeParty(
 ) : Party(ownerId, name, celebrantNickname, startedAt, purpose) {
     override val partyOption: PartyOption get() = PartyOption.REALTIME
 
+    override fun hostViewableAt(): LocalDateTime = startedAt.plusMinutes(LIVE_DURATION_MINUTES)
+
     fun status(now: LocalDateTime = LocalDateTime.now()): RealtimePartyStatus {
         val liveStart = startedAt
         val liveEnd = liveStart.plusMinutes(LIVE_DURATION_MINUTES)

--- a/src/main/kotlin/com/team2/server/rollingpaper/controller/RollingPaperApi.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/controller/RollingPaperApi.kt
@@ -8,6 +8,7 @@ import com.team2.server.common.swagger.InternalServerErrorResponse
 import com.team2.server.common.swagger.OptionalAuth
 import com.team2.server.rollingpaper.dto.CreateRollingPaperRequest
 import com.team2.server.rollingpaper.dto.CreateRollingPaperResponse
+import com.team2.server.rollingpaper.dto.ParticipantRollingPaperListResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
@@ -19,6 +20,51 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
 
 @Tag(name = "Rolling Paper", description = "롤링페이퍼 API")
 interface RollingPaperApi {
+    @Operation(
+        summary = "참가자용 롤링페이퍼 목록 조회",
+        description =
+            "초대 토큰으로 롤링페이퍼 목록을 조회한다. 인증 없이도 조회 가능하다. " +
+                "Authorization header를 보낼 경우 유효한 Bearer token이어야 한다.",
+        security = [
+            SecurityRequirement(name = "Bearer Authentication"),
+            SecurityRequirement(name = ""),
+        ],
+    )
+    @SwaggerApiResponse(
+        responseCode = "200",
+        description = "참가자용 롤링페이퍼 목록 조회 성공",
+    )
+    @AuthErrorResponses
+    @SwaggerApiResponse(
+        responseCode = "404",
+        description = "파티 없음",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = ErrorResponse::class),
+                examples = [
+                    ExampleObject(
+                        name = "파티 없음",
+                        value = """
+                            {
+                              "status": 404,
+                              "error": {
+                                "code": "PARTY_NOT_FOUND",
+                                "message": "파티를 찾을 수 없습니다"
+                              }
+                            }
+                        """,
+                    ),
+                ],
+            ),
+        ],
+    )
+    @InternalServerErrorResponse
+    fun getParticipantRollingPapers(
+        @Parameter(description = "초대 토큰", example = "exampletoken0000") inviteToken: String,
+        @Parameter(description = "페이지 번호. 1보다 작으면 1로 보정합니다.", example = "1") page: Int,
+    ): ApiResponse<ParticipantRollingPaperListResponse>
+
     @Operation(
         summary = "롤링페이퍼 작성",
         description =

--- a/src/main/kotlin/com/team2/server/rollingpaper/controller/RollingPaperApi.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/controller/RollingPaperApi.kt
@@ -27,9 +27,9 @@ interface RollingPaperApi {
                 "Authorization header를 보낼 경우 유효한 Bearer token이어야 한다.",
         security = [
             SecurityRequirement(name = "Bearer Authentication"),
-            SecurityRequirement(name = ""),
         ],
     )
+    @OptionalAuth
     @SwaggerApiResponse(
         responseCode = "200",
         description = "참가자용 롤링페이퍼 목록 조회 성공",

--- a/src/main/kotlin/com/team2/server/rollingpaper/controller/RollingPaperController.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/controller/RollingPaperController.kt
@@ -4,14 +4,18 @@ import com.team2.server.auth.principal.UserPrincipal
 import com.team2.server.common.response.ApiResponse
 import com.team2.server.rollingpaper.dto.CreateRollingPaperRequest
 import com.team2.server.rollingpaper.dto.CreateRollingPaperResponse
+import com.team2.server.rollingpaper.dto.ParticipantRollingPaperListResponse
 import com.team2.server.rollingpaper.usecase.CreateRollingPaperUseCase
+import com.team2.server.rollingpaper.usecase.GetRollingPaperListUseCase
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
@@ -19,7 +23,15 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1/party-invites")
 class RollingPaperController(
     private val createRollingPaperUseCase: CreateRollingPaperUseCase,
+    private val getRollingPaperListUseCase: GetRollingPaperListUseCase,
 ) : RollingPaperApi {
+    @GetMapping("/{inviteToken}/rolling-papers")
+    override fun getParticipantRollingPapers(
+        @PathVariable inviteToken: String,
+        @RequestParam(defaultValue = "1") page: Int,
+    ): ApiResponse<ParticipantRollingPaperListResponse> =
+        ApiResponse.success(getRollingPaperListUseCase.getParticipantList(inviteToken, page))
+
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/{inviteToken}/rolling-papers")
     override fun createRollingPaper(

--- a/src/main/kotlin/com/team2/server/rollingpaper/controller/RollingPaperOwnerApi.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/controller/RollingPaperOwnerApi.kt
@@ -1,0 +1,96 @@
+package com.team2.server.rollingpaper.controller
+
+import com.team2.server.auth.principal.UserPrincipal
+import com.team2.server.common.response.ApiResponse
+import com.team2.server.common.response.ErrorResponse
+import com.team2.server.common.swagger.AuthErrorResponses
+import com.team2.server.common.swagger.InternalServerErrorResponse
+import com.team2.server.rollingpaper.dto.OwnerRollingPaperListResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
+
+@Tag(name = "Rolling Paper", description = "롤링페이퍼 API")
+interface RollingPaperOwnerApi {
+    @Operation(
+        summary = "주최자용 롤링페이퍼 목록 조회",
+        description = "인증된 파티 소유자가 롤링페이퍼 목록을 조회한다.",
+        security = [SecurityRequirement(name = "Bearer Authentication")],
+    )
+    @SwaggerApiResponse(
+        responseCode = "200",
+        description = "주최자용 롤링페이퍼 목록 조회 성공",
+    )
+    @AuthErrorResponses
+    @SwaggerApiResponse(
+        responseCode = "403",
+        description = "파티 권한 없음 또는 아직 열람 불가",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = ErrorResponse::class),
+                examples = [
+                    ExampleObject(
+                        name = "파티 권한 없음",
+                        value = """
+                            {
+                              "status": 403,
+                              "error": {
+                                "code": "PARTY_FORBIDDEN",
+                                "message": "파티에 대한 권한이 없습니다"
+                              }
+                            }
+                        """,
+                    ),
+                    ExampleObject(
+                        name = "아직 열람 불가",
+                        value = """
+                            {
+                              "status": 403,
+                              "error": {
+                                "code": "ROLLING_PAPER_NOT_VIEWABLE",
+                                "message": "아직 롤링페이퍼를 확인할 수 없습니다"
+                              }
+                            }
+                        """,
+                    ),
+                ],
+            ),
+        ],
+    )
+    @SwaggerApiResponse(
+        responseCode = "404",
+        description = "파티 없음",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = ErrorResponse::class),
+                examples = [
+                    ExampleObject(
+                        name = "파티 없음",
+                        value = """
+                            {
+                              "status": 404,
+                              "error": {
+                                "code": "PARTY_NOT_FOUND",
+                                "message": "파티를 찾을 수 없습니다"
+                              }
+                            }
+                        """,
+                    ),
+                ],
+            ),
+        ],
+    )
+    @InternalServerErrorResponse
+    fun getOwnerRollingPapers(
+        @Parameter(hidden = true) principal: UserPrincipal,
+        @Parameter(description = "파티 ID", example = "1") partyId: Long,
+        @Parameter(description = "페이지 번호. 1보다 작으면 1로 보정합니다.", example = "1") page: Int,
+    ): ApiResponse<OwnerRollingPaperListResponse>
+}

--- a/src/main/kotlin/com/team2/server/rollingpaper/controller/RollingPaperOwnerController.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/controller/RollingPaperOwnerController.kt
@@ -1,0 +1,26 @@
+package com.team2.server.rollingpaper.controller
+
+import com.team2.server.auth.principal.UserPrincipal
+import com.team2.server.common.response.ApiResponse
+import com.team2.server.rollingpaper.dto.OwnerRollingPaperListResponse
+import com.team2.server.rollingpaper.usecase.GetRollingPaperListUseCase
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/parties")
+class RollingPaperOwnerController(
+    private val getRollingPaperListUseCase: GetRollingPaperListUseCase,
+) : RollingPaperOwnerApi {
+    @GetMapping("/{partyId}/rolling-papers")
+    override fun getOwnerRollingPapers(
+        @AuthenticationPrincipal principal: UserPrincipal,
+        @PathVariable partyId: Long,
+        @RequestParam(defaultValue = "1") page: Int,
+    ): ApiResponse<OwnerRollingPaperListResponse> =
+        ApiResponse.success(getRollingPaperListUseCase.getOwnerList(partyId, principal.userId, page))
+}

--- a/src/main/kotlin/com/team2/server/rollingpaper/dto/RollingPaperListResponse.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/dto/RollingPaperListResponse.kt
@@ -1,0 +1,61 @@
+package com.team2.server.rollingpaper.dto
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.team2.server.party.entity.PartyOption
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@JsonInclude(JsonInclude.Include.ALWAYS)
+@Schema(description = "참가자용 롤링페이퍼 목록 조회 응답")
+data class ParticipantRollingPaperListResponse(
+    @Schema(
+        description = "파티 옵션. REALTIME: 실시간 파티, PAPER_ONLY: 롤링페이퍼 전용 파티",
+        allowableValues = ["REALTIME", "PAPER_ONLY"],
+        example = "REALTIME",
+    )
+    val partyOption: PartyOption,
+    @Schema(description = "실시간 파티 종료 시각. PAPER_ONLY면 null", nullable = true, example = "2026-05-05T22:10:00")
+    val liveEndAt: LocalDateTime?,
+    @Schema(description = "현재 페이지. page가 1보다 작으면 1로 보정합니다.", example = "1")
+    val page: Int,
+    @Schema(description = "전체 페이지 수. 롤링페이퍼가 없으면 0입니다.", example = "2")
+    val totalPages: Int,
+    @Schema(description = "다음 페이지 존재 여부", example = "true")
+    val hasNext: Boolean,
+    @Schema(description = "롤링페이퍼 목록")
+    val items: List<RollingPaperListItemResponse>,
+)
+
+@JsonInclude(JsonInclude.Include.ALWAYS)
+@Schema(description = "주최자용 롤링페이퍼 목록 조회 응답")
+data class OwnerRollingPaperListResponse(
+    @Schema(description = "파티 주인공 이름", example = "홍길동", nullable = true)
+    val celebrantNickname: String?,
+    @Schema(description = "파티 자체 종료 시각", example = "2026-05-12T14:30:00")
+    val partyEndAt: LocalDateTime,
+    @Schema(description = "현재 페이지. page가 1보다 작으면 1로 보정합니다.", example = "1")
+    val page: Int,
+    @Schema(description = "전체 롤링페이퍼 수", example = "8")
+    val totalCount: Long,
+    @Schema(description = "전체 페이지 수. 롤링페이퍼가 없으면 0입니다.", example = "2")
+    val totalPages: Int,
+    @Schema(description = "다음 페이지 존재 여부", example = "true")
+    val hasNext: Boolean,
+    @Schema(description = "롤링페이퍼 목록")
+    val items: List<RollingPaperListItemResponse>,
+)
+
+@JsonInclude(JsonInclude.Include.ALWAYS)
+@Schema(description = "롤링페이퍼 목록 item")
+data class RollingPaperListItemResponse(
+    @Schema(description = "롤링페이퍼 ID", example = "10")
+    val rollingPaperId: Long,
+    @Schema(description = "롤링페이퍼 작성자 닉네임", example = "축하요정")
+    val writerNickname: String,
+    @Schema(
+        description = "롤링페이퍼 래퍼 이미지 URL. 이미지가 없으면 null",
+        nullable = true,
+        example = "/images/rolling-paper-wrappers/Topping_Candle.svg",
+    )
+    val wrapperImageUrl: String?,
+)

--- a/src/main/kotlin/com/team2/server/rollingpaper/repository/RollingPaperRepository.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/repository/RollingPaperRepository.kt
@@ -2,6 +2,7 @@ package com.team2.server.rollingpaper.repository
 
 import com.team2.server.party.entity.Party
 import com.team2.server.rollingpaper.entity.RollingPaper
+import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
@@ -14,13 +15,11 @@ interface RollingPaperRepository : JpaRepository<RollingPaper, Long> {
         writerNicknameKey: String,
     ): Boolean
 
-    fun countByParty(party: Party): Long
-
     @EntityGraph(attributePaths = ["wrapper"])
     fun findAllByParty(
         party: Party,
         pageable: Pageable,
-    ): List<RollingPaper>
+    ): Page<RollingPaper>
 
     @Modifying
     @Transactional

--- a/src/main/kotlin/com/team2/server/rollingpaper/repository/RollingPaperRepository.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/repository/RollingPaperRepository.kt
@@ -2,6 +2,8 @@ package com.team2.server.rollingpaper.repository
 
 import com.team2.server.party.entity.Party
 import com.team2.server.rollingpaper.entity.RollingPaper
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.transaction.annotation.Transactional
@@ -11,6 +13,14 @@ interface RollingPaperRepository : JpaRepository<RollingPaper, Long> {
         party: Party,
         writerNicknameKey: String,
     ): Boolean
+
+    fun countByParty(party: Party): Long
+
+    @EntityGraph(attributePaths = ["wrapper"])
+    fun findAllByParty(
+        party: Party,
+        pageable: Pageable,
+    ): List<RollingPaper>
 
     @Modifying
     @Transactional

--- a/src/main/kotlin/com/team2/server/rollingpaper/usecase/GetRollingPaperListUseCase.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/usecase/GetRollingPaperListUseCase.kt
@@ -3,7 +3,7 @@ package com.team2.server.rollingpaper.usecase
 import com.team2.server.common.entity.ImageTargetType
 import com.team2.server.common.exception.BusinessException
 import com.team2.server.common.exception.ErrorCode
-import com.team2.server.common.repository.ImageRepository
+import com.team2.server.common.service.ImageQueryService
 import com.team2.server.party.entity.Party
 import com.team2.server.party.entity.PartyOption
 import com.team2.server.party.repository.PartyInviteRepository
@@ -25,7 +25,7 @@ class GetRollingPaperListUseCase(
     private val partyInviteRepository: PartyInviteRepository,
     private val partyRepository: PartyRepository,
     private val rollingPaperRepository: RollingPaperRepository,
-    private val imageRepository: ImageRepository,
+    private val imageQueryService: ImageQueryService,
 ) {
     @Transactional(readOnly = true)
     fun getParticipantList(
@@ -93,19 +93,7 @@ class GetRollingPaperListUseCase(
         requestedPage: Int,
     ): RollingPaperPageResult {
         val page = requestedPage.coerceAtLeast(MIN_PAGE)
-        val totalCount = rollingPaperRepository.countByParty(party)
-        val totalPages = calculateTotalPages(totalCount)
-        if (totalCount == 0L || page > totalPages) {
-            return RollingPaperPageResult(
-                page = page,
-                totalCount = totalCount,
-                totalPages = totalPages,
-                hasNext = false,
-                items = emptyList(),
-            )
-        }
-
-        val rollingPapers =
+        val rollingPaperPage =
             rollingPaperRepository.findAllByParty(
                 party,
                 PageRequest.of(
@@ -117,43 +105,29 @@ class GetRollingPaperListUseCase(
                     ),
                 ),
             )
+        val rollingPapers = rollingPaperPage.content
         val imageUrlByWrapperId = findImageUrlByWrapperId(rollingPapers)
         return RollingPaperPageResult(
             page = page,
-            totalCount = totalCount,
-            totalPages = totalPages,
-            hasNext = page < totalPages,
+            totalCount = rollingPaperPage.totalElements,
+            totalPages = rollingPaperPage.totalPages,
+            hasNext = rollingPaperPage.hasNext(),
             items =
                 rollingPapers.map { rollingPaper ->
                     RollingPaperListItemResponse(
                         rollingPaperId = rollingPaper.id,
-                        writerNickname = rollingPaper.writerNickname.orEmpty(),
+                        writerNickname = rollingPaper.writerNickname,
                         wrapperImageUrl = imageUrlByWrapperId[rollingPaper.wrapper.id],
                     )
                 },
         )
     }
 
-    private fun calculateTotalPages(totalCount: Long): Int =
-        if (totalCount == 0L) {
-            0
-        } else {
-            ((totalCount + PAGE_SIZE - 1) / PAGE_SIZE).toInt()
-        }
-
-    private fun findImageUrlByWrapperId(rollingPapers: List<RollingPaper>): Map<Long, String> {
-        val wrapperIds = rollingPapers.map { it.wrapper.id }.distinct()
-        if (wrapperIds.isEmpty()) {
-            return emptyMap()
-        }
-
-        return imageRepository
-            .findAllByTargetTypeAndTargetIdsOrderByTargetIdAndSortOrder(
-                ImageTargetType.ROLLING_PAPER_WRAPPER,
-                wrapperIds,
-            ).distinctBy { it.targetId }
-            .associate { it.targetId to it.imageUrl }
-    }
+    private fun findImageUrlByWrapperId(rollingPapers: List<RollingPaper>): Map<Long, String> =
+        imageQueryService.findFirstImageUrlByTargetIds(
+            ImageTargetType.ROLLING_PAPER_WRAPPER,
+            rollingPapers.map { it.wrapper.id },
+        )
 
     private data class RollingPaperPageResult(
         val page: Int,

--- a/src/main/kotlin/com/team2/server/rollingpaper/usecase/GetRollingPaperListUseCase.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/usecase/GetRollingPaperListUseCase.kt
@@ -1,0 +1,170 @@
+package com.team2.server.rollingpaper.usecase
+
+import com.team2.server.common.entity.ImageTargetType
+import com.team2.server.common.exception.BusinessException
+import com.team2.server.common.exception.ErrorCode
+import com.team2.server.common.repository.ImageRepository
+import com.team2.server.party.entity.Party
+import com.team2.server.party.entity.PartyOption
+import com.team2.server.party.repository.PartyInviteRepository
+import com.team2.server.party.repository.PartyRepository
+import com.team2.server.rollingpaper.dto.OwnerRollingPaperListResponse
+import com.team2.server.rollingpaper.dto.ParticipantRollingPaperListResponse
+import com.team2.server.rollingpaper.dto.RollingPaperListItemResponse
+import com.team2.server.rollingpaper.entity.RollingPaper
+import com.team2.server.rollingpaper.repository.RollingPaperRepository
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service
+class GetRollingPaperListUseCase(
+    private val partyInviteRepository: PartyInviteRepository,
+    private val partyRepository: PartyRepository,
+    private val rollingPaperRepository: RollingPaperRepository,
+    private val imageRepository: ImageRepository,
+) {
+    @Transactional(readOnly = true)
+    fun getParticipantList(
+        inviteToken: String,
+        page: Int,
+    ): ParticipantRollingPaperListResponse {
+        val party =
+            partyInviteRepository.findByToken(inviteToken)?.party
+                ?: throw BusinessException(ErrorCode.PARTY_NOT_FOUND)
+        val pageResult = getPageResult(party, page)
+        return ParticipantRollingPaperListResponse(
+            partyOption = party.partyOption,
+            liveEndAt =
+                if (party.partyOption == PartyOption.REALTIME) {
+                    party.hostViewableAt()
+                } else {
+                    null
+                },
+            page = pageResult.page,
+            totalPages = pageResult.totalPages,
+            hasNext = pageResult.hasNext,
+            items = pageResult.items,
+        )
+    }
+
+    @Transactional(readOnly = true)
+    fun getOwnerList(
+        partyId: Long,
+        userId: Long,
+        page: Int,
+    ): OwnerRollingPaperListResponse {
+        val party =
+            partyRepository.findByIdOrNull(partyId)
+                ?: throw BusinessException(ErrorCode.PARTY_NOT_FOUND)
+        validateOwner(party, userId)
+
+        val now = LocalDateTime.now()
+        if (!party.canHostViewRollingPapers(now)) {
+            throw BusinessException(ErrorCode.ROLLING_PAPER_NOT_VIEWABLE)
+        }
+
+        val pageResult = getPageResult(party, page)
+        return OwnerRollingPaperListResponse(
+            celebrantNickname = party.celebrantNickname,
+            partyEndAt = party.endedAt(),
+            page = pageResult.page,
+            totalCount = pageResult.totalCount,
+            totalPages = pageResult.totalPages,
+            hasNext = pageResult.hasNext,
+            items = pageResult.items,
+        )
+    }
+
+    private fun validateOwner(
+        party: Party,
+        userId: Long,
+    ) {
+        if (party.ownerId != userId) {
+            throw BusinessException(ErrorCode.PARTY_FORBIDDEN)
+        }
+    }
+
+    private fun getPageResult(
+        party: Party,
+        requestedPage: Int,
+    ): RollingPaperPageResult {
+        val page = requestedPage.coerceAtLeast(MIN_PAGE)
+        val totalCount = rollingPaperRepository.countByParty(party)
+        val totalPages = calculateTotalPages(totalCount)
+        if (totalCount == 0L || page > totalPages) {
+            return RollingPaperPageResult(
+                page = page,
+                totalCount = totalCount,
+                totalPages = totalPages,
+                hasNext = false,
+                items = emptyList(),
+            )
+        }
+
+        val rollingPapers =
+            rollingPaperRepository.findAllByParty(
+                party,
+                PageRequest.of(
+                    page - 1,
+                    PAGE_SIZE,
+                    Sort.by(
+                        Sort.Order.desc("createdAt"),
+                        Sort.Order.desc("id"),
+                    ),
+                ),
+            )
+        val imageUrlByWrapperId = findImageUrlByWrapperId(rollingPapers)
+        return RollingPaperPageResult(
+            page = page,
+            totalCount = totalCount,
+            totalPages = totalPages,
+            hasNext = page < totalPages,
+            items =
+                rollingPapers.map { rollingPaper ->
+                    RollingPaperListItemResponse(
+                        rollingPaperId = rollingPaper.id,
+                        writerNickname = rollingPaper.writerNickname.orEmpty(),
+                        wrapperImageUrl = imageUrlByWrapperId[rollingPaper.wrapper.id],
+                    )
+                },
+        )
+    }
+
+    private fun calculateTotalPages(totalCount: Long): Int =
+        if (totalCount == 0L) {
+            0
+        } else {
+            ((totalCount + PAGE_SIZE - 1) / PAGE_SIZE).toInt()
+        }
+
+    private fun findImageUrlByWrapperId(rollingPapers: List<RollingPaper>): Map<Long, String> {
+        val wrapperIds = rollingPapers.map { it.wrapper.id }.distinct()
+        if (wrapperIds.isEmpty()) {
+            return emptyMap()
+        }
+
+        return imageRepository
+            .findAllByTargetTypeAndTargetIdsOrderByTargetIdAndSortOrder(
+                ImageTargetType.ROLLING_PAPER_WRAPPER,
+                wrapperIds,
+            ).distinctBy { it.targetId }
+            .associate { it.targetId to it.imageUrl }
+    }
+
+    private data class RollingPaperPageResult(
+        val page: Int,
+        val totalCount: Long,
+        val totalPages: Int,
+        val hasNext: Boolean,
+        val items: List<RollingPaperListItemResponse>,
+    )
+
+    companion object {
+        const val PAGE_SIZE: Int = 7
+        private const val MIN_PAGE: Int = 1
+    }
+}

--- a/src/main/kotlin/com/team2/server/rollingpaper/usecase/GetRollingPaperWrappersUseCase.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/usecase/GetRollingPaperWrappersUseCase.kt
@@ -1,7 +1,7 @@
 package com.team2.server.rollingpaper.usecase
 
 import com.team2.server.common.entity.ImageTargetType
-import com.team2.server.common.repository.ImageRepository
+import com.team2.server.common.service.ImageQueryService
 import com.team2.server.rollingpaper.dto.RollingPaperWrapperResult
 import com.team2.server.rollingpaper.repository.RollingPaperWrapperRepository
 import org.springframework.data.domain.Sort
@@ -11,7 +11,7 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class GetRollingPaperWrappersUseCase(
     private val rollingPaperWrapperRepository: RollingPaperWrapperRepository,
-    private val imageRepository: ImageRepository,
+    private val imageQueryService: ImageQueryService,
 ) {
     @Transactional(readOnly = true)
     fun getWrappers(): List<RollingPaperWrapperResult> {
@@ -20,12 +20,10 @@ class GetRollingPaperWrappersUseCase(
             return emptyList()
         }
         val imageUrlByTargetId =
-            imageRepository
-                .findAllByTargetTypeAndTargetIdsOrderByTargetIdAndSortOrder(
-                    ImageTargetType.ROLLING_PAPER_WRAPPER,
-                    wrappers.map { it.id },
-                ).distinctBy { it.targetId }
-                .associate { it.targetId to it.imageUrl }
+            imageQueryService.findFirstImageUrlByTargetIds(
+                ImageTargetType.ROLLING_PAPER_WRAPPER,
+                wrappers.map { it.id },
+            )
 
         return wrappers.map { wrapper ->
             RollingPaperWrapperResult(

--- a/src/test/kotlin/com/team2/server/common/config/SwaggerConfigTest.kt
+++ b/src/test/kotlin/com/team2/server/common/config/SwaggerConfigTest.kt
@@ -36,6 +36,10 @@ class SwaggerConfigTest
                 apiDocs,
                 "$.paths['/api/v1/party-invites/{inviteToken}/rolling-papers'].post.security",
             )
+            assertOptionalAuthSecurity(
+                apiDocs,
+                "$.paths['/api/v1/party-invites/{inviteToken}/rolling-papers'].get.security",
+            )
         }
 
         private fun assertOptionalAuthSecurity(

--- a/src/test/kotlin/com/team2/server/party/entity/PartyStatusTest.kt
+++ b/src/test/kotlin/com/team2/server/party/entity/PartyStatusTest.kt
@@ -78,6 +78,15 @@ class PartyStatusTest {
         assertEquals(true, party.canHostViewRollingPapers(hostViewableAt))
     }
 
+    @Test
+    fun `PaperOnlyParty - 시작 시각이 오후 10시 이후이면 다음날 오후 10시에 주최자 열람 가능`() {
+        val party = paperParty(startedAt = birthday.atTime(23, 30))
+        val hostViewableAt = birthday.plusDays(1).atTime(22, 0)
+        assertEquals(hostViewableAt, party.hostViewableAt())
+        assertEquals(false, party.canHostViewRollingPapers(hostViewableAt.minusNanos(1)))
+        assertEquals(true, party.canHostViewRollingPapers(hostViewableAt))
+    }
+
     // --- RealtimeParty ---
 
     @Test

--- a/src/test/kotlin/com/team2/server/party/entity/PartyStatusTest.kt
+++ b/src/test/kotlin/com/team2/server/party/entity/PartyStatusTest.kt
@@ -69,6 +69,15 @@ class PartyStatusTest {
         assertEquals(PaperOnlyPartyStatus.CLOSED, party.status(now))
     }
 
+    @Test
+    fun `PaperOnlyParty - 주최자 롤링페이퍼 열람 시각은 시작일 오후 10시`() {
+        val party = paperParty(startedAt = birthday.atStartOfDay())
+        val hostViewableAt = birthday.atTime(22, 0)
+        assertEquals(hostViewableAt, party.hostViewableAt())
+        assertEquals(false, party.canHostViewRollingPapers(hostViewableAt.minusNanos(1)))
+        assertEquals(true, party.canHostViewRollingPapers(hostViewableAt))
+    }
+
     // --- RealtimeParty ---
 
     @Test
@@ -103,5 +112,14 @@ class PartyStatusTest {
         val party = realtimeParty()
         val now = createdAt.plusDays(7)
         assertEquals(RealtimePartyStatus.ROLLING_PAPER_CLOSED, party.status(now))
+    }
+
+    @Test
+    fun `RealtimeParty - 주최자 롤링페이퍼 열람 시각은 라이브 종료 시각`() {
+        val party = realtimeParty()
+        val hostViewableAt = liveStart.plusMinutes(RealtimeParty.LIVE_DURATION_MINUTES)
+        assertEquals(hostViewableAt, party.hostViewableAt())
+        assertEquals(false, party.canHostViewRollingPapers(hostViewableAt.minusNanos(1)))
+        assertEquals(true, party.canHostViewRollingPapers(hostViewableAt))
     }
 }

--- a/src/test/kotlin/com/team2/server/rollingpaper/controller/RollingPaperListControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/rollingpaper/controller/RollingPaperListControllerTest.kt
@@ -180,12 +180,7 @@ class RollingPaperListControllerTest
                 savePaperOnlyParty(
                     ownerId = owner.id,
                     createdAt = LocalDateTime.of(2026, 5, 5, 14, 30),
-                    startedAt =
-                        LocalDateTime
-                            .now()
-                            .minusDays(1)
-                            .toLocalDate()
-                            .atStartOfDay(),
+                    startedAt = ALWAYS_VIEWABLE_STARTED_AT,
                 )
             val wrapper = saveWrapperWithImages()
             saveRollingPaper(party, wrapper, "축하요정", DEFAULT_NOW)
@@ -212,12 +207,7 @@ class RollingPaperListControllerTest
             val party =
                 savePaperOnlyParty(
                     ownerId = owner.id,
-                    startedAt =
-                        LocalDateTime
-                            .now()
-                            .minusDays(1)
-                            .toLocalDate()
-                            .atStartOfDay(),
+                    startedAt = ALWAYS_VIEWABLE_STARTED_AT,
                 )
 
             mockMvc
@@ -235,7 +225,7 @@ class RollingPaperListControllerTest
             val party =
                 saveRealtimeParty(
                     ownerId = owner.id,
-                    startedAt = LocalDateTime.now().plusMinutes(1),
+                    startedAt = NOT_VIEWABLE_REALTIME_STARTED_AT,
                 )
 
             mockMvc
@@ -253,7 +243,7 @@ class RollingPaperListControllerTest
             val party =
                 saveRealtimeParty(
                     ownerId = owner.id,
-                    startedAt = LocalDateTime.now().minusMinutes(RealtimeParty.LIVE_DURATION_MINUTES).minusSeconds(1),
+                    startedAt = ALWAYS_VIEWABLE_REALTIME_STARTED_AT,
                 )
 
             mockMvc
@@ -415,5 +405,8 @@ class RollingPaperListControllerTest
 
         companion object {
             private val DEFAULT_NOW: LocalDateTime = LocalDateTime.of(2026, 5, 6, 12, 0)
+            private val ALWAYS_VIEWABLE_STARTED_AT: LocalDateTime = LocalDateTime.of(2020, 1, 1, 0, 0)
+            private val ALWAYS_VIEWABLE_REALTIME_STARTED_AT: LocalDateTime = LocalDateTime.of(2020, 1, 1, 0, 0)
+            private val NOT_VIEWABLE_REALTIME_STARTED_AT: LocalDateTime = LocalDateTime.of(2099, 1, 1, 0, 0)
         }
     }

--- a/src/test/kotlin/com/team2/server/rollingpaper/controller/RollingPaperListControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/rollingpaper/controller/RollingPaperListControllerTest.kt
@@ -1,0 +1,419 @@
+package com.team2.server.rollingpaper.controller
+
+import com.team2.server.auth.config.JwtProperties
+import com.team2.server.auth.jwt.JwtTokenProvider
+import com.team2.server.common.entity.Image
+import com.team2.server.common.entity.ImageTargetType
+import com.team2.server.common.repository.ImageRepository
+import com.team2.server.party.entity.PaperOnlyParty
+import com.team2.server.party.entity.Participant
+import com.team2.server.party.entity.Party
+import com.team2.server.party.entity.PartyInvite
+import com.team2.server.party.entity.RealtimeParty
+import com.team2.server.party.repository.ParticipantRepository
+import com.team2.server.party.repository.PartyInviteRepository
+import com.team2.server.party.repository.PartyRepository
+import com.team2.server.rollingpaper.entity.RollingPaper
+import com.team2.server.rollingpaper.entity.RollingPaperWrapper
+import com.team2.server.rollingpaper.repository.RollingPaperRepository
+import com.team2.server.rollingpaper.repository.RollingPaperWrapperRepository
+import com.team2.server.user.entity.AuthProvider
+import com.team2.server.user.entity.User
+import com.team2.server.user.repository.UserRepository
+import org.hamcrest.Matchers.nullValue
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import java.time.LocalDateTime
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class RollingPaperListControllerTest
+    @Autowired
+    constructor(
+        private val mockMvc: MockMvc,
+        private val rollingPaperRepository: RollingPaperRepository,
+        private val rollingPaperWrapperRepository: RollingPaperWrapperRepository,
+        private val imageRepository: ImageRepository,
+        private val partyInviteRepository: PartyInviteRepository,
+        private val participantRepository: ParticipantRepository,
+        private val partyRepository: PartyRepository,
+        private val userRepository: UserRepository,
+        private val jwtProperties: JwtProperties,
+    ) {
+        private val tokenProvider = JwtTokenProvider(jwtProperties)
+
+        @BeforeEach
+        fun setUp() {
+            clearDatabase()
+        }
+
+        @AfterEach
+        fun tearDown() {
+            clearDatabase()
+        }
+
+        @Test
+        fun `참가자용 목록은 인증 없이 최신순 7개씩 조회된다`() {
+            val party = saveRealtimeParty(startedAt = DEFAULT_NOW.withHour(22).withMinute(0))
+            val invite = saveInvite(party, "listtoken000001")
+            val wrapper = saveWrapperWithImages()
+            (1..8).forEach { index ->
+                saveRollingPaper(
+                    party = party,
+                    wrapper = wrapper,
+                    writerNickname = "작성자$index",
+                    createdAt = DEFAULT_NOW.plusMinutes(index.toLong()),
+                )
+            }
+
+            mockMvc
+                .get("/api/v1/party-invites/${invite.token}/rolling-papers") {
+                    param("page", "1")
+                }.andExpect {
+                    status { isOk() }
+                    jsonPath("$.data.partyOption") { value("REALTIME") }
+                    jsonPath("$.data.liveEndAt") { value("2026-05-06T22:10:00") }
+                    jsonPath("$.data.page") { value(1) }
+                    jsonPath("$.data.totalPages") { value(2) }
+                    jsonPath("$.data.hasNext") { value(true) }
+                    jsonPath("$.data.totalCount") { doesNotExist() }
+                    jsonPath("$.data.items.length()") { value(7) }
+                    jsonPath("$.data.items[0].writerNickname") { value("작성자8") }
+                    jsonPath("$.data.items[0].wrapperImageUrl") { value("/images/rolling-paper-wrappers/first.svg") }
+                    jsonPath("$.data.items[6].writerNickname") { value("작성자2") }
+                }
+
+            mockMvc
+                .get("/api/v1/party-invites/${invite.token}/rolling-papers") {
+                    param("page", "2")
+                }.andExpect {
+                    status { isOk() }
+                    jsonPath("$.data.page") { value(2) }
+                    jsonPath("$.data.hasNext") { value(false) }
+                    jsonPath("$.data.items.length()") { value(1) }
+                    jsonPath("$.data.items[0].writerNickname") { value("작성자1") }
+                }
+        }
+
+        @Test
+        fun `참가자용 목록은 유효 Bearer token이 있어도 조회된다`() {
+            val user = saveUser("participant-list")
+            val party = savePaperOnlyParty()
+            val invite = saveInvite(party, "authedlist00001")
+            val token = tokenProvider.issue(user)
+
+            mockMvc
+                .get("/api/v1/party-invites/${invite.token}/rolling-papers") {
+                    header("Authorization", "Bearer $token")
+                }.andExpect {
+                    status { isOk() }
+                    jsonPath("$.data.partyOption") { value("PAPER_ONLY") }
+                    jsonPath("$.data.liveEndAt") { value(nullValue()) }
+                }
+        }
+
+        @Test
+        fun `참가자용 목록은 page가 1보다 작으면 1로 보정하고 빈 목록을 반환한다`() {
+            val party = savePaperOnlyParty()
+            val invite = saveInvite(party, "emptylist000001")
+
+            mockMvc
+                .get("/api/v1/party-invites/${invite.token}/rolling-papers") {
+                    param("page", "0")
+                }.andExpect {
+                    status { isOk() }
+                    jsonPath("$.data.page") { value(1) }
+                    jsonPath("$.data.totalPages") { value(0) }
+                    jsonPath("$.data.hasNext") { value(false) }
+                    jsonPath("$.data.items.length()") { value(0) }
+                    jsonPath("$.data.totalCount") { doesNotExist() }
+                }
+        }
+
+        @Test
+        fun `참가자용 목록은 파티 자체 종료 후에도 조회된다`() {
+            val party = savePaperOnlyParty(createdAt = DEFAULT_NOW.minusDays(8))
+            val invite = saveInvite(party, "endedlist000001")
+
+            mockMvc
+                .get("/api/v1/party-invites/${invite.token}/rolling-papers")
+                .andExpect {
+                    status { isOk() }
+                    jsonPath("$.data.totalPages") { value(0) }
+                }
+        }
+
+        @Test
+        fun `참가자용 목록은 잘못된 Bearer token이면 401`() {
+            val party = savePaperOnlyParty()
+            val invite = saveInvite(party, "invalidlist0001")
+
+            mockMvc
+                .get("/api/v1/party-invites/${invite.token}/rolling-papers") {
+                    header("Authorization", "Bearer not-a-jwt")
+                }.andExpect {
+                    status { isUnauthorized() }
+                    jsonPath("$.error.code") { value("AUTH_INVALID_TOKEN") }
+                }
+        }
+
+        @Test
+        fun `참가자용 목록은 없는 inviteToken이면 404`() {
+            mockMvc
+                .get("/api/v1/party-invites/missing-token/rolling-papers")
+                .andExpect {
+                    status { isNotFound() }
+                    jsonPath("$.error.code") { value("PARTY_NOT_FOUND") }
+                }
+        }
+
+        @Test
+        fun `주최자용 목록은 소유자만 열람 가능하고 총 개수를 포함한다`() {
+            val owner = saveUser("owner-list")
+            val party =
+                savePaperOnlyParty(
+                    ownerId = owner.id,
+                    createdAt = LocalDateTime.of(2026, 5, 5, 14, 30),
+                    startedAt =
+                        LocalDateTime
+                            .now()
+                            .minusDays(1)
+                            .toLocalDate()
+                            .atStartOfDay(),
+                )
+            val wrapper = saveWrapperWithImages()
+            saveRollingPaper(party, wrapper, "축하요정", DEFAULT_NOW)
+
+            mockMvc
+                .get("/api/v1/parties/${party.id}/rolling-papers") {
+                    header("Authorization", "Bearer ${tokenProvider.issue(owner)}")
+                }.andExpect {
+                    status { isOk() }
+                    jsonPath("$.data.celebrantNickname") { value("홍길동") }
+                    jsonPath("$.data.partyEndAt") { value("2026-05-12T14:30:00") }
+                    jsonPath("$.data.page") { value(1) }
+                    jsonPath("$.data.totalCount") { value(1) }
+                    jsonPath("$.data.totalPages") { value(1) }
+                    jsonPath("$.data.hasNext") { value(false) }
+                    jsonPath("$.data.items[0].writerNickname") { value("축하요정") }
+                }
+        }
+
+        @Test
+        fun `주최자용 목록은 소유자가 아니면 403`() {
+            val owner = saveUser("owner-forbidden")
+            val other = saveUser("other-forbidden")
+            val party =
+                savePaperOnlyParty(
+                    ownerId = owner.id,
+                    startedAt =
+                        LocalDateTime
+                            .now()
+                            .minusDays(1)
+                            .toLocalDate()
+                            .atStartOfDay(),
+                )
+
+            mockMvc
+                .get("/api/v1/parties/${party.id}/rolling-papers") {
+                    header("Authorization", "Bearer ${tokenProvider.issue(other)}")
+                }.andExpect {
+                    status { isForbidden() }
+                    jsonPath("$.error.code") { value("PARTY_FORBIDDEN") }
+                }
+        }
+
+        @Test
+        fun `주최자용 목록은 열람 가능 전이면 403`() {
+            val owner = saveUser("owner-before-open")
+            val party =
+                saveRealtimeParty(
+                    ownerId = owner.id,
+                    startedAt = LocalDateTime.now().plusMinutes(1),
+                )
+
+            mockMvc
+                .get("/api/v1/parties/${party.id}/rolling-papers") {
+                    header("Authorization", "Bearer ${tokenProvider.issue(owner)}")
+                }.andExpect {
+                    status { isForbidden() }
+                    jsonPath("$.error.code") { value("ROLLING_PAPER_NOT_VIEWABLE") }
+                }
+        }
+
+        @Test
+        fun `주최자용 목록은 실시간 파티 종료 시각부터 열람 가능하다`() {
+            val owner = saveUser("owner-realtime-open")
+            val party =
+                saveRealtimeParty(
+                    ownerId = owner.id,
+                    startedAt = LocalDateTime.now().minusMinutes(RealtimeParty.LIVE_DURATION_MINUTES).minusSeconds(1),
+                )
+
+            mockMvc
+                .get("/api/v1/parties/${party.id}/rolling-papers") {
+                    header("Authorization", "Bearer ${tokenProvider.issue(owner)}")
+                }.andExpect {
+                    status { isOk() }
+                    jsonPath("$.data.totalCount") { value(0) }
+                    jsonPath("$.data.totalPages") { value(0) }
+                }
+        }
+
+        @Test
+        fun `공통 목록은 초과 페이지 요청값을 유지하고 빈 items를 반환한다`() {
+            val party = savePaperOnlyParty()
+            val invite = saveInvite(party, "overpagelist001")
+            val wrapper = saveWrapperWithImages()
+            saveRollingPaper(party, wrapper, "하나", DEFAULT_NOW)
+
+            mockMvc
+                .get("/api/v1/party-invites/${invite.token}/rolling-papers") {
+                    param("page", "5")
+                }.andExpect {
+                    status { isOk() }
+                    jsonPath("$.data.page") { value(5) }
+                    jsonPath("$.data.totalPages") { value(1) }
+                    jsonPath("$.data.hasNext") { value(false) }
+                    jsonPath("$.data.items.length()") { value(0) }
+                }
+        }
+
+        @Test
+        fun `wrapper 이미지가 없으면 wrapperImageUrl은 null이다`() {
+            val party = savePaperOnlyParty()
+            val invite = saveInvite(party, "noimagelist0001")
+            val wrapper = saveWrapper()
+            saveRollingPaper(party, wrapper, "이미지없음", DEFAULT_NOW)
+
+            mockMvc
+                .get("/api/v1/party-invites/${invite.token}/rolling-papers")
+                .andExpect {
+                    status { isOk() }
+                    jsonPath("$.data.items[0].wrapperImageUrl") { value(nullValue()) }
+                }
+        }
+
+        private fun savePaperOnlyParty(
+            ownerId: Long = 1L,
+            createdAt: LocalDateTime = DEFAULT_NOW.minusDays(1),
+            startedAt: LocalDateTime = DEFAULT_NOW.toLocalDate().atStartOfDay(),
+        ): Party {
+            val saved =
+                partyRepository.saveAndFlush(
+                    PaperOnlyParty(
+                        ownerId = ownerId,
+                        celebrantNickname = "홍길동",
+                        startedAt = startedAt,
+                    ),
+                )
+            saved.createdAt = createdAt
+            return partyRepository.saveAndFlush(saved)
+        }
+
+        private fun saveRealtimeParty(
+            ownerId: Long = 1L,
+            createdAt: LocalDateTime = DEFAULT_NOW.minusDays(1),
+            startedAt: LocalDateTime = DEFAULT_NOW.withHour(20).withMinute(0),
+        ): Party {
+            val saved =
+                partyRepository.saveAndFlush(
+                    RealtimeParty(
+                        ownerId = ownerId,
+                        celebrantNickname = "홍길동",
+                        startedAt = startedAt,
+                    ),
+                )
+            saved.createdAt = createdAt
+            return partyRepository.saveAndFlush(saved)
+        }
+
+        private fun saveInvite(
+            party: Party,
+            token: String,
+            expiresAt: LocalDateTime = DEFAULT_NOW.plusDays(1),
+        ): PartyInvite =
+            partyInviteRepository.save(
+                PartyInvite(
+                    party = party,
+                    token = token,
+                    expiresAt = expiresAt,
+                ),
+            )
+
+        private fun saveWrapper(): RollingPaperWrapper =
+            rollingPaperWrapperRepository.saveAndFlush(RollingPaperWrapper(name = "Topping_Candle"))
+
+        private fun saveWrapperWithImages(): RollingPaperWrapper {
+            val wrapper = saveWrapper()
+            imageRepository.save(
+                Image(
+                    imageUrl = "/images/rolling-paper-wrappers/second.svg",
+                    targetType = ImageTargetType.ROLLING_PAPER_WRAPPER,
+                    targetId = wrapper.id,
+                    sortOrder = 1,
+                ),
+            )
+            imageRepository.save(
+                Image(
+                    imageUrl = "/images/rolling-paper-wrappers/first.svg",
+                    targetType = ImageTargetType.ROLLING_PAPER_WRAPPER,
+                    targetId = wrapper.id,
+                    sortOrder = 0,
+                ),
+            )
+            return wrapper
+        }
+
+        private fun saveRollingPaper(
+            party: Party,
+            wrapper: RollingPaperWrapper,
+            writerNickname: String,
+            createdAt: LocalDateTime,
+        ): RollingPaper {
+            val participant = participantRepository.saveAndFlush(Participant(party = party, hasWrittenPaper = true))
+            val saved =
+                rollingPaperRepository.saveAndFlush(
+                    RollingPaper(
+                        wrapper = wrapper,
+                        writer = participant,
+                        party = party,
+                        writerNickname = writerNickname,
+                        content = "축하해요",
+                    ),
+                )
+            saved.createdAt = createdAt
+            return rollingPaperRepository.saveAndFlush(saved)
+        }
+
+        private fun saveUser(providerId: String): User =
+            userRepository.saveAndFlush(
+                User(
+                    name = "사용자",
+                    birthDay = "01-01",
+                    provider = AuthProvider.KAKAO,
+                    providerId = providerId,
+                    email = "$providerId@kakao.local",
+                ),
+            )
+
+        private fun clearDatabase() {
+            rollingPaperRepository.deleteAll()
+            imageRepository.deleteAll()
+            rollingPaperWrapperRepository.deleteAll()
+            partyInviteRepository.deleteAll()
+            participantRepository.deleteAll()
+            partyRepository.deleteAll()
+            userRepository.deleteAll()
+        }
+
+        companion object {
+            private val DEFAULT_NOW: LocalDateTime = LocalDateTime.of(2026, 5, 6, 12, 0)
+        }
+    }


### PR DESCRIPTION
## 🔗 Issue
- closes #101

## 💬 Context
참가자와 주최자 화면에서 롤링페이퍼 목록을 각각의 접근 정책에 맞게 조회해야 합니다.

## 🛠 Changes
- 참가자용 공개 목록 조회 API 추가
- 주최자용 인증 목록 조회 API 및 열람 가능 시각 검증 추가
- Swagger 문서와 주요 권한/페이징 테스트 추가

## 👀 Review Focus
- 참가자/주최자 응답 계약과 접근 권한 정책
- 롤링페이퍼 전용/실시간 파티의 주최자 열람 가능 시각

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [ ] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 참여자용 롤링페이퍼 목록 조회 기능 추가
  * 주최자용 롤링페이퍼 목록 조회 기능 추가
  * 페이지네이션을 통한 목록 관리 지원
  * 주최자의 롤링페이퍼 열람 시간 기반 제한 적용
  * 아직 확인할 수 없는 롤링페이퍼에 대한 오류 처리 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->