### PR TITLE
[Fix] 카카오 OAuth 콜백 시 redirect_uri 손실 수정

### DIFF
--- a/src/main/kotlin/com/team2/server/auth/config/OAuth2Properties.kt
+++ b/src/main/kotlin/com/team2/server/auth/config/OAuth2Properties.kt
@@ -9,4 +9,5 @@ import org.springframework.validation.annotation.Validated
 data class OAuth2Properties(
     @field:NotEmpty
     val authorizedRedirectUris: List<String>,
+    val cookieSecure: Boolean = false,
 )

--- a/src/main/kotlin/com/team2/server/auth/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/team2/server/auth/config/SecurityConfig.kt
@@ -4,6 +4,7 @@ import com.team2.server.auth.jwt.JwtAuthenticationEntryPoint
 import com.team2.server.auth.jwt.JwtAuthenticationFilter
 import com.team2.server.auth.oauth2.CustomOAuth2UserService
 import com.team2.server.auth.oauth2.OAuth2FailureHandler
+import com.team2.server.auth.oauth2.OAuth2RedirectUriCaptureFilter
 import com.team2.server.auth.oauth2.OAuth2SuccessHandler
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -11,6 +12,7 @@ import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 import org.springframework.web.cors.CorsConfiguration
@@ -59,7 +61,10 @@ class SecurityConfig(
                 oauth.successHandler(oAuth2SuccessHandler)
                 oauth.failureHandler(oAuth2FailureHandler)
             }.exceptionHandling { it.authenticationEntryPoint(jwtAuthenticationEntryPoint) }
-            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
+            .addFilterBefore(
+                OAuth2RedirectUriCaptureFilter(oAuth2Properties),
+                OAuth2AuthorizationRequestRedirectFilter::class.java,
+            ).addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
         return http.build()
     }
 

--- a/src/main/kotlin/com/team2/server/auth/oauth2/OAuth2FailureHandler.kt
+++ b/src/main/kotlin/com/team2/server/auth/oauth2/OAuth2FailureHandler.kt
@@ -23,7 +23,7 @@ class OAuth2FailureHandler(
     ) {
         log.warn("OAuth2 authentication failed", exception)
 
-        val target = oAuth2Properties.authorizedRedirectUris.first()
+        val target = resolveRedirectUri(request) ?: oAuth2Properties.authorizedRedirectUris.first()
         val redirectUrl =
             UriComponentsBuilder
                 .fromUriString(target)
@@ -31,6 +31,15 @@ class OAuth2FailureHandler(
                 .build()
                 .toUriString()
 
+        OAuth2RedirectUriCookies.clear(response, oAuth2Properties.cookieSecure)
         redirectStrategy.sendRedirect(request, response, redirectUrl)
+    }
+
+    private fun resolveRedirectUri(request: HttpServletRequest): String? {
+        val candidate =
+            OAuth2RedirectUriCookies.read(request)
+                ?: request.getParameter("redirect_uri")
+                ?: return null
+        return if (oAuth2Properties.authorizedRedirectUris.contains(candidate)) candidate else null
     }
 }

--- a/src/main/kotlin/com/team2/server/auth/oauth2/OAuth2RedirectUriCaptureFilter.kt
+++ b/src/main/kotlin/com/team2/server/auth/oauth2/OAuth2RedirectUriCaptureFilter.kt
@@ -1,0 +1,30 @@
+package com.team2.server.auth.oauth2
+
+import com.team2.server.auth.config.OAuth2Properties
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.web.filter.OncePerRequestFilter
+
+class OAuth2RedirectUriCaptureFilter(
+    private val oAuth2Properties: OAuth2Properties,
+) : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        if (request.servletPath.startsWith(AUTHORIZATION_BASE_URI)) {
+            val redirectUri = request.getParameter(REDIRECT_URI_PARAM)
+            if (!redirectUri.isNullOrBlank() && oAuth2Properties.authorizedRedirectUris.contains(redirectUri)) {
+                OAuth2RedirectUriCookies.write(response, redirectUri, oAuth2Properties.cookieSecure)
+            }
+        }
+        filterChain.doFilter(request, response)
+    }
+
+    companion object {
+        const val AUTHORIZATION_BASE_URI = "/oauth2/authorization/"
+        const val REDIRECT_URI_PARAM = "redirect_uri"
+    }
+}

