### PR TITLE
[Feat] 초대장 회원 참여 API 추가

### DIFF
--- a/docs/superpowers/specs/2026-05-04-party-invite-lookup-design.md
+++ b/docs/superpowers/specs/2026-05-04-party-invite-lookup-design.md
@@ -135,6 +135,7 @@ POST /api/v1/party-invites/{inviteToken}/participants/me
 - 로그인 회원 전용
 - Authorization header가 없으면 401
 - 잘못된 Bearer token은 기존 정책대로 401
+- 요청 body는 없다.
 
 응답:
 
@@ -152,6 +153,7 @@ POST /api/v1/party-invites/{inviteToken}/participants/me
 - `party.createdAt + 7일`이 지났으면 `PARTY_ENDED`.
 - 로그인 회원의 기존 participant가 있으면 그대로 반환한다.
 - 기존 participant가 없으면 `Participant(party, user)`를 생성한다.
+- 기존 participant를 반환할 때는 `hasWrittenPaper`, `isCelebrant` 등 기존 participant 필드를 변경하지 않는다.
 - 같은 회원이 동시에 호출해 `(party_id, user_id)` unique constraint가 발생하면 기존 participant를 다시 조회해 반환한다.
 - 신규 생성과 기존 조회 모두 200으로 응답한다. 이 API는 "참여 상태 보장" 성격의 idempotent POST로 본다.
 
@@ -394,6 +396,7 @@ src/main/kotlin/com/team2/server/party/usecase/JoinPartyInviteUseCase.kt
 - `joinMember(party, user)`는 기존 participant가 있으면 그대로 반환한다.
 - 없으면 `Participant(party = party, user = user)`를 `saveAndFlush`로 저장한다.
 - `uk_participant_party_user` 위반은 기존 participant 재조회로 복구한다.
+- 기존 participant를 반환하는 경우 `hasWrittenPaper`, `isCelebrant` 같은 상태 필드는 갱신하지 않는다.
 - 비회원 롤링페이퍼 작성 흐름을 위해 `joinAnonymous(party)`도 제공한다.
 
 ### 7-4. DTO

--- a/docs/superpowers/specs/2026-05-04-party-invite-lookup-design.md
+++ b/docs/superpowers/specs/2026-05-04-party-invite-lookup-design.md
@@ -1,8 +1,8 @@
-# Party Invite Lookup API Design
+# Party Invite Lookup and Member Join API Design
 
 - 작성일: 2026-05-04
 - 기준 브랜치: `feature/party-invite-lookup`
-- 목적: 공유 링크 진입 시 `inviteToken`만으로 초대장/파티 요약을 조회하는 공개 API 추가
+- 목적: 공유 링크 진입 시 `inviteToken`만으로 초대장/파티 요약을 조회하고, 로그인 회원을 명시적으로 참여자로 저장하는 API 추가
 - 구현 전 확인 상태: 이 문서는 구현 전 설계 확인용이며, 승인 전에는 Kotlin 코드를 변경하지 않는다.
 
 ---
@@ -12,15 +12,18 @@
 1. 사용자가 공유 링크로 진입한다.
 2. 프론트가 링크의 `inviteToken`으로 초대장/파티 요약을 조회한다.
 3. 프론트가 `inviteToken`과 party summary를 `localStorage`에 저장한다.
-4. 이 시점에는 `participant`를 생성하지 않는다.
-5. `"롤페 작성하기"` 클릭 시 participant 생성/복원 후 rolling paper 작성 플로우로 이동한다.
-6. `"파티 입장하기"` 클릭 시 participant 생성/복원 후 realtime profile 설정/입장 플로우로 이동한다.
+4. 초대장 조회 자체는 `participant`를 생성하지 않는다.
+5. 로그인 회원이면 프론트가 조회 성공 직후 회원 참여 API를 호출해 `participant`를 생성/복원한다.
+6. `"롤페 작성하기"` 클릭 시 rolling paper 작성 플로우로 이동한다.
+7. `"파티 입장하기"` 클릭 시 realtime profile 설정/입장 플로우로 이동한다.
 
 핵심 경계:
 
 - 초대장 조회는 **공개 조회**다.
 - 초대장 조회는 **participant 생성/복원 side effect가 없어야 한다**.
-- participant 생성/복원은 이후 작성/입장 액션의 책임으로 남긴다.
+- 회원 자동 참여는 조회 GET에 숨기지 않고 **인증 회원 전용 POST**로 분리한다.
+- 비회원은 초대장 조회 직후 participant를 생성하지 않는다.
+- 만료된 초대 토큰이나 종료된 파티에는 회원 참여자를 생성하지 않는다.
 
 ---
 
@@ -44,6 +47,7 @@
 이번 기획과 달라지는 지점:
 
 - 신규 조회 API 경로는 `GET /api/v1/party-invites/{inviteToken}`이다.
+- 신규 회원 참여 API 경로는 `POST /api/v1/party-invites/{inviteToken}/participants/me`이다.
 - 응답은 초대장 조회 전용 응답이다.
 - `partyEnded`, `partyStartDate`, `partyEndDate`는 `endedAt` 전용 컬럼이 아니라 `createdAt + 7일` 기준으로 계산한다.
 - `REALTIME` 파티는 조회 시점 상태값 대신 프론트가 버튼/카운트다운 상태를 계산할 기준 시각을 내려준다.
@@ -120,6 +124,37 @@ GET /api/v1/party-invites/{inviteToken}
 | `realtimeSchedule.liveEndAt` | `Party.startedAt + 10분` | 프론트 종료 상태 기준 시각 |
 | `realtimeSchedule.liveDurationMinutes` | 정책 상수 | 실시간 파티 진행 시간 |
 
+### 3-4. 회원 참여 Endpoint
+
+```http
+POST /api/v1/party-invites/{inviteToken}/participants/me
+```
+
+인증:
+
+- 로그인 회원 전용
+- Authorization header가 없으면 401
+- 잘못된 Bearer token은 기존 정책대로 401
+
+응답:
+
+```json
+{
+  "participantId": 1
+}
+```
+
+처리 정책:
+
+- `inviteToken`으로 `PartyInvite`를 조회한다.
+- 토큰이 없으면 `PARTY_NOT_FOUND`.
+- `PartyInvite.expiresAt`이 지났으면 `INVITE_LINK_EXPIRED`.
+- `party.createdAt + 7일`이 지났으면 `PARTY_ENDED`.
+- 로그인 회원의 기존 participant가 있으면 그대로 반환한다.
+- 기존 participant가 없으면 `Participant(party, user)`를 생성한다.
+- 같은 회원이 동시에 호출해 `(party_id, user_id)` unique constraint가 발생하면 기존 participant를 다시 조회해 반환한다.
+- 신규 생성과 기존 조회 모두 200으로 응답한다. 이 API는 "참여 상태 보장" 성격의 idempotent POST로 본다.
+
 ---
 
 ## 4. Realtime Schedule 설계
