### PR TITLE
[Feat] 주최자 롤링페이퍼 상세 조회 API 추가

### DIFF
--- a/src/main/kotlin/com/team2/server/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/team2/server/common/exception/ErrorCode.kt
@@ -30,4 +30,5 @@ enum class ErrorCode(
     ROLLING_PAPER_NICKNAME_DUPLICATED(HttpStatus.CONFLICT, "이미 사용 중인 롤링페이퍼 닉네임입니다"),
     ROLLING_PAPER_ALREADY_WRITTEN(HttpStatus.CONFLICT, "이미 롤링페이퍼를 작성했습니다"),
     ROLLING_PAPER_NOT_VIEWABLE(HttpStatus.FORBIDDEN, "아직 롤링페이퍼를 확인할 수 없습니다"),
+    ROLLING_PAPER_NOT_FOUND(HttpStatus.NOT_FOUND, "롤링페이퍼를 찾을 수 없습니다"),
 }

--- a/src/main/kotlin/com/team2/server/rollingpaper/controller/RollingPaperOwnerApi.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/controller/RollingPaperOwnerApi.kt
@@ -5,6 +5,7 @@ import com.team2.server.common.response.ApiResponse
 import com.team2.server.common.response.ErrorResponse
 import com.team2.server.common.swagger.AuthErrorResponses
 import com.team2.server.common.swagger.InternalServerErrorResponse
+import com.team2.server.rollingpaper.dto.OwnerRollingPaperDetailResponse
 import com.team2.server.rollingpaper.dto.OwnerRollingPaperListResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -93,4 +94,93 @@ interface RollingPaperOwnerApi {
         @Parameter(description = "파티 ID", example = "1") partyId: Long,
         @Parameter(description = "페이지 번호. 1보다 작으면 1로 보정합니다.", example = "1") page: Int,
     ): ApiResponse<OwnerRollingPaperListResponse>
+
+    @Operation(
+        summary = "주최자용 롤링페이퍼 상세 조회",
+        description = "인증된 파티 소유자가 롤링페이퍼 상세 내용을 조회한다.",
+        security = [SecurityRequirement(name = "Bearer Authentication")],
+    )
+    @SwaggerApiResponse(
+        responseCode = "200",
+        description = "주최자용 롤링페이퍼 상세 조회 성공",
+    )
+    @AuthErrorResponses
+    @SwaggerApiResponse(
+        responseCode = "403",
+        description = "파티 권한 없음 또는 아직 열람 불가",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = ErrorResponse::class),
+                examples = [
+                    ExampleObject(
+                        name = "파티 권한 없음",
+                        value = """
+                            {
+                              "status": 403,
+                              "error": {
+                                "code": "PARTY_FORBIDDEN",
+                                "message": "파티에 대한 권한이 없습니다"
+                              }
+                            }
+                        """,
+                    ),
+                    ExampleObject(
+                        name = "아직 열람 불가",
+                        value = """
+                            {
+                              "status": 403,
+                              "error": {
+                                "code": "ROLLING_PAPER_NOT_VIEWABLE",
+                                "message": "아직 롤링페이퍼를 확인할 수 없습니다"
+                              }
+                            }
+                        """,
+                    ),
+                ],
+            ),
+        ],
+    )
+    @SwaggerApiResponse(
+        responseCode = "404",
+        description = "파티 또는 롤링페이퍼 없음",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = ErrorResponse::class),
+                examples = [
+                    ExampleObject(
+                        name = "파티 없음",
+                        value = """
+                            {
+                              "status": 404,
+                              "error": {
+                                "code": "PARTY_NOT_FOUND",
+                                "message": "파티를 찾을 수 없습니다"
+                              }
+                            }
+                        """,
+                    ),
+                    ExampleObject(
+                        name = "롤링페이퍼 없음",
+                        value = """
+                            {
+                              "status": 404,
+                              "error": {
+                                "code": "ROLLING_PAPER_NOT_FOUND",
+                                "message": "롤링페이퍼를 찾을 수 없습니다"
+                              }
+                            }
+                        """,
+                    ),
+                ],
+            ),
+        ],
+    )
+    @InternalServerErrorResponse
+    fun getOwnerRollingPaperDetail(
+        @Parameter(hidden = true) principal: UserPrincipal,
+        @Parameter(description = "파티 ID", example = "1") partyId: Long,
+        @Parameter(description = "롤링페이퍼 ID", example = "10") rollingPaperId: Long,
+    ): ApiResponse<OwnerRollingPaperDetailResponse>
 }