--- a/src/main/kotlin/com/team2/server/auth/oauth2/OAuth2RedirectUriCookies.kt
+++ b/src/main/kotlin/com/team2/server/auth/oauth2/OAuth2RedirectUriCookies.kt
@@ -1,0 +1,44 @@
+package com.team2.server.auth.oauth2
+
+import jakarta.servlet.http.Cookie
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+
+internal object OAuth2RedirectUriCookies {
+    const val NAME = "OAUTH2_REDIRECT_URI"
+    private const val PATH = "/"
+    private const val MAX_AGE_SECONDS = 180
+
+    fun read(request: HttpServletRequest): String? = request.cookies?.firstOrNull { it.name == NAME }?.value
+
+    fun write(
+        response: HttpServletResponse,
+        value: String,
+        secure: Boolean,
+    ) {
+        val cookie =
+            Cookie(NAME, value).apply {
+                path = PATH
+                isHttpOnly = true
+                maxAge = MAX_AGE_SECONDS
+                this.secure = secure
+                setAttribute("SameSite", "Lax")
+            }
+        response.addCookie(cookie)
+    }
+
+    fun clear(
+        response: HttpServletResponse,
+        secure: Boolean,
+    ) {
+        val cookie =
+            Cookie(NAME, "").apply {
+                path = PATH
+                isHttpOnly = true
+                maxAge = 0
+                this.secure = secure
+                setAttribute("SameSite", "Lax")
+            }
+        response.addCookie(cookie)
+    }
+}

--- a/src/main/kotlin/com/team2/server/auth/oauth2/OAuth2SuccessHandler.kt
+++ b/src/main/kotlin/com/team2/server/auth/oauth2/OAuth2SuccessHandler.kt
@@ -39,12 +39,16 @@ class OAuth2SuccessHandler(
                 .build()
                 .toUriString()
 
+        OAuth2RedirectUriCookies.clear(response, oAuth2Properties.cookieSecure)
         clearAuthenticationAttributes(request)
         redirectStrategy.sendRedirect(request, response, redirectUrl)
     }
 
     private fun resolveRedirectUri(request: HttpServletRequest): String? {
-        val candidate = request.getParameter("redirect_uri") ?: return null
+        val candidate =
+            OAuth2RedirectUriCookies.read(request)
+                ?: request.getParameter("redirect_uri")
+                ?: return null
         return if (oAuth2Properties.authorizedRedirectUris.contains(candidate)) candidate else null
     }
 }

--- a/src/test/kotlin/com/team2/server/auth/oauth2/OAuth2FailureHandlerTest.kt
+++ b/src/test/kotlin/com/team2/server/auth/oauth2/OAuth2FailureHandlerTest.kt
@@ -1,0 +1,60 @@
+package com.team2.server.auth.oauth2
+
+import com.team2.server.auth.config.OAuth2Properties
+import jakarta.servlet.http.Cookie
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.security.core.AuthenticationException
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class OAuth2FailureHandlerTest {
+    private fun handler(allowed: List<String>) = OAuth2FailureHandler(OAuth2Properties(allowed))
+
+    private val ex = object : AuthenticationException("boom") {}
+
+    @Test
+    fun `쿠키에 redirect_uri 있으면 해당 값으로 에러 리다이렉트 + 쿠키 삭제`() {
+        val req =
+            MockHttpServletRequest().apply {
+                setCookies(Cookie(OAuth2RedirectUriCookies.NAME, "http://localhost:5173/oauth/callback"))
+            }
+        val res = MockHttpServletResponse()
+
+        handler(listOf("http://localhost:5173/oauth/callback", "https://hapalin.com/oauth/redirect"))
+            .onAuthenticationFailure(req, res, ex)
+
+        val location = res.getHeader("Location") ?: error("no location")
+        assertTrue(location.startsWith("http://localhost:5173/oauth/callback?error="))
+        val cleared = res.getCookie(OAuth2RedirectUriCookies.NAME) ?: error("expected clear cookie")
+        assertEquals(0, cleared.maxAge)
+    }
+
+    @Test
+    fun `쿠키 없으면 디폴트(첫번째 허용목록)로 에러 리다이렉트`() {
+        val req = MockHttpServletRequest()
+        val res = MockHttpServletResponse()
+
+        handler(listOf("https://app.example.com/cb"))
+            .onAuthenticationFailure(req, res, ex)
+
+        val location = res.getHeader("Location") ?: error("no location")
+        assertTrue(location.startsWith("https://app.example.com/cb?error="))
+    }
+
+    @Test
+    fun `허용 목록에 없는 쿠키 값은 디폴트로 폴백`() {
+        val req =
+            MockHttpServletRequest().apply {
+                setCookies(Cookie(OAuth2RedirectUriCookies.NAME, "https://evil.example.com/steal"))
+            }
+        val res = MockHttpServletResponse()
+
+        handler(listOf("https://app.example.com/cb"))
+            .onAuthenticationFailure(req, res, ex)
+
+        val location = res.getHeader("Location") ?: error("no location")
+        assertTrue(location.startsWith("https://app.example.com/cb?error="))
+    }
+}