@@ -169,6 +204,7 @@ data class RealtimeSchedule(
 - `PartyInvite.expiresAt`은 "초대 링크 발급/재사용 및 참여 가능성"에 쓰고, 초대장 요약 조회 자체를 막지는 않는다.
 - 만료된 토큰도 파티 요약을 보여줘야 프론트가 `realtimeSchedule.liveEndAt` 또는 `partyEnded = true` 같은 기준으로 상태 화면을 안정적으로 만들 수 있다.
 - 없는 token은 기존 관례대로 `PARTY_NOT_FOUND`를 반환한다.
+- 회원 참여 API는 실제 participant 저장이므로 `PartyInvite.expiresAt`과 `party.isEnded(now)`를 모두 검증한다.
 
 기존 발급/재사용 정책과 분리하기 위해 조회 전용 `findByToken` 흐름을 둔다.
 
@@ -194,6 +230,8 @@ party/
 - 새 `application.usecase` 패키지는 만들지 않는다.
 - 새 조회 흐름은 기존 `party/usecase/GetCharactersUseCase` 패턴을 따른다.
 - `PartyInviteService`는 초대 토큰 발급/재사용 행위를 계속 담당하고, 초대장 조회는 별도 `LookupPartyInviteUseCase`가 담당한다.
+- 회원 참여 흐름은 별도 `JoinPartyInviteUseCase`가 담당한다.
+- participant 저장/복원과 DB unique constraint 복구는 `ParticipantService`가 담당한다.
 
 추가 파일 위치:
 
@@ -203,32 +241,37 @@ party/
 │   ├── PartyInviteLookupApi.kt
 │   └── PartyInviteLookupController.kt
 ├── dto/
-│   └── PartyInviteLookupResponse.kt
+│   ├── PartyInviteLookupResponse.kt
+│   └── PartyInviteParticipationResponse.kt
+├── service/
+│   └── ParticipantService.kt
 └── usecase/
-    └── LookupPartyInviteUseCase.kt
+    ├── LookupPartyInviteUseCase.kt
+    └── JoinPartyInviteUseCase.kt
 ```
 
 의존 방향:
 
 ```text
 controller -> usecase -> repository/entity/dto
+controller -> usecase -> service -> repository/entity
 ```
 
 지킬 것:
 
 - Controller는 Repository를 직접 보지 않는다.
 - Controller는 기존 `CharacterController`처럼 UseCase만 호출한다.
-- UseCase는 다른 Service를 주입하지 않는다.
-- UseCase는 필요한 Repository만 직접 주입한다.
+- 조회 UseCase는 필요한 Repository만 직접 주입한다.
+- 쓰기 UseCase는 participant 저장/복원 행위를 `ParticipantService`에 위임한다.
 - UseCase는 HTTP 타입, `HttpServletRequest`, `AuthenticationPrincipal`을 모른다.
 - DTO 변환은 조회 전용 UseCase 내부에서만 수행한다. 단, Controller에 변환 로직을 두지 않는다.
 - 신규 조회 UseCase는 participant 생성/수정/save를 하지 않는다.
 - 신규 조회 UseCase는 `PartyInviteService.activateInviteLink(...)`를 호출하지 않는다.
-- 신규 조회 UseCase는 나중에 작성/입장 API가 생기더라도 participant 생성/복원 책임을 가져오지 않는다.
 
 트랜잭션:
 
 - 현재 `GetCharactersUseCase` 패턴에 맞춰 `LookupPartyInviteUseCase`의 조회 메서드에 `@Transactional(readOnly = true)`를 둔다.
+- `JoinPartyInviteUseCase`에는 participant 저장이 있으므로 `@Transactional`을 둔다.
 - public 메서드명은 컨트롤러에서 의미가 드러나도록 `lookup(...)`을 사용한다.
 - 조회 유스케이스이므로 Repository write method는 호출하지 않는다.
 
@@ -247,6 +290,7 @@ src/main/kotlin/com/team2/server/party/controller/PartyInviteLookupController.kt
 역할:
 
 - `GET /api/v1/party-invites/{inviteToken}` 매핑
+- `POST /api/v1/party-invites/{inviteToken}/participants/me` 매핑
 - `@AuthenticationPrincipal principal: UserPrincipal?`를 optional로 받음
 - 유스케이스에 `inviteToken`, `principal?.userId` 전달
 - `ApiResponse.success(...)`로 감쌈
@@ -268,6 +312,7 @@ src/main/kotlin/com/team2/server/party/controller/PartyInviteLookupApi.kt
 
 - 404: `PARTY_NOT_FOUND`
 - 500: 공통 서버 오류
+- 회원 참여 API는 400: `INVITE_LINK_EXPIRED`, `PARTY_ENDED`, 401: 인증 실패, 404: `PARTY_NOT_FOUND`, 500을 문서화한다.
 
 성공 응답은 `ApiResponse<PartyInviteLookupResponse>` 반환 타입으로 자동 매칭되게 두고, Swagger에 200 응답을 수동 작성하지 않는다.
 Enum 필드는 DTO `@Schema` 설명에 값별 의미를 명시한다.
@@ -322,6 +367,35 @@ fun findByPartyIdAndUserId(
 
 이 추가는 기존 `existsByPartyIdAndUserId`와 같은 축이라 자연스럽다.
 
+회원 참여 UseCase:
+
+```text
+src/main/kotlin/com/team2/server/party/usecase/JoinPartyInviteUseCase.kt
+```
+
+의존성:
+
+- `PartyInviteRepository`
+- `UserRepository`
+- `ParticipantService`
+
+흐름:
+
+1. `partyInviteRepository.findByToken(inviteToken)`
+2. 없으면 `BusinessException(ErrorCode.PARTY_NOT_FOUND)`
+3. `PartyInvite.expiresAt` 검증
+4. `party.isEnded(now)` 검증
+5. `userRepository.findByIdOrNull(userId)`로 회원 조회
+6. `participantService.joinMember(party, user)`로 회원 participant 생성/복원
+7. `PartyInviteParticipationResponse(participantId)` 반환
+
+`ParticipantService`:
+
+- `joinMember(party, user)`는 기존 participant가 있으면 그대로 반환한다.
+- 없으면 `Participant(party = party, user = user)`를 `saveAndFlush`로 저장한다.
+- `uk_participant_party_user` 위반은 기존 participant 재조회로 복구한다.
+- 비회원 롤링페이퍼 작성 흐름을 위해 `joinAnonymous(party)`도 제공한다.
+
 ### 7-4. DTO
 
 새 DTO:
@@ -358,6 +432,11 @@ Kotlin 타입:
 auth.requestMatchers(HttpMethod.GET, "/api/v1/party-invites/*").permitAll()
 ```
 
+회원 참여 API:
+
+- `POST /api/v1/party-invites/*/participants/me`는 별도 `permitAll`을 추가하지 않는다.
+- 기존 `anyRequest().authenticated()`에 의해 로그인 회원만 접근한다.
+
 현재 `develop`에는 `GET /api/v1/parties/{inviteToken}`가 없다. Swagger 문서에도 이 API를 새로 유지하거나 복구하지 않는다.
 
 ---
@@ -378,6 +457,11 @@ src/test/kotlin/com/team2/server/party/controller/PartyInviteLookupControllerTes
 - 인증 없이 조회해도 participant count가 증가하지 않음
 - 인증 회원 participant가 있고 `hasWrittenPaper = true`이면 `rollingPaperWritten = true`
 - participant가 없으면 `rollingPaperWritten = false`
+- 인증 회원이 회원 참여 API를 호출하면 participant 생성
+- 이미 참여한 회원이 회원 참여 API를 다시 호출하면 기존 participant 반환
+- 인증 없이 회원 참여 API를 호출하면 401
+- 만료된 초대 토큰으로 회원 참여 API를 호출하면 participant 미생성 및 `INVITE_LINK_EXPIRED`
+- 종료된 파티로 회원 참여 API를 호출하면 participant 미생성 및 `PARTY_ENDED`
 - `PAPER_ONLY`는 `realtimeSchedule`이 null
 - `REALTIME`은 `realtimeSchedule.liveStartAt`, `enterableFrom`, `liveEndAt`, `liveDurationMinutes`가 내려감
 - `createdAt + 7일` 이상이면 `partyEnded = true`
@@ -411,6 +495,7 @@ src/test/kotlin/com/team2/server/party/controller/PartyInviteLookupControllerTes
 검증:
 
 - `GET /api/v1/party-invites/{inviteToken}`는 토큰 없이 200
+- `POST /api/v1/party-invites/{inviteToken}/participants/me`는 토큰 없이 401
 - 없는 token도 인증 없이 404까지 도달
 - invalid Bearer token은 기존 보안 정책대로 401
 
@@ -429,13 +514,16 @@ src/test/kotlin/com/team2/server/party/controller/PartyInviteLookupControllerTes
 승인 후 진행 순서:
 
 1. `PartyInviteLookupResponse`, `RealtimeSchedule` DTO 추가
-2. `ParticipantRepository.findByPartyIdAndUserId(...)` 추가
-3. `LookupPartyInviteUseCase` 추가
-4. `PartyInviteLookupApi`, `PartyInviteLookupController` 추가
-5. `SecurityConfig`에 `GET /api/v1/party-invites/*` permitAll 추가
-6. controller/usecase/security 테스트 추가
-7. 필요한 Swagger 예시 정리
-8. 검증 실행
+2. `PartyInviteParticipationResponse` DTO 추가
+3. `ParticipantRepository.findByPartyIdAndUserId(...)` 추가
+4. `ParticipantService` 추가
+5. `LookupPartyInviteUseCase` 추가
+6. `JoinPartyInviteUseCase` 추가
+7. `PartyInviteLookupApi`, `PartyInviteLookupController` 추가
+8. `SecurityConfig`에 `GET /api/v1/party-invites/*` permitAll 추가
+9. controller/usecase/security 테스트 추가
+10. 필요한 Swagger 예시 정리
+11. 검증 실행
    - `./gradlew test --tests com.team2.server.party.controller.PartyInviteLookupControllerTest`
    - 필요 시 `./gradlew test`
 
@@ -448,3 +536,4 @@ src/test/kotlin/com/team2/server/party/controller/PartyInviteLookupControllerTes
 3. 이번 기능은 기존 패키지 구조에 맞춰 작게 추가한다.
 4. invalid Bearer token이 들어온 공개 조회 요청은 기존 정책대로 401로 본다.
 5. `RealtimeParty.startedAt`은 현재 모델에서 non-null이므로 null 비정상 데이터 케이스는 별도 처리하지 않는다.
+6. 회원 참여 API는 만료된 초대 토큰 또는 종료된 파티에는 participant를 생성하지 않는다.

--- a/docs/superpowers/specs/2026-05-04-party-invite-lookup-design.md
+++ b/docs/superpowers/specs/2026-05-04-party-invite-lookup-design.md
@@ -79,7 +79,9 @@ GET /api/v1/party-invites/{inviteToken}
 
 ```json
 {
+  "partyId": 1,
   "celebrantNickname": "홍길동",
+  "isHost": true,
   "partyOption": "REALTIME",
   "partyEnded": false,
   "rollingPaperWritten": false,
@@ -98,7 +100,9 @@ GET /api/v1/party-invites/{inviteToken}
 
 ```json
 {
+  "partyId": 1,
   "celebrantNickname": "홍길동",
+  "isHost": false,
   "partyOption": "PAPER_ONLY",
   "partyEnded": false,
   "rollingPaperWritten": false,
@@ -112,7 +116,9 @@ GET /api/v1/party-invites/{inviteToken}
 
 | 응답 필드 | source | 계산 |
 |---|---|---|
+| `partyId` | `Party.id` | 이후 주최자용 API, 화면 이동 등에 사용할 파티 식별자 |
 | `celebrantNickname` | `Party.celebrantNickname` | 컬럼명과 동일 의미 유지 |
+| `isHost` | `Party.ownerId` | 인증 회원이고 `party.ownerId == userId`이면 true, 비회원이면 false |
 | `partyOption` | 현재 코드의 `Party.partyOption` | 그대로 |
 | `partyEnded` | `Party.createdAt` | `now >= createdAt.plusDays(7)` |
 | `rollingPaperWritten` | `Participant.hasWrittenPaper` | 식별 가능한 회원 participant가 있으면 해당 값, 없으면 false |
@@ -341,13 +347,15 @@ src/main/kotlin/com/team2/server/party/usecase/LookupPartyInviteUseCase.kt
 2. 없으면 `BusinessException(ErrorCode.PARTY_NOT_FOUND)`
 3. `party = invite.party`
 4. `partyEndAt = party.createdAt.plusDays(7)`
-5. `rollingPaperWritten` 계산
-6. `realtimeSchedule` 계산
-7. `PartyInviteLookupResponse` 반환
+5. `isHost` 계산
+6. `rollingPaperWritten` 계산
+7. `realtimeSchedule` 계산
+8. `PartyInviteLookupResponse` 반환
 
 의존성 제한:
 
 - `LookupPartyInviteUseCase`는 `PartyInviteRepository`, `ParticipantRepository`만 주입하는 것을 우선한다.
+- `isHost`는 `Party.ownerId`와 `userId`만 비교하므로 별도 Repository가 필요 없다.
 - `rollingPaperWritten`은 `userId`만 있으면 `ParticipantRepository.findByPartyIdAndUserId(...)`로 계산 가능하므로 `UserRepository`를 주입하지 않는다.
 - 이렇게 하면 조회 흐름이 user aggregate를 직접 조회하지 않아도 되고, 의존성이 더 작아진다.
 - 단, 유효한 JWT인데 DB에서 user가 삭제된 케이스는 JWT 필터 단계에서 이미 `AUTH_USER_NOT_FOUND`로 처리되는 현재 구조를 따른다.
@@ -411,7 +419,9 @@ src/main/kotlin/com/team2/server/party/dto/PartyInviteLookupResponse.kt
 
 Kotlin 타입:
 
+- `partyId: Long`
 - `celebrantNickname: String?`
+- `isHost: Boolean`
 - `partyOption: PartyOption`
 - `partyEnded: Boolean`
 - `rollingPaperWritten: Boolean`

--- a/docs/superpowers/specs/2026-05-04-party-invite-lookup-design.md
+++ b/docs/superpowers/specs/2026-05-04-party-invite-lookup-design.md
@@ -155,6 +155,7 @@ POST /api/v1/party-invites/{inviteToken}/participants/me
 - 기존 participant가 없으면 `Participant(party, user)`를 생성한다.
 - 기존 participant를 반환할 때는 `hasWrittenPaper`, `isCelebrant` 등 기존 participant 필드를 변경하지 않는다.
 - 같은 회원이 동시에 호출해 `(party_id, user_id)` unique constraint가 발생하면 기존 participant를 다시 조회해 반환한다.
+- 단, `uk_participant_party_user` 위반일 때만 기존 participant 재조회 복구를 수행하고, 다른 DB 제약 위반은 그대로 전파한다.
 - 신규 생성과 기존 조회 모두 200으로 응답한다. 이 API는 "참여 상태 보장" 성격의 idempotent POST로 본다.
 
 ---
@@ -396,8 +397,9 @@ src/main/kotlin/com/team2/server/party/usecase/JoinPartyInviteUseCase.kt
 - `joinMember(party, user)`는 기존 participant가 있으면 그대로 반환한다.
 - 없으면 `Participant(party = party, user = user)`를 `saveAndFlush`로 저장한다.
 - `uk_participant_party_user` 위반은 기존 participant 재조회로 복구한다.
+- `uk_participant_party_user`가 아닌 `DataIntegrityViolationException`은 복구하지 않고 그대로 던진다.
+- unique constraint 위반 후 재조회해도 participant가 없으면 원 예외를 다시 던진다.
 - 기존 participant를 반환하는 경우 `hasWrittenPaper`, `isCelebrant` 같은 상태 필드는 갱신하지 않는다.
-- 비회원 롤링페이퍼 작성 흐름을 위해 `joinAnonymous(party)`도 제공한다.
 
 ### 7-4. DTO
 

--- a/docs/superpowers/specs/2026-05-04-rolling-paper-write-design.md
+++ b/docs/superpowers/specs/2026-05-04-rolling-paper-write-design.md
@@ -449,6 +449,7 @@ POST /api/v1/party-invites/{inviteToken}/participants/me
 
 - 회원 작성 요청은 같은 `ParticipantService.joinMember(...)` 경로로 participant를 조회/생성한다.
 - 프론트가 `participants/me`를 먼저 호출하지 못했더라도 작성 API는 participant 생성/복원 fallback을 수행한다.
+- 회원 작성 fallback은 blind insert가 아니라 `ParticipantService.joinMember(...)`의 "기존 participant 조회 -> 없으면 생성 -> `uk_participant_party_user` 위반 시 재조회" 경로를 그대로 사용한다.
 - 작성 API에서 기존 participant를 찾았고 `hasWrittenPaper = true`이면 `ROLLING_PAPER_ALREADY_WRITTEN`으로 실패한다.
 
 주의:

--- a/docs/superpowers/specs/2026-05-04-rolling-paper-write-design.md
+++ b/docs/superpowers/specs/2026-05-04-rolling-paper-write-design.md
@@ -39,16 +39,18 @@
 
 1. 사용자가 공유 링크로 진입한다.
 2. 프론트가 `GET /api/v1/party-invites/{inviteToken}`으로 초대장/파티 요약을 조회한다.
-3. 사용자가 `"롤페 작성하기"`를 누른다.
-4. 프론트가 `GET /api/v1/rolling-paper-wrappers`로 선택 가능한 래퍼 목록을 조회한다.
-5. 사용자가 닉네임, 내용, 래퍼를 모두 입력/선택한다.
-6. 프론트가 `POST /api/v1/party-invites/{inviteToken}/rolling-papers`로 작성한다.
-7. 작성 성공 후 프론트는 해당 파티의 받은 롤링페이퍼 리스트 화면으로 이동한다.
+3. 로그인 회원이면 프론트가 `POST /api/v1/party-invites/{inviteToken}/participants/me`로 회원 참여 상태를 보장한다.
+4. 사용자가 `"롤페 작성하기"`를 누른다.
+5. 프론트가 `GET /api/v1/rolling-paper-wrappers`로 선택 가능한 래퍼 목록을 조회한다.
+6. 사용자가 닉네임, 내용, 래퍼를 모두 입력/선택한다.
+7. 프론트가 `POST /api/v1/party-invites/{inviteToken}/rolling-papers`로 작성한다.
+8. 작성 성공 후 프론트는 해당 파티의 받은 롤링페이퍼 리스트 화면으로 이동한다.
 
 핵심 경계:
 
 - 초대장 조회는 participant를 만들지 않는다.
-- 롤링페이퍼 작성은 participant 생성/복원과 `hasWrittenPaper = true` 갱신을 책임진다.
+- 로그인 회원의 화면 진입 직후 참여 처리는 별도 회원 참여 API가 책임진다.
+- 롤링페이퍼 작성은 작성 시점에 participant가 없으면 생성/복원하고, `hasWrittenPaper = true` 갱신을 책임진다.
 - 래퍼 조회는 공개 조회다.
 - 작성자 닉네임은 실시간 프로필 닉네임과 별개인 롤링페이퍼 작성 당시 스냅샷이다.
 - 비회원은 별도 브라우저 식별자를 두지 않으므로, 서버는 닉네임 중복만 막는다.
@@ -160,7 +162,7 @@ POST /api/v1/party-invites/{inviteToken}/rolling-papers
 
 - `permitAll`
 - Authorization header가 없어도 작성 가능
-- Authorization header가 유효하면 회원 participant를 생성/복원해서 작성한다.
+- Authorization header가 유효하면 회원 participant를 조회하거나 생성해서 작성한다.
 - Authorization header가 없으면 비회원 participant를 생성해서 작성한다.
 - 잘못된 Bearer token은 기존 정책대로 401
 
@@ -210,7 +212,7 @@ UseCase 진입 이후:
 4. 파티 생성 시각 기준 7일이 지나 파티가 종료됐으면 `PARTY_ENDED`.
 5. `wrapperId`로 `RollingPaperWrapper`를 조회한다.
 6. 래퍼가 없으면 `ROLLING_PAPER_WRAPPER_NOT_FOUND`.
-7. 회원이면 파티 내 회원 participant를 조회하거나 생성한다.
+7. 회원이면 파티 내 회원 participant를 조회하고, 아직 없으면 생성한다.
 8. 비회원이면 새 participant를 생성한다.
 9. 회원 participant가 이미 `hasWrittenPaper = true`이면 `ROLLING_PAPER_ALREADY_WRITTEN`.
 10. `writerNickname`, `content`를 trim한다.
@@ -372,6 +374,7 @@ controller -> usecase -> repository/entity/dto
 - `uk_rolling_paper_party_writer_nickname` 위반은 `ROLLING_PAPER_NICKNAME_DUPLICATED`로 변환한다.
 - `uk_rolling_paper_writer_participant` 위반은 `ROLLING_PAPER_ALREADY_WRITTEN`으로 변환한다.
 - `uk_participant_party_user` 위반은 기존 participant 재조회로 복구하고, 복구할 수 없으면 원 예외를 다시 던진다.
+- 회원 participant 생성/복원 공통 로직은 `party/service/ParticipantService`를 사용한다.
 - 이미지 URL 해석은 기존 `GetCharactersUseCase`처럼 `ImageRepository`와 `ImageTargetType`을 사용한다.
 - 래퍼 목록 조회에서는 N+1을 피하기 위해 wrapper id 목록으로 image를 `IN` 조회한다.
 - 현재 `Image`는 `targetType`, `targetId` 기반 공통 이미지 테이블이라 `RollingPaperWrapper`와 직접 JPA 연관관계가 없다. 이 구조에서는 fetch join보다 `ImageRepository`의 bulk 조회 메서드를 추가하는 방식이 더 단순하다.
@@ -410,6 +413,16 @@ ROLLING_PAPER_ALREADY_WRITTEN(HttpStatus.CONFLICT, "이미 롤링페이퍼를 �
 auth.requestMatchers(HttpMethod.GET, "/api/v1/rolling-paper-wrappers").permitAll()
 auth.requestMatchers(HttpMethod.POST, "/api/v1/party-invites/*/rolling-papers").permitAll()
 ```
+
+회원 참여 API:
+
+```http
+POST /api/v1/party-invites/{inviteToken}/participants/me
+```
+
+- 로그인 회원 전용이다.
+- 별도 `permitAll`을 추가하지 않고 `anyRequest().authenticated()`로 보호한다.
+- 만료된 초대 토큰 또는 종료된 파티에는 participant를 생성하지 않는다.
 
 주의:
 

--- a/docs/superpowers/specs/2026-05-04-rolling-paper-write-design.md
+++ b/docs/superpowers/specs/2026-05-04-rolling-paper-write-design.md
@@ -50,7 +50,10 @@
 
 - 초대장 조회는 participant를 만들지 않는다.
 - 로그인 회원의 화면 진입 직후 참여 처리는 별도 회원 참여 API가 책임진다.
-- 롤링페이퍼 작성은 작성 시점에 participant가 없으면 생성/복원하고, `hasWrittenPaper = true` 갱신을 책임진다.
+- 프론트는 로그인 회원이면 롤링페이퍼 작성 전 `participants/me` 호출을 우선한다.
+- 롤링페이퍼 작성 API도 방어적으로 작성 시점에 participant가 없으면 생성/복원한다.
+- 따라서 `participants/me`는 권장 선행 호출이고, 작성 API는 fallback 생성/복원을 가진다.
+- 롤링페이퍼 작성 성공 시점에는 participant의 `hasWrittenPaper = true` 갱신을 작성 API가 책임진다.
 - 래퍼 조회는 공개 조회다.
 - 작성자 닉네임은 실시간 프로필 닉네임과 별개인 롤링페이퍼 작성 당시 스냅샷이다.
 - 비회원은 별도 브라우저 식별자를 두지 않으므로, 서버는 닉네임 중복만 막는다.
@@ -421,8 +424,32 @@ POST /api/v1/party-invites/{inviteToken}/participants/me
 ```
 
 - 로그인 회원 전용이다.
+- 요청 body는 없다.
+- 응답은 `ApiResponse` 래퍼 안에 `participantId`만 내려준다.
+- 이미 참여한 회원이 다시 호출하면 기존 participant를 반환하고 새 participant를 만들지 않는다.
+- 기존 participant를 반환하는 경우 `hasWrittenPaper`, `isCelebrant` 같은 상태 필드는 갱신하지 않는다.
 - 별도 `permitAll`을 추가하지 않고 `anyRequest().authenticated()`로 보호한다.
+- 토큰이 없으면 `PARTY_NOT_FOUND`, 404로 실패한다.
 - 만료된 초대 토큰 또는 종료된 파티에는 participant를 생성하지 않는다.
+- 만료된 초대 토큰은 `INVITE_LINK_EXPIRED`, 400으로 실패한다.
+- 종료된 파티는 `PARTY_ENDED`, 400으로 실패한다.
+
+응답:
+
+```json
+{
+  "status": 200,
+  "data": {
+    "participantId": 1
+  }
+}
+```
+
+롤링페이퍼 작성 API와의 관계:
+
+- 회원 작성 요청은 같은 `ParticipantService.joinMember(...)` 경로로 participant를 조회/생성한다.
+- 프론트가 `participants/me`를 먼저 호출하지 못했더라도 작성 API는 participant 생성/복원 fallback을 수행한다.
+- 작성 API에서 기존 participant를 찾았고 `hasWrittenPaper = true`이면 `ROLLING_PAPER_ALREADY_WRITTEN`으로 실패한다.
 
 주의:
 

--- a/docs/swagger-interface.md
+++ b/docs/swagger-interface.md
@@ -85,10 +85,12 @@ class ExampleController(
     summary = "파티 정보 조회",
     security = [
         SecurityRequirement(name = "Bearer Authentication"),
-        SecurityRequirement(name = ""),  // 토큰 없이도 호출 가능
     ],
 )
+@OptionalAuth
 ```
+
+`@OptionalAuth`를 붙이면 OpenAPI security에 `Bearer Authentication`과 빈 security requirement가 함께 등록되어, 토큰이 없어도 호출 가능한 API로 표시된다.
 
 ### 4. 도메인 특화 에러 응답
 

--- a/src/main/kotlin/com/team2/server/party/controller/PartyInviteLookupApi.kt
+++ b/src/main/kotlin/com/team2/server/party/controller/PartyInviteLookupApi.kt
@@ -3,9 +3,11 @@ package com.team2.server.party.controller
 import com.team2.server.auth.principal.UserPrincipal
 import com.team2.server.common.response.ApiResponse
 import com.team2.server.common.response.ErrorResponse
+import com.team2.server.common.swagger.AuthErrorResponses
 import com.team2.server.common.swagger.InternalServerErrorResponse
 import com.team2.server.common.swagger.OptionalAuth
 import com.team2.server.party.dto.PartyInviteLookupResponse
+import com.team2.server.party.dto.PartyInviteParticipationResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
@@ -59,4 +61,83 @@ interface PartyInviteLookupApi {
         @Parameter(hidden = true) principal: UserPrincipal?,
         @Parameter(description = "초대 토큰", example = "exampletoken0000") inviteToken: String,
     ): ApiResponse<PartyInviteLookupResponse>
+
+    @Operation(
+        summary = "회원 초대장 참여",
+        description =
+            "로그인 회원을 초대 토큰의 파티 참여자로 생성하거나 기존 참여자를 반환한다. " +
+                "만료된 초대 토큰 또는 종료된 파티에는 참여자를 생성하지 않는다.",
+        security = [
+            SecurityRequirement(name = "Bearer Authentication"),
+        ],
+    )
+    @SwaggerApiResponse(
+        responseCode = "200",
+        description = "회원 참여자 생성 또는 조회 성공",
+    )
+    @AuthErrorResponses
+    @SwaggerApiResponse(
+        responseCode = "400",
+        description = "만료된 초대 토큰 또는 종료된 파티",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = ErrorResponse::class),
+                examples = [
+                    ExampleObject(
+                        name = "만료된 초대 토큰",
+                        value = """
+                            {
+                              "status": 400,
+                              "error": {
+                                "code": "INVITE_LINK_EXPIRED",
+                                "message": "만료된 초대링크입니다"
+                              }
+                            }
+                        """,
+                    ),
+                    ExampleObject(
+                        name = "종료된 파티",
+                        value = """
+                            {
+                              "status": 400,
+                              "error": {
+                                "code": "PARTY_ENDED",
+                                "message": "이미 종료된 파티입니다"
+                              }
+                            }
+                        """,
+                    ),
+                ],
+            ),
+        ],
+    )
+    @SwaggerApiResponse(
+        responseCode = "404",
+        description = "존재하지 않는 초대 토큰",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = ErrorResponse::class),
+                examples = [
+                    ExampleObject(
+                        value = """
+                            {
+                              "status": 404,
+                              "error": {
+                                "code": "PARTY_NOT_FOUND",
+                                "message": "파티를 찾을 수 없습니다"
+                              }
+                            }
+                        """,
+                    ),
+                ],
+            ),
+        ],
+    )
+    @InternalServerErrorResponse
+    fun joinPartyInvite(
+        @Parameter(hidden = true) principal: UserPrincipal,
+        @Parameter(description = "초대 토큰", example = "exampletoken0000") inviteToken: String,
+    ): ApiResponse<PartyInviteParticipationResponse>
 }

--- a/src/main/kotlin/com/team2/server/party/controller/PartyInviteLookupController.kt
+++ b/src/main/kotlin/com/team2/server/party/controller/PartyInviteLookupController.kt
@@ -3,10 +3,13 @@ package com.team2.server.party.controller
 import com.team2.server.auth.principal.UserPrincipal
 import com.team2.server.common.response.ApiResponse
 import com.team2.server.party.dto.PartyInviteLookupResponse
+import com.team2.server.party.dto.PartyInviteParticipationResponse
+import com.team2.server.party.usecase.JoinPartyInviteUseCase
 import com.team2.server.party.usecase.LookupPartyInviteUseCase
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -14,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1/party-invites")
 class PartyInviteLookupController(
     private val lookupPartyInviteUseCase: LookupPartyInviteUseCase,
+    private val joinPartyInviteUseCase: JoinPartyInviteUseCase,
 ) : PartyInviteLookupApi {
     @GetMapping("/{inviteToken}")
     override fun getPartyInvite(
@@ -21,4 +25,11 @@ class PartyInviteLookupController(
         @PathVariable inviteToken: String,
     ): ApiResponse<PartyInviteLookupResponse> =
         ApiResponse.success(lookupPartyInviteUseCase.lookup(inviteToken, principal?.userId))
+
+    @PostMapping("/{inviteToken}/participants/me")
+    override fun joinPartyInvite(
+        @AuthenticationPrincipal principal: UserPrincipal,
+        @PathVariable inviteToken: String,
+    ): ApiResponse<PartyInviteParticipationResponse> =
+        ApiResponse.success(joinPartyInviteUseCase.join(inviteToken, principal.userId))
 }

--- a/src/main/kotlin/com/team2/server/party/dto/PartyInviteLookupResponse.kt
+++ b/src/main/kotlin/com/team2/server/party/dto/PartyInviteLookupResponse.kt
@@ -9,8 +9,12 @@ import java.time.LocalDateTime
 @JsonInclude(JsonInclude.Include.ALWAYS)
 @Schema(description = "초대장 조회 응답")
 data class PartyInviteLookupResponse(
+    @Schema(description = "파티 ID", example = "1")
+    val partyId: Long,
     @Schema(description = "파티 주인공 이름", example = "홍길동")
     val celebrantNickname: String?,
+    @Schema(description = "현재 조회자가 파티 주최자인지 여부", example = "false")
+    val isHost: Boolean,
     @Schema(
         description = "파티 옵션. REALTIME: 실시간 파티, PAPER_ONLY: 롤링페이퍼 전용 파티",
         allowableValues = ["REALTIME", "PAPER_ONLY"],

--- a/src/main/kotlin/com/team2/server/party/dto/PartyInviteParticipationResponse.kt
+++ b/src/main/kotlin/com/team2/server/party/dto/PartyInviteParticipationResponse.kt
@@ -1,0 +1,9 @@
+package com.team2.server.party.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "초대장 회원 참여 응답")
+data class PartyInviteParticipationResponse(
+    @Schema(description = "참여자 ID", example = "1")
+    val participantId: Long,
+)

--- a/src/main/kotlin/com/team2/server/party/service/ParticipantService.kt
+++ b/src/main/kotlin/com/team2/server/party/service/ParticipantService.kt
@@ -1,0 +1,45 @@
+package com.team2.server.party.service
+
+import com.team2.server.common.exception.isConstraintViolation
+import com.team2.server.party.entity.Participant
+import com.team2.server.party.entity.Party
+import com.team2.server.party.repository.ParticipantRepository
+import com.team2.server.user.entity.User
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.stereotype.Service
+
+@Service
+class ParticipantService(
+    private val participantRepository: ParticipantRepository,
+) {
+    fun joinMember(
+        party: Party,
+        user: User,
+    ): Participant =
+        participantRepository.findByPartyAndUser(party, user)
+            ?: createMemberParticipant(party, user)
+
+    fun joinAnonymous(party: Party): Participant = participantRepository.save(Participant(party = party))
+
+    private fun createMemberParticipant(
+        party: Party,
+        user: User,
+    ): Participant =
+        try {
+            participantRepository.saveAndFlush(
+                Participant(
+                    party = party,
+                    user = user,
+                ),
+            )
+        } catch (e: DataIntegrityViolationException) {
+            if (!e.isConstraintViolation(PARTICIPANT_UNIQUE_CONSTRAINT)) {
+                throw e
+            }
+            participantRepository.findByPartyAndUser(party, user) ?: throw e
+        }
+
+    companion object {
+        private const val PARTICIPANT_UNIQUE_CONSTRAINT = "uk_participant_party_user"
+    }
+}

--- a/src/main/kotlin/com/team2/server/party/service/PartyInviteService.kt
+++ b/src/main/kotlin/com/team2/server/party/service/PartyInviteService.kt
@@ -42,6 +42,21 @@ class PartyInviteService(
         return ActivateInviteLinkResponse(token = invite.token)
     }
 
+    fun findUsableInvite(
+        inviteToken: String,
+        now: LocalDateTime,
+    ): PartyInvite {
+        val invite =
+            partyInviteRepository.findByToken(inviteToken)
+                ?: throw BusinessException(ErrorCode.PARTY_NOT_FOUND)
+
+        if (!invite.expiresAt.isAfter(now)) {
+            throw BusinessException(ErrorCode.INVITE_LINK_EXPIRED)
+        }
+
+        return invite
+    }
+
     private fun canActivateInviteLink(
         party: Party,
         userId: Long,

--- a/src/main/kotlin/com/team2/server/party/usecase/JoinPartyInviteUseCase.kt
+++ b/src/main/kotlin/com/team2/server/party/usecase/JoinPartyInviteUseCase.kt
@@ -1,0 +1,54 @@
+package com.team2.server.party.usecase
+
+import com.team2.server.common.exception.BusinessException
+import com.team2.server.common.exception.ErrorCode
+import com.team2.server.party.dto.PartyInviteParticipationResponse
+import com.team2.server.party.entity.PartyInvite
+import com.team2.server.party.repository.PartyInviteRepository
+import com.team2.server.party.service.ParticipantService
+import com.team2.server.user.repository.UserRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service
+class JoinPartyInviteUseCase(
+    private val partyInviteRepository: PartyInviteRepository,
+    private val userRepository: UserRepository,
+    private val participantService: ParticipantService,
+) {
+    @Transactional
+    fun join(
+        inviteToken: String,
+        userId: Long,
+    ): PartyInviteParticipationResponse {
+        val invite = findInvite(inviteToken)
+        val now = LocalDateTime.now()
+        validateInvite(invite, now)
+
+        val party = invite.party
+        if (party.isEnded(now)) {
+            throw BusinessException(ErrorCode.PARTY_ENDED)
+        }
+
+        val user =
+            userRepository.findByIdOrNull(userId)
+                ?: throw BusinessException(ErrorCode.AUTH_USER_NOT_FOUND)
+        val participant = participantService.joinMember(party, user)
+        return PartyInviteParticipationResponse(participantId = participant.id)
+    }
+
+    private fun findInvite(inviteToken: String): PartyInvite =
+        partyInviteRepository.findByToken(inviteToken)
+            ?: throw BusinessException(ErrorCode.PARTY_NOT_FOUND)
+
+    private fun validateInvite(
+        invite: PartyInvite,
+        now: LocalDateTime,
+    ) {
+        if (!invite.expiresAt.isAfter(now)) {
+            throw BusinessException(ErrorCode.INVITE_LINK_EXPIRED)
+        }
+    }
+}

--- a/src/main/kotlin/com/team2/server/party/usecase/JoinPartyInviteUseCase.kt
+++ b/src/main/kotlin/com/team2/server/party/usecase/JoinPartyInviteUseCase.kt
@@ -3,9 +3,8 @@ package com.team2.server.party.usecase
 import com.team2.server.common.exception.BusinessException
 import com.team2.server.common.exception.ErrorCode
 import com.team2.server.party.dto.PartyInviteParticipationResponse
-import com.team2.server.party.entity.PartyInvite
-import com.team2.server.party.repository.PartyInviteRepository
 import com.team2.server.party.service.ParticipantService
+import com.team2.server.party.service.PartyInviteService
 import com.team2.server.user.repository.UserRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -14,18 +13,17 @@ import java.time.LocalDateTime
 
 @Service
 class JoinPartyInviteUseCase(
-    private val partyInviteRepository: PartyInviteRepository,
     private val userRepository: UserRepository,
     private val participantService: ParticipantService,
+    private val partyInviteService: PartyInviteService,
 ) {
     @Transactional
     fun join(
         inviteToken: String,
         userId: Long,
     ): PartyInviteParticipationResponse {
-        val invite = findInvite(inviteToken)
         val now = LocalDateTime.now()
-        validateInvite(invite, now)
+        val invite = partyInviteService.findUsableInvite(inviteToken, now)
 
         val party = invite.party
         if (party.isEnded(now)) {
@@ -37,18 +35,5 @@ class JoinPartyInviteUseCase(
                 ?: throw BusinessException(ErrorCode.AUTH_USER_NOT_FOUND)
         val participant = participantService.joinMember(party, user)
         return PartyInviteParticipationResponse(participantId = participant.id)
-    }
-
-    private fun findInvite(inviteToken: String): PartyInvite =
-        partyInviteRepository.findByToken(inviteToken)
-            ?: throw BusinessException(ErrorCode.PARTY_NOT_FOUND)
-
-    private fun validateInvite(
-        invite: PartyInvite,
-        now: LocalDateTime,
-    ) {
-        if (!invite.expiresAt.isAfter(now)) {
-            throw BusinessException(ErrorCode.INVITE_LINK_EXPIRED)
-        }
     }
 }

--- a/src/main/kotlin/com/team2/server/party/usecase/LookupPartyInviteUseCase.kt
+++ b/src/main/kotlin/com/team2/server/party/usecase/LookupPartyInviteUseCase.kt
@@ -32,7 +32,9 @@ class LookupPartyInviteUseCase(
         val isRealtime = party.partyOption == PartyOption.REALTIME
 
         return PartyInviteLookupResponse(
+            partyId = party.id,
             celebrantNickname = party.celebrantNickname,
+            isHost = isHost(party, userId),
             partyOption = party.partyOption,
             partyEnded = !now.isBefore(partyEndAt),
             rollingPaperWritten = hasWrittenPaper(party, userId),
@@ -41,6 +43,11 @@ class LookupPartyInviteUseCase(
             realtimeSchedule = if (isRealtime) createRealtimeSchedule(party) else null,
         )
     }
+
+    private fun isHost(
+        party: Party,
+        userId: Long?,
+    ): Boolean = userId != null && party.ownerId == userId
 
     private fun hasWrittenPaper(
         party: Party,

--- a/src/main/kotlin/com/team2/server/rollingpaper/usecase/CreateRollingPaperUseCase.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/usecase/CreateRollingPaperUseCase.kt
@@ -5,9 +5,8 @@ import com.team2.server.common.exception.ErrorCode
 import com.team2.server.common.exception.isConstraintViolation
 import com.team2.server.party.entity.Participant
 import com.team2.server.party.entity.Party
-import com.team2.server.party.entity.PartyInvite
-import com.team2.server.party.repository.PartyInviteRepository
 import com.team2.server.party.service.ParticipantService
+import com.team2.server.party.service.PartyInviteService
 import com.team2.server.rollingpaper.dto.CreateRollingPaperRequest
 import com.team2.server.rollingpaper.dto.CreateRollingPaperResponse
 import com.team2.server.rollingpaper.entity.RollingPaper
@@ -24,11 +23,11 @@ import java.time.LocalDateTime
 
 @Service
 class CreateRollingPaperUseCase(
-    private val partyInviteRepository: PartyInviteRepository,
     private val rollingPaperWrapperRepository: RollingPaperWrapperRepository,
     private val rollingPaperRepository: RollingPaperRepository,
     private val userRepository: UserRepository,
     private val participantService: ParticipantService,
+    private val partyInviteService: PartyInviteService,
 ) {
     @Transactional
     fun create(
@@ -36,9 +35,8 @@ class CreateRollingPaperUseCase(
         userId: Long?,
         request: CreateRollingPaperRequest,
     ): CreateRollingPaperResponse {
-        val invite = findInvite(inviteToken)
         val now = LocalDateTime.now()
-        validateInvite(invite, now)
+        val invite = partyInviteService.findUsableInvite(inviteToken, now)
         val party = invite.party
         validatePartyWritable(party, now)
 
@@ -53,19 +51,6 @@ class CreateRollingPaperUseCase(
         val rollingPaper = saveRollingPaper(wrapper, participant, party, writerNickname, content)
         participant.hasWrittenPaper = true
         return CreateRollingPaperResponse(rollingPaperId = rollingPaper.id)
-    }
-
-    private fun findInvite(inviteToken: String): PartyInvite =
-        partyInviteRepository.findByToken(inviteToken)
-            ?: throw BusinessException(ErrorCode.PARTY_NOT_FOUND)
-
-    private fun validateInvite(
-        invite: PartyInvite,
-        now: LocalDateTime,
-    ) {
-        if (!invite.expiresAt.isAfter(now)) {
-            throw BusinessException(ErrorCode.INVITE_LINK_EXPIRED)
-        }
     }
 
     private fun validatePartyWritable(

--- a/src/main/kotlin/com/team2/server/rollingpaper/usecase/CreateRollingPaperUseCase.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/usecase/CreateRollingPaperUseCase.kt
@@ -6,8 +6,8 @@ import com.team2.server.common.exception.isConstraintViolation
 import com.team2.server.party.entity.Participant
 import com.team2.server.party.entity.Party
 import com.team2.server.party.entity.PartyInvite
-import com.team2.server.party.repository.ParticipantRepository
 import com.team2.server.party.repository.PartyInviteRepository
+import com.team2.server.party.service.ParticipantService
 import com.team2.server.rollingpaper.dto.CreateRollingPaperRequest
 import com.team2.server.rollingpaper.dto.CreateRollingPaperResponse
 import com.team2.server.rollingpaper.entity.RollingPaper
@@ -15,7 +15,6 @@ import com.team2.server.rollingpaper.entity.RollingPaperWrapper
 import com.team2.server.rollingpaper.entity.toWriterNicknameKey
 import com.team2.server.rollingpaper.repository.RollingPaperRepository
 import com.team2.server.rollingpaper.repository.RollingPaperWrapperRepository
-import com.team2.server.user.entity.User
 import com.team2.server.user.repository.UserRepository
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.data.repository.findByIdOrNull
@@ -27,9 +26,9 @@ import java.time.LocalDateTime
 class CreateRollingPaperUseCase(
     private val partyInviteRepository: PartyInviteRepository,
     private val rollingPaperWrapperRepository: RollingPaperWrapperRepository,
-    private val participantRepository: ParticipantRepository,
     private val rollingPaperRepository: RollingPaperRepository,
     private val userRepository: UserRepository,
+    private val participantService: ParticipantService,
 ) {
     @Transactional
     fun create(
@@ -93,32 +92,14 @@ class CreateRollingPaperUseCase(
         userId: Long?,
     ): Participant {
         if (userId == null) {
-            return participantRepository.save(Participant(party = party))
+            return participantService.joinAnonymous(party)
         }
 
         val user =
             userRepository.findByIdOrNull(userId)
                 ?: throw BusinessException(ErrorCode.AUTH_USER_NOT_FOUND)
-        return participantRepository.findByPartyAndUser(party, user) ?: createMemberParticipant(party, user)
+        return participantService.joinMember(party, user)
     }
-
-    private fun createMemberParticipant(
-        party: Party,
-        user: User,
-    ): Participant =
-        try {
-            participantRepository.saveAndFlush(
-                Participant(
-                    party = party,
-                    user = user,
-                ),
-            )
-        } catch (e: DataIntegrityViolationException) {
-            if (!e.isConstraintViolation("uk_participant_party_user")) {
-                throw e
-            }
-            participantRepository.findByPartyAndUser(party, user) ?: throw e
-        }
 
     private fun validateWriterNicknameAvailable(
         party: Party,

--- a/src/test/kotlin/com/team2/server/party/controller/PartyInviteLookupControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/party/controller/PartyInviteLookupControllerTest.kt
@@ -21,10 +21,12 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -153,6 +155,133 @@ class PartyInviteLookupControllerTest
                     status { isOk() }
                     jsonPath("$.data.rollingPaperWritten") { value(true) }
                 }
+        }
+
+        @Test
+        fun `인증 회원은 초대장 참여 API로 participant를 생성한다`() {
+            val user = saveUser("kakao-join", "join@kakao.local")
+            val party =
+                saveParty(
+                    PaperOnlyParty(
+                        ownerId = 1L,
+                        celebrantNickname = "홍길동",
+                        startedAt = LocalDateTime.now().toLocalDate().atStartOfDay(),
+                    ),
+                    LocalDateTime.now().minusDays(1),
+                )
+            saveInvite(party, "memberjoin0001")
+            val accessToken = tokenProvider.issue(user)
+
+            mockMvc
+                .post("/api/v1/party-invites/memberjoin0001/participants/me") {
+                    header("Authorization", "Bearer $accessToken")
+                }.andExpect {
+                    status { isOk() }
+                    jsonPath("$.status") { value(200) }
+                    jsonPath("$.data.participantId") { exists() }
+                }
+
+            val participant = assertNotNull(participantRepository.findByPartyAndUser(party, user))
+            assertEquals(false, participant.hasWrittenPaper)
+        }
+
+        @Test
+        fun `이미 참여한 회원이 초대장 참여 API를 다시 호출하면 기존 participant를 반환한다`() {
+            val user = saveUser("kakao-join-existing", "join-existing@kakao.local")
+            val party =
+                saveParty(
+                    PaperOnlyParty(
+                        ownerId = 1L,
+                        celebrantNickname = "홍길동",
+                        startedAt = LocalDateTime.now().toLocalDate().atStartOfDay(),
+                    ),
+                    LocalDateTime.now().minusDays(1),
+                )
+            val existingParticipant = participantRepository.saveAndFlush(Participant(party = party, user = user))
+            saveInvite(party, "memberjoin0002")
+            val accessToken = tokenProvider.issue(user)
+
+            mockMvc
+                .post("/api/v1/party-invites/memberjoin0002/participants/me") {
+                    header("Authorization", "Bearer $accessToken")
+                }.andExpect {
+                    status { isOk() }
+                    jsonPath("$.data.participantId") { value(existingParticipant.id) }
+                }
+
+            assertEquals(1, participantRepository.findAllByPartyId(party.id).size)
+        }
+
+        @Test
+        fun `인증 없이 초대장 참여 API를 호출하면 401`() {
+            mockMvc.post("/api/v1/party-invites/memberjoin0003/participants/me").andExpect {
+                status { isUnauthorized() }
+                jsonPath("$.error.code") { value("AUTH_UNAUTHORIZED") }
+            }
+        }
+
+        @Test
+        fun `잘못된 Bearer 토큰으로 초대장 참여 API를 호출하면 401`() {
+            mockMvc
+                .post("/api/v1/party-invites/memberjoin0004/participants/me") {
+                    header("Authorization", "Bearer not-a-jwt")
+                }.andExpect {
+                    status { isUnauthorized() }
+                    jsonPath("$.error.code") { value("AUTH_INVALID_TOKEN") }
+                }
+        }
+
+        @Test
+        fun `만료된 초대 토큰으로 참여하면 participant를 생성하지 않고 실패한다`() {
+            val user = saveUser("kakao-expired-join", "expired-join@kakao.local")
+            val party =
+                saveParty(
+                    PaperOnlyParty(
+                        ownerId = 1L,
+                        celebrantNickname = "홍길동",
+                        startedAt = LocalDateTime.now().toLocalDate().atStartOfDay(),
+                    ),
+                    LocalDateTime.now().minusDays(1),
+                )
+            saveInvite(party, "expiredjoin001", LocalDateTime.now().minusHours(1))
+            val accessToken = tokenProvider.issue(user)
+
+            mockMvc
+                .post("/api/v1/party-invites/expiredjoin001/participants/me") {
+                    header("Authorization", "Bearer $accessToken")
+                }.andExpect {
+                    status { isBadRequest() }
+                    jsonPath("$.error.code") { value("INVITE_LINK_EXPIRED") }
+                }
+
+            assertEquals(0, participantRepository.count())
+        }
+
+        @Test
+        fun `종료된 파티에 참여하면 participant를 생성하지 않고 실패한다`() {
+            val user = saveUser("kakao-ended-join", "ended-join@kakao.local")
+            val createdAt = LocalDateTime.now().minusDays(8).truncatedTo(ChronoUnit.SECONDS)
+            val party =
+                saveParty(
+                    PaperOnlyParty(
+                        ownerId = 1L,
+                        celebrantNickname = "홍길동",
+                        startedAt = createdAt.toLocalDate().atStartOfDay(),
+                    ),
+                    createdAt,
+                )
+            saveInvite(party, "endedjoin00001", LocalDateTime.now().plusHours(1))
+            val accessToken = tokenProvider.issue(user)
+
+            mockMvc
+                .post("/api/v1/party-invites/endedjoin00001/participants/me") {
+                    header("Authorization", "Bearer $accessToken")
+                }.andExpect {
+                    status { isBadRequest() }
+                    jsonPath("$.error.code") { value("PARTY_ENDED") }
+                }
+
+            assertEquals(0, participantRepository.count())
         }
 
         @Test

--- a/src/test/kotlin/com/team2/server/party/controller/PartyInviteLookupControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/party/controller/PartyInviteLookupControllerTest.kt
@@ -67,8 +67,9 @@ class PartyInviteLookupControllerTest
             mockMvc.get("/api/v1/party-invites/paperlookup0001").andExpect {
                 status { isOk() }
                 jsonPath("$.status") { value(200) }
-                jsonPath("$.data.partyId") { doesNotExist() }
+                jsonPath("$.data.partyId") { value(party.id) }
                 jsonPath("$.data.celebrantNickname") { value("홍길동") }
+                jsonPath("$.data.isHost") { value(false) }
                 jsonPath("$.data.partyOption") { value("PAPER_ONLY") }
                 jsonPath("$.data.partyEnded") { value(false) }
                 jsonPath("$.data.rollingPaperWritten") { value(false) }
@@ -122,7 +123,7 @@ class PartyInviteLookupControllerTest
 
             mockMvc.get("/api/v1/party-invites/expiredlookup1").andExpect {
                 status { isOk() }
-                jsonPath("$.data.partyId") { doesNotExist() }
+                jsonPath("$.data.partyId") { value(party.id) }
             }
         }
 
@@ -153,7 +154,34 @@ class PartyInviteLookupControllerTest
                     header("Authorization", "Bearer $accessToken")
                 }.andExpect {
                     status { isOk() }
+                    jsonPath("$.data.partyId") { value(party.id) }
+                    jsonPath("$.data.isHost") { value(true) }
                     jsonPath("$.data.rollingPaperWritten") { value(true) }
+                }
+        }
+
+        @Test
+        fun `인증 회원이 주최자가 아니면 isHost false`() {
+            val user = saveUser("kakao-lookup-guest", "lookup-guest@kakao.local")
+            val party =
+                saveParty(
+                    PaperOnlyParty(
+                        ownerId = 999L,
+                        celebrantNickname = "홍길동",
+                        startedAt = LocalDateTime.now().toLocalDate().atStartOfDay(),
+                    ),
+                    LocalDateTime.now().minusDays(1),
+                )
+            saveInvite(party, "hostlookup0001")
+            val accessToken = tokenProvider.issue(user)
+
+            mockMvc
+                .get("/api/v1/party-invites/hostlookup0001") {
+                    header("Authorization", "Bearer $accessToken")
+                }.andExpect {
+                    status { isOk() }
+                    jsonPath("$.data.partyId") { value(party.id) }
+                    jsonPath("$.data.isHost") { value(false) }
                 }
         }
 


### PR DESCRIPTION
## 🔗 Issue
- closes #110

## 💬 Context
초대장 조회는 read-only로 유지하고, 로그인 회원의 참여 상태 보장은 별도 POST API로 분리합니다. 초대장 조회 응답에는 후속 화면 분기를 위해 `partyId`, `isHost`를 추가합니다.

## 🛠 Changes
- `POST /api/v1/party-invites/{inviteToken}/participants/me` 추가
- 회원/비회원 participant 생성 로직을 `ParticipantService`로 공통화
- 사용 가능한 초대 토큰 조회 및 만료 검증을 `PartyInviteService.findUsableInvite`로 공통화
- 초대장 조회 응답에 `partyId`, `isHost` 추가
- Swagger/설계 문서 및 통합 테스트 갱신

## 👀 Review Focus
- GET 초대장 조회와 POST 회원 참여의 책임 분리가 적절한지
- participant 생성/복원 멱등성과 unique constraint 복구 흐름
- 초대장 조회 응답의 `partyId`, `isHost` 계약

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

검증:
- `./gradlew test --tests com.team2.server.party.controller.PartyInviteLookupControllerTest`
- `./gradlew test --tests com.team2.server.party.controller.PartyInviteLookupControllerTest --tests com.team2.server.rollingpaper.controller.RollingPaperControllerTest --tests com.team2.server.party.service.PartyInviteServiceTest`
- `./gradlew check`

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 초대 토큰으로 파티 정보 조회 기능 추가 (공개 API)
  * 인증된 사용자가 초대 링크를 통해 파티 참여 가능
  * 조회 응답에 파티 ID, 호스트 여부, 실시간 일정 정보 포함
  * 멤버 및 비멤버 참여자 통합 지원
  * 롤링페이퍼에 래퍼 기반 선택 시스템 추가

* **문서화**
  * API 엔드포인트 문서 업데이트 및 에러 코드 확장

<!-- end of auto-generated comment: release notes by coderabbit.ai -->