--- a/src/main/kotlin/com/team2/server/rollingpaper/controller/RollingPaperOwnerController.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/controller/RollingPaperOwnerController.kt
@@ -2,7 +2,9 @@ package com.team2.server.rollingpaper.controller
 
 import com.team2.server.auth.principal.UserPrincipal
 import com.team2.server.common.response.ApiResponse
+import com.team2.server.rollingpaper.dto.OwnerRollingPaperDetailResponse
 import com.team2.server.rollingpaper.dto.OwnerRollingPaperListResponse
+import com.team2.server.rollingpaper.usecase.GetRollingPaperDetailUseCase
 import com.team2.server.rollingpaper.usecase.GetRollingPaperListUseCase
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v1/parties")
 class RollingPaperOwnerController(
     private val getRollingPaperListUseCase: GetRollingPaperListUseCase,
+    private val getRollingPaperDetailUseCase: GetRollingPaperDetailUseCase,
 ) : RollingPaperOwnerApi {
     @GetMapping("/{partyId}/rolling-papers")
     override fun getOwnerRollingPapers(
@@ -23,4 +26,12 @@ class RollingPaperOwnerController(
         @RequestParam(defaultValue = "1") page: Int,
     ): ApiResponse<OwnerRollingPaperListResponse> =
         ApiResponse.success(getRollingPaperListUseCase.getOwnerList(partyId, principal.userId, page))
+
+    @GetMapping("/{partyId}/rolling-papers/{rollingPaperId}")
+    override fun getOwnerRollingPaperDetail(
+        @AuthenticationPrincipal principal: UserPrincipal,
+        @PathVariable partyId: Long,
+        @PathVariable rollingPaperId: Long,
+    ): ApiResponse<OwnerRollingPaperDetailResponse> =
+        ApiResponse.success(getRollingPaperDetailUseCase.getOwnerDetail(partyId, rollingPaperId, principal.userId))
 }

--- a/src/main/kotlin/com/team2/server/rollingpaper/dto/OwnerRollingPaperDetailResponse.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/dto/OwnerRollingPaperDetailResponse.kt
@@ -14,4 +14,8 @@ data class OwnerRollingPaperDetailResponse(
     val position: Long,
     @Schema(description = "파티의 전체 롤링페이퍼 수", example = "12")
     val totalCount: Long,
+    @Schema(description = "최신순 화면 순서상 바로 이전 롤링페이퍼 ID. 첫 번째 롤링페이퍼면 null", example = "11")
+    val previousRollingPaperId: Long?,
+    @Schema(description = "최신순 화면 순서상 바로 다음 롤링페이퍼 ID. 마지막 롤링페이퍼면 null", example = "9")
+    val nextRollingPaperId: Long?,
 )

--- a/src/main/kotlin/com/team2/server/rollingpaper/dto/OwnerRollingPaperDetailResponse.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/dto/OwnerRollingPaperDetailResponse.kt
@@ -1,0 +1,17 @@
+package com.team2.server.rollingpaper.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "주최자용 롤링페이퍼 상세 조회 응답")
+data class OwnerRollingPaperDetailResponse(
+    @Schema(description = "롤링페이퍼 ID", example = "10")
+    val rollingPaperId: Long,
+    @Schema(description = "롤링페이퍼 내용", example = "생일 축하해요!")
+    val content: String,
+    @Schema(description = "롤링페이퍼 작성자 닉네임", example = "축하요정")
+    val writerNickname: String,
+    @Schema(description = "최신순 기준 현재 롤링페이퍼 순번. 1부터 시작합니다.", example = "1")
+    val position: Long,
+    @Schema(description = "파티의 전체 롤링페이퍼 수", example = "12")
+    val totalCount: Long,
+)