--- a/src/test/kotlin/com/team2/server/auth/oauth2/OAuth2RedirectUriCaptureFilterTest.kt
+++ b/src/test/kotlin/com/team2/server/auth/oauth2/OAuth2RedirectUriCaptureFilterTest.kt
@@ -1,0 +1,73 @@
+package com.team2.server.auth.oauth2
+
+import com.team2.server.auth.config.OAuth2Properties
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.MockFilterChain
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class OAuth2RedirectUriCaptureFilterTest {
+    private fun filter(allowed: List<String> = listOf("http://localhost:5173/oauth/callback")) =
+        OAuth2RedirectUriCaptureFilter(OAuth2Properties(allowed))
+
+    @Test
+    fun `oauth2 인가 요청 경로에서 허용 redirect_uri 쿼리를 쿠키로 저장`() {
+        val req =
+            MockHttpServletRequest("GET", "/oauth2/authorization/kakao").apply {
+                servletPath = "/oauth2/authorization/kakao"
+                setParameter("redirect_uri", "http://localhost:5173/oauth/callback")
+            }
+        val res = MockHttpServletResponse()
+
+        filter().doFilter(req, res, MockFilterChain())
+
+        val cookie = res.getCookie(OAuth2RedirectUriCookies.NAME) ?: error("expected cookie")
+        assertEquals("http://localhost:5173/oauth/callback", cookie.value)
+        assertEquals(true, cookie.isHttpOnly)
+        assertEquals("/", cookie.path)
+    }
+
+    @Test
+    fun `redirect_uri 파라미터가 없으면 쿠키 미설정`() {
+        val req =
+            MockHttpServletRequest("GET", "/oauth2/authorization/kakao").apply {
+                servletPath = "/oauth2/authorization/kakao"
+            }
+        val res = MockHttpServletResponse()
+
+        filter().doFilter(req, res, MockFilterChain())
+
+        assertNull(res.getCookie(OAuth2RedirectUriCookies.NAME))
+    }
+
+    @Test
+    fun `허용 목록에 없는 redirect_uri는 쿠키 미설정 (오픈 리다이렉트 방어)`() {
+        val req =
+            MockHttpServletRequest("GET", "/oauth2/authorization/kakao").apply {
+                servletPath = "/oauth2/authorization/kakao"
+                setParameter("redirect_uri", "https://evil.example.com/steal")
+            }
+        val res = MockHttpServletResponse()
+
+        filter(allowed = listOf("http://localhost:5173/oauth/callback"))
+            .doFilter(req, res, MockFilterChain())
+
+        assertNull(res.getCookie(OAuth2RedirectUriCookies.NAME))
+    }
+
+    @Test
+    fun `oauth2 인가 요청 경로가 아니면 쿼리가 있어도 쿠키 미설정`() {
+        val req =
+            MockHttpServletRequest("GET", "/api/v1/foo").apply {
+                servletPath = "/api/v1/foo"
+                setParameter("redirect_uri", "http://localhost:5173/oauth/callback")
+            }
+        val res = MockHttpServletResponse()
+
+        filter().doFilter(req, res, MockFilterChain())
+
+        assertNull(res.getCookie(OAuth2RedirectUriCookies.NAME))
+    }
+}