--- a/src/main/kotlin/com/team2/server/rollingpaper/repository/RollingPaperRepository.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/repository/RollingPaperRepository.kt
@@ -48,6 +48,44 @@ interface RollingPaperRepository : JpaRepository<RollingPaper, Long> {
         @Param("rollingPaperId") rollingPaperId: Long,
     ): Long
 
+    @Query(
+        """
+            SELECT rp.id
+            FROM RollingPaper rp
+            WHERE rp.party = :party
+              AND (
+                rp.createdAt > :createdAt OR
+                (rp.createdAt = :createdAt AND rp.id > :rollingPaperId)
+              )
+            ORDER BY rp.createdAt ASC, rp.id ASC
+        """,
+    )
+    fun findPreviousIdsByParty(
+        @Param("party") party: Party,
+        @Param("createdAt") createdAt: LocalDateTime,
+        @Param("rollingPaperId") rollingPaperId: Long,
+        pageable: Pageable,
+    ): List<Long>
+
+    @Query(
+        """
+            SELECT rp.id
+            FROM RollingPaper rp
+            WHERE rp.party = :party
+              AND (
+                rp.createdAt < :createdAt OR
+                (rp.createdAt = :createdAt AND rp.id < :rollingPaperId)
+              )
+            ORDER BY rp.createdAt DESC, rp.id DESC
+        """,
+    )
+    fun findNextIdsByParty(
+        @Param("party") party: Party,
+        @Param("createdAt") createdAt: LocalDateTime,
+        @Param("rollingPaperId") rollingPaperId: Long,
+        pageable: Pageable,
+    ): List<Long>
+
     @Modifying
     @Transactional
     fun deleteAllByPartyId(partyId: Long)

--- a/src/main/kotlin/com/team2/server/rollingpaper/repository/RollingPaperRepository.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/repository/RollingPaperRepository.kt
@@ -7,7 +7,10 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 interface RollingPaperRepository : JpaRepository<RollingPaper, Long> {
     fun existsByPartyAndWriterNicknameKey(
@@ -20,6 +23,30 @@ interface RollingPaperRepository : JpaRepository<RollingPaper, Long> {
         party: Party,
         pageable: Pageable,
     ): Page<RollingPaper>
+
+    fun findByIdAndParty(
+        id: Long,
+        party: Party,
+    ): RollingPaper?
+
+    fun countByParty(party: Party): Long
+
+    @Query(
+        """
+            SELECT COUNT(rp)
+            FROM RollingPaper rp
+            WHERE rp.party = :party
+              AND (
+                rp.createdAt > :createdAt OR
+                (rp.createdAt = :createdAt AND rp.id > :rollingPaperId)
+              )
+        """,
+    )
+    fun countNewerByParty(
+        @Param("party") party: Party,
+        @Param("createdAt") createdAt: LocalDateTime,
+        @Param("rollingPaperId") rollingPaperId: Long,
+    ): Long
 
     @Modifying
     @Transactional

--- a/src/main/kotlin/com/team2/server/rollingpaper/usecase/GetRollingPaperDetailUseCase.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/usecase/GetRollingPaperDetailUseCase.kt
@@ -1,0 +1,71 @@
+package com.team2.server.rollingpaper.usecase
+
+import com.team2.server.common.exception.BusinessException
+import com.team2.server.common.exception.ErrorCode
+import com.team2.server.party.entity.Party
+import com.team2.server.party.repository.PartyRepository
+import com.team2.server.rollingpaper.dto.OwnerRollingPaperDetailResponse
+import com.team2.server.rollingpaper.entity.RollingPaper
+import com.team2.server.rollingpaper.repository.RollingPaperRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Component
+class GetRollingPaperDetailUseCase(
+    private val partyRepository: PartyRepository,
+    private val rollingPaperRepository: RollingPaperRepository,
+) {
+    @Transactional(readOnly = true)
+    fun getOwnerDetail(
+        partyId: Long,
+        rollingPaperId: Long,
+        userId: Long,
+    ): OwnerRollingPaperDetailResponse {
+        val party =
+            partyRepository.findByIdOrNull(partyId)
+                ?: throw BusinessException(ErrorCode.PARTY_NOT_FOUND)
+        validateOwner(party, userId)
+        validateViewable(party)
+
+        val rollingPaper =
+            rollingPaperRepository.findByIdAndParty(rollingPaperId, party)
+                ?: throw BusinessException(ErrorCode.ROLLING_PAPER_NOT_FOUND)
+        val totalCount = rollingPaperRepository.countByParty(party)
+        val position = calculatePosition(party, rollingPaper)
+
+        return OwnerRollingPaperDetailResponse(
+            rollingPaperId = rollingPaper.id,
+            content = rollingPaper.content,
+            writerNickname = rollingPaper.writerNickname,
+            position = position,
+            totalCount = totalCount,
+        )
+    }
+
+    private fun validateOwner(
+        party: Party,
+        userId: Long,
+    ) {
+        if (party.ownerId != userId) {
+            throw BusinessException(ErrorCode.PARTY_FORBIDDEN)
+        }
+    }
+
+    private fun validateViewable(party: Party) {
+        if (!party.canHostViewRollingPapers(LocalDateTime.now())) {
+            throw BusinessException(ErrorCode.ROLLING_PAPER_NOT_VIEWABLE)
+        }
+    }
+
+    private fun calculatePosition(
+        party: Party,
+        rollingPaper: RollingPaper,
+    ): Long =
+        rollingPaperRepository.countNewerByParty(
+            party = party,
+            createdAt = rollingPaper.createdAt,
+            rollingPaperId = rollingPaper.id,
+        ) + 1
+}

--- a/src/main/kotlin/com/team2/server/rollingpaper/usecase/GetRollingPaperDetailUseCase.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/usecase/GetRollingPaperDetailUseCase.kt
@@ -7,6 +7,7 @@ import com.team2.server.party.repository.PartyRepository
 import com.team2.server.rollingpaper.dto.OwnerRollingPaperDetailResponse
 import com.team2.server.rollingpaper.entity.RollingPaper
 import com.team2.server.rollingpaper.repository.RollingPaperRepository
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
@@ -34,6 +35,8 @@ class GetRollingPaperDetailUseCase(
                 ?: throw BusinessException(ErrorCode.ROLLING_PAPER_NOT_FOUND)
         val totalCount = rollingPaperRepository.countByParty(party)
         val position = calculatePosition(party, rollingPaper)
+        val previousRollingPaperId = findPreviousRollingPaperId(party, rollingPaper)
+        val nextRollingPaperId = findNextRollingPaperId(party, rollingPaper)
 
         return OwnerRollingPaperDetailResponse(
             rollingPaperId = rollingPaper.id,
@@ -41,6 +44,8 @@ class GetRollingPaperDetailUseCase(
             writerNickname = rollingPaper.writerNickname,
             position = position,
             totalCount = totalCount,
+            previousRollingPaperId = previousRollingPaperId,
+            nextRollingPaperId = nextRollingPaperId,
         )
     }
 
@@ -68,4 +73,32 @@ class GetRollingPaperDetailUseCase(
             createdAt = rollingPaper.createdAt,
             rollingPaperId = rollingPaper.id,
         ) + 1
+
+    private fun findPreviousRollingPaperId(
+        party: Party,
+        rollingPaper: RollingPaper,
+    ): Long? =
+        rollingPaperRepository
+            .findPreviousIdsByParty(
+                party = party,
+                createdAt = rollingPaper.createdAt,
+                rollingPaperId = rollingPaper.id,
+                pageable = FIRST_RESULT,
+            ).firstOrNull()
+
+    private fun findNextRollingPaperId(
+        party: Party,
+        rollingPaper: RollingPaper,
+    ): Long? =
+        rollingPaperRepository
+            .findNextIdsByParty(
+                party = party,
+                createdAt = rollingPaper.createdAt,
+                rollingPaperId = rollingPaper.id,
+                pageable = FIRST_RESULT,
+            ).firstOrNull()
+
+    companion object {
+        private val FIRST_RESULT = PageRequest.of(0, 1)
+    }
 }

--- a/src/test/kotlin/com/team2/server/rollingpaper/controller/RollingPaperListControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/rollingpaper/controller/RollingPaperListControllerTest.kt
@@ -257,6 +257,130 @@ class RollingPaperListControllerTest
         }
 
         @Test
+        fun `주최자용 상세는 내용과 최신순 기준 순번을 조회한다`() {
+            val owner = saveUser("owner-detail")
+            val party =
+                savePaperOnlyParty(
+                    ownerId = owner.id,
+                    startedAt = ALWAYS_VIEWABLE_STARTED_AT,
+                )
+            val wrapper = saveWrapperWithImages()
+            saveRollingPaper(party, wrapper, "첫번째", DEFAULT_NOW.plusMinutes(1), content = "첫 번째 축하")
+            val target =
+                saveRollingPaper(party, wrapper, "두번째", DEFAULT_NOW.plusMinutes(2), content = "두 번째 축하")
+            saveRollingPaper(party, wrapper, "세번째", DEFAULT_NOW.plusMinutes(3), content = "세 번째 축하")
+
+            mockMvc
+                .get("/api/v1/parties/${party.id}/rolling-papers/${target.id}") {
+                    header("Authorization", "Bearer ${tokenProvider.issue(owner)}")
+                }.andExpect {
+                    status { isOk() }
+                    jsonPath("$.data.rollingPaperId") { value(target.id) }
+                    jsonPath("$.data.content") { value("두 번째 축하") }
+                    jsonPath("$.data.writerNickname") { value("두번째") }
+                    jsonPath("$.data.position") { value(2) }
+                    jsonPath("$.data.totalCount") { value(3) }
+                }
+        }
+
+        @Test
+        fun `주최자용 상세는 같은 생성 시각이면 id 내림차순 기준 순번을 계산한다`() {
+            val owner = saveUser("owner-detail-same-time")
+            val party =
+                savePaperOnlyParty(
+                    ownerId = owner.id,
+                    startedAt = ALWAYS_VIEWABLE_STARTED_AT,
+                )
+            val wrapper = saveWrapperWithImages()
+            val old = saveRollingPaper(party, wrapper, "먼저작성", DEFAULT_NOW, content = "먼저")
+            val latest = saveRollingPaper(party, wrapper, "나중작성", DEFAULT_NOW, content = "나중")
+
+            mockMvc
+                .get("/api/v1/parties/${party.id}/rolling-papers/${old.id}") {
+                    header("Authorization", "Bearer ${tokenProvider.issue(owner)}")
+                }.andExpect {
+                    status { isOk() }
+                    jsonPath("$.data.position") { value(2) }
+                    jsonPath("$.data.totalCount") { value(2) }
+                }
+
+            mockMvc
+                .get("/api/v1/parties/${party.id}/rolling-papers/${latest.id}") {
+                    header("Authorization", "Bearer ${tokenProvider.issue(owner)}")
+                }.andExpect {
+                    status { isOk() }
+                    jsonPath("$.data.position") { value(1) }
+                    jsonPath("$.data.totalCount") { value(2) }
+                }
+        }
+
+        @Test
+        fun `주최자용 상세는 해당 파티의 롤링페이퍼가 아니면 404`() {
+            val owner = saveUser("owner-detail-missing")
+            val party =
+                savePaperOnlyParty(
+                    ownerId = owner.id,
+                    startedAt = ALWAYS_VIEWABLE_STARTED_AT,
+                )
+            val otherParty =
+                savePaperOnlyParty(
+                    ownerId = owner.id,
+                    startedAt = ALWAYS_VIEWABLE_STARTED_AT,
+                )
+            val wrapper = saveWrapperWithImages()
+            val otherRollingPaper = saveRollingPaper(otherParty, wrapper, "다른파티", DEFAULT_NOW)
+
+            mockMvc
+                .get("/api/v1/parties/${party.id}/rolling-papers/${otherRollingPaper.id}") {
+                    header("Authorization", "Bearer ${tokenProvider.issue(owner)}")
+                }.andExpect {
+                    status { isNotFound() }
+                    jsonPath("$.error.code") { value("ROLLING_PAPER_NOT_FOUND") }
+                }
+        }
+
+        @Test
+        fun `주최자용 상세는 소유자가 아니면 403`() {
+            val owner = saveUser("owner-detail-forbidden")
+            val other = saveUser("other-detail-forbidden")
+            val party =
+                savePaperOnlyParty(
+                    ownerId = owner.id,
+                    startedAt = ALWAYS_VIEWABLE_STARTED_AT,
+                )
+            val wrapper = saveWrapperWithImages()
+            val rollingPaper = saveRollingPaper(party, wrapper, "작성자", DEFAULT_NOW)
+
+            mockMvc
+                .get("/api/v1/parties/${party.id}/rolling-papers/${rollingPaper.id}") {
+                    header("Authorization", "Bearer ${tokenProvider.issue(other)}")
+                }.andExpect {
+                    status { isForbidden() }
+                    jsonPath("$.error.code") { value("PARTY_FORBIDDEN") }
+                }
+        }
+
+        @Test
+        fun `주최자용 상세는 열람 가능 전이면 403`() {
+            val owner = saveUser("owner-detail-before-open")
+            val party =
+                saveRealtimeParty(
+                    ownerId = owner.id,
+                    startedAt = NOT_VIEWABLE_REALTIME_STARTED_AT,
+                )
+            val wrapper = saveWrapperWithImages()
+            val rollingPaper = saveRollingPaper(party, wrapper, "작성자", DEFAULT_NOW)
+
+            mockMvc
+                .get("/api/v1/parties/${party.id}/rolling-papers/${rollingPaper.id}") {
+                    header("Authorization", "Bearer ${tokenProvider.issue(owner)}")
+                }.andExpect {
+                    status { isForbidden() }
+                    jsonPath("$.error.code") { value("ROLLING_PAPER_NOT_VIEWABLE") }
+                }
+        }
+
+        @Test
         fun `공통 목록은 초과 페이지 요청값을 유지하고 빈 items를 반환한다`() {
             val party = savePaperOnlyParty()
             val invite = saveInvite(party, "overpagelist001")
@@ -366,6 +490,7 @@ class RollingPaperListControllerTest
             wrapper: RollingPaperWrapper,
             writerNickname: String,
             createdAt: LocalDateTime,
+            content: String = "축하해요",
         ): RollingPaper {
             val participant = participantRepository.saveAndFlush(Participant(party = party, hasWrittenPaper = true))
             val saved =
@@ -375,7 +500,7 @@ class RollingPaperListControllerTest
                         writer = participant,
                         party = party,
                         writerNickname = writerNickname,
-                        content = "축하해요",
+                        content = content,
                     ),
                 )
             saved.createdAt = createdAt