--- a/src/test/kotlin/com/team2/server/auth/oauth2/OAuth2SuccessHandlerTest.kt
+++ b/src/test/kotlin/com/team2/server/auth/oauth2/OAuth2SuccessHandlerTest.kt
@@ -7,6 +7,7 @@ import com.team2.server.auth.jwt.JwtTokenProvider
 import com.team2.server.auth.principal.UserPrincipal
 import com.team2.server.user.entity.AuthProvider
 import com.team2.server.user.entity.User
+import jakarta.servlet.http.Cookie
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -53,6 +54,8 @@ class OAuth2SuccessHandlerTest {
         return auth
     }
 
+    private fun redirectUriCookie(value: String): Cookie = Cookie(OAuth2RedirectUriCookies.NAME, value)
+
     @Test
     fun `허용 redirect_uri 쿼리에 토큰 포함하여 302`() {
         val repo = FakeUserRepository()
@@ -95,6 +98,63 @@ class OAuth2SuccessHandlerTest {
         val repo = FakeUserRepository()
         val user = seedUser(repo, 12L)
         val req = MockHttpServletRequest().apply { setParameter("redirect_uri", "https://evil.example.com/steal") }
+        val res = MockHttpServletResponse()
+        val auth = authWith(UserPrincipal.from(user))
+
+        handler(repo, allowed = listOf("https://app.example.com/cb"))
+            .onAuthenticationSuccess(req, res, auth)
+
+        val location = res.getHeader("Location") ?: error("no location")
+        assertTrue(location.startsWith("https://app.example.com/cb?token="))
+    }
+
+    @Test
+    fun `쿠키에 redirect_uri가 있으면 해당 값으로 302 후 쿠키 삭제`() {
+        val repo = FakeUserRepository()
+        val user = seedUser(repo, 13L)
+        val req =
+            MockHttpServletRequest().apply {
+                setCookies(redirectUriCookie("http://localhost:5173/oauth/callback"))
+            }
+        val res = MockHttpServletResponse()
+        val auth = authWith(UserPrincipal.from(user))
+
+        handler(repo, allowed = listOf("http://localhost:5173/oauth/callback", "https://hapalin.com/oauth/redirect"))
+            .onAuthenticationSuccess(req, res, auth)
+
+        val location = res.getHeader("Location") ?: error("no location")
+        assertTrue(location.startsWith("http://localhost:5173/oauth/callback?token="))
+        val cleared = res.getCookie(OAuth2RedirectUriCookies.NAME) ?: error("expected clear cookie")
+        assertEquals(0, cleared.maxAge)
+    }
+
+    @Test
+    fun `쿠키와 쿼리가 모두 있을 때 쿠키 값을 우선 사용`() {
+        val repo = FakeUserRepository()
+        val user = seedUser(repo, 14L)
+        val req =
+            MockHttpServletRequest().apply {
+                setCookies(redirectUriCookie("http://localhost:5173/oauth/callback"))
+                setParameter("redirect_uri", "https://hapalin.com/oauth/redirect")
+            }
+        val res = MockHttpServletResponse()
+        val auth = authWith(UserPrincipal.from(user))
+
+        handler(repo, allowed = listOf("http://localhost:5173/oauth/callback", "https://hapalin.com/oauth/redirect"))
+            .onAuthenticationSuccess(req, res, auth)
+
+        val location = res.getHeader("Location") ?: error("no location")
+        assertTrue(location.startsWith("http://localhost:5173/oauth/callback?token="))
+    }
+
+    @Test
+    fun `쿠키 값이 화이트리스트에 없으면 폴백`() {
+        val repo = FakeUserRepository()
+        val user = seedUser(repo, 15L)
+        val req =
+            MockHttpServletRequest().apply {
+                setCookies(redirectUriCookie("https://evil.example.com/steal"))
+            }
         val res = MockHttpServletResponse()
         val auth = authWith(UserPrincipal.from(user))
 


### PR DESCRIPTION
## 🔗 Issue
- closes #108

## 💬 Context
프론트가 `/oauth2/authorization/kakao?redirect_uri=http://localhost:5173/oauth/callback` 으로 인가 요청을 시작해도, 카카오 콜백(`/login/oauth2/code/kakao?code=...`) 시점에는 OAuth2 스펙상 `code`/`state`만 돌아오기 때문에 프론트가 보낸 `redirect_uri` 쿼리는 사라진다. 그 결과 `OAuth2SuccessHandler.resolveRedirectUri()`가 항상 `null`이 되어 `authorizedRedirectUris.first()` 폴백(`hapalin.com`)으로 강제 리다이렉트되는 버그.

`/oauth2/authorization` 요청과 카카오 콜백은 **별개의 HTTP 요청**이므로, 인가 요청 시점의 `redirect_uri`를 서버가 별도로 보관해 콜백 시점에 복원해야 한다. SPA + STATELESS 백엔드 환경에서 표준 패턴인 **HttpOnly 쿠키 기반 보관**(Spring Security 공식 샘플의 `HttpCookieOAuth2AuthorizationRequestRepository` 패턴)으로 해결.

## 🛠 Changes
- `OAuth2RedirectUriCaptureFilter` 신규 — `/oauth2/authorization/**` 진입 시 `redirect_uri` 쿼리를 화이트리스트 검증 후 HttpOnly 쿠키(`OAUTH2_REDIRECT_URI`, TTL 180s, SameSite=Lax)로 저장 (오픈 리다이렉트 방어)
- `OAuth2RedirectUriCookies` 헬퍼 신규 — 쿠키 read/write/clear 캡슐화
- `OAuth2SuccessHandler` — 쿠키 → 쿼리 → 디폴트 우선순위로 redirect_uri 복원, 사용 후 쿠키 삭제
- `OAuth2FailureHandler` — 동일 버그 보유로 같이 수정 (실패 시에도 SPA 측으로 정상 복귀하도록)
- `OAuth2Properties` — `cookieSecure` 옵션 추가 (local=false / prod=true 분기 가능)
- `SecurityConfig` — 캡처 필터를 `OAuth2AuthorizationRequestRedirectFilter` 앞에 등록
- 테스트 13개 추가/갱신 (Filter 4 / Success 6 / Failure 3): 쿠키 우선/쿼리 폴백/화이트리스트 미포함/디폴트 폴백 케이스 커버
- `config/secret` 서브모듈 — 로컬 화이트리스트에 `http://localhost:5173/oauth/callback` 추가 (dev/prod는 기존에 이미 등록되어 있음)

## 👀 Review Focus
- **오픈 리다이렉트 방어**: 필터/SuccessHandler/FailureHandler 세 군데 모두에서 `authorizedRedirectUris.contains(...)` 화이트리스트 검증을 거치는지
- **쿠키 속성**: HttpOnly + SameSite=Lax 선택 근거 (top-level navigation으로 카카오 → 백엔드 콜백 시 쿠키 동봉, JS 접근 차단)
- **상태 정리 시점**: Success/Failure 두 경로 모두에서 쿠키가 maxAge=0으로 삭제되는지 — 누수 방지
- **STATELESS 정책 호환**: 세션을 쓰지 않고 쿠키 단독으로 OAuth 라운드트립을 해결한 설계
- **테스트 시나리오**: 기존 3개 테스트(쿼리 fallback, 디폴트 폴백, 화이트리스트 미포함)가 깨지지 않으면서 신규 케이스가 추가됐는지

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * OAuth2 리다이렉트 URI 쿠키 기반 관리 추가로 보안 강화
  * 쿠키 보안 설정 옵션 추가

* **개선 사항**
  * OAuth2 인증 흐름 중 리다이렉트 URI 검증 로직 개선
  * 실패 및 성공 핸들러의 리다이렉트 처리 안정성 향상

* **테스트**
  * OAuth2 핸들러 및 필터에 대한 포괄적인 단위 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->