--- a/src/test/kotlin/com/team2/server/rollingpaper/controller/RollingPaperListControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/rollingpaper/controller/RollingPaperListControllerTest.kt
@@ -265,10 +265,12 @@ class RollingPaperListControllerTest
                     startedAt = ALWAYS_VIEWABLE_STARTED_AT,
                 )
             val wrapper = saveWrapperWithImages()
-            saveRollingPaper(party, wrapper, "첫번째", DEFAULT_NOW.plusMinutes(1), content = "첫 번째 축하")
+            val first =
+                saveRollingPaper(party, wrapper, "첫번째", DEFAULT_NOW.plusMinutes(1), content = "첫 번째 축하")
             val target =
                 saveRollingPaper(party, wrapper, "두번째", DEFAULT_NOW.plusMinutes(2), content = "두 번째 축하")
-            saveRollingPaper(party, wrapper, "세번째", DEFAULT_NOW.plusMinutes(3), content = "세 번째 축하")
+            val latest =
+                saveRollingPaper(party, wrapper, "세번째", DEFAULT_NOW.plusMinutes(3), content = "세 번째 축하")
 
             mockMvc
                 .get("/api/v1/parties/${party.id}/rolling-papers/${target.id}") {
@@ -280,6 +282,8 @@ class RollingPaperListControllerTest
                     jsonPath("$.data.writerNickname") { value("두번째") }
                     jsonPath("$.data.position") { value(2) }
                     jsonPath("$.data.totalCount") { value(3) }
+                    jsonPath("$.data.previousRollingPaperId") { value(latest.id) }
+                    jsonPath("$.data.nextRollingPaperId") { value(first.id) }
                 }
         }
 
@@ -302,6 +306,8 @@ class RollingPaperListControllerTest
                     status { isOk() }
                     jsonPath("$.data.position") { value(2) }
                     jsonPath("$.data.totalCount") { value(2) }
+                    jsonPath("$.data.previousRollingPaperId") { value(latest.id) }
+                    jsonPath("$.data.nextRollingPaperId") { value(nullValue()) }
                 }
 
             mockMvc
@@ -311,6 +317,8 @@ class RollingPaperListControllerTest
                     status { isOk() }
                     jsonPath("$.data.position") { value(1) }
                     jsonPath("$.data.totalCount") { value(2) }
+                    jsonPath("$.data.previousRollingPaperId") { value(nullValue()) }
+                    jsonPath("$.data.nextRollingPaperId") { value(old.id) }
                 }
         }
 


### PR DESCRIPTION
## 🔗 Issue
- closes #112

## 💬 Context
주최자가 롤링페이퍼 목록 또는 상세 화면에서 특정 롤링페이퍼를 선택했을 때 상세 내용과 현재 위치, 이전/다음 이동 정보를 확인할 수 있도록 주최자 전용 상세 조회 API를 추가합니다.

## 🛠 Changes
- `GET /api/v1/parties/{partyId}/rolling-papers/{rollingPaperId}` 주최자용 상세 조회 API 추가
- 파티 소유자 권한과 롤링페이퍼 열람 가능 시점 검증 추가
- 상세 응답에 `rollingPaperId`, `content`, `writerNickname`, `position`, `totalCount`, `previousRollingPaperId`, `nextRollingPaperId` 포함
- 파티 내 롤링페이퍼 존재 여부, 최신순 기준 현재 순번, 이전/다음 롤링페이퍼 ID 계산 쿼리 추가
- 성공/권한 없음/열람 불가/미존재/동일 생성 시각 정렬 케이스 컨트롤러 테스트 추가

## 👀 Review Focus
- 상세 조회에서 주최자 권한 및 열람 가능 시점 검증 순서가 적절한지
- 최신순 기준 `position`, `previousRollingPaperId`, `nextRollingPaperId` 계산 기준이 목록 API 정렬 정책과 일치하는지
- 첫 번째/마지막 롤링페이퍼에서 인접 ID가 `null`로 내려가는 계약이 적절한지

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [ ] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견