### PR TITLE
[Feat] 홈 다가오는 파티 목록 API 추가

### DIFF
--- a/docs/party-status.md
+++ b/docs/party-status.md
@@ -16,7 +16,7 @@
 
 ### 상태 전이 조건
 
-```
+```text
 READY  : now < startedAt
 OPEN   : startedAt ≤ now < startedAt + 7일
 CLOSED : now ≥ startedAt + 7일
@@ -43,7 +43,7 @@ CLOSED : now ≥ startedAt + 7일
 
 ### 상태 전이 조건
 
-```
+```text
 ROLLING_PAPER_OPEN   : now < startedAt
 LIVE_OPEN            : startedAt ≤ now < startedAt + 10분
 LIVE_CLOSED          : startedAt + 10분 ≤ now < startedAt + 7일

--- a/docs/party-status.md
+++ b/docs/party-status.md
@@ -11,15 +11,15 @@
 | 상태 | 시점 | 참가자 | 주최자 |
 |------|------|--------|--------|
 | **READY** | 파티 생성 직후 ~ startedAt 전 | 작성 가능, 조회 가능 | 확인 불가 |
-| **OPEN** | startedAt ~ 생성일 +7일 | 작성 가능, 조회 가능 | 조회 가능 |
-| **CLOSED** | 생성일 +7일 이후 | 조회만 가능 | 조회만 가능 |
+| **OPEN** | startedAt ~ startedAt +7일 | 작성 가능, 조회 가능 | 조회 가능 |
+| **CLOSED** | startedAt +7일 이후 | 조회만 가능 | 조회만 가능 |
 
 ### 상태 전이 조건
 
 ```
 READY  : now < startedAt
-OPEN   : startedAt ≤ now < createdAt + 7일
-CLOSED : now ≥ createdAt + 7일
+OPEN   : startedAt ≤ now < startedAt + 7일
+CLOSED : now ≥ startedAt + 7일
 ```
 
 | 상수 | 값 |
@@ -38,16 +38,16 @@ CLOSED : now ≥ createdAt + 7일
 |------|------|------|
 | **ROLLING_PAPER_OPEN** | 파티 생성 직후 ~ 라이브 시작 전 | 롤페 작성·조회 가능 |
 | **LIVE_OPEN** | 라이브 시작 ~ +10분 | 라이브 진행(채팅 활성화) + 롤페 작성·조회 가능 |
-| **LIVE_CLOSED** | 라이브 종료 후 ~ 생성일 +7일 | 롤페 추가 작성·조회 가능 |
-| **ROLLING_PAPER_CLOSED** | 생성일 +7일 이후 | 롤페 조회만 가능 |
+| **LIVE_CLOSED** | 라이브 종료 후 ~ startedAt +7일 | 롤페 추가 작성·조회 가능 |
+| **ROLLING_PAPER_CLOSED** | startedAt +7일 이후 | 롤페 조회만 가능 |
 
 ### 상태 전이 조건
 
 ```
 ROLLING_PAPER_OPEN   : now < startedAt
 LIVE_OPEN            : startedAt ≤ now < startedAt + 10분
-LIVE_CLOSED          : startedAt + 10분 ≤ now < createdAt + 7일
-ROLLING_PAPER_CLOSED : now ≥ createdAt + 7일
+LIVE_CLOSED          : startedAt + 10분 ≤ now < startedAt + 7일
+ROLLING_PAPER_CLOSED : now ≥ startedAt + 7일
 ```
 
 | 상수 | 값 |

--- a/docs/superpowers/plans/2026-05-04-rolling-paper-write.md
+++ b/docs/superpowers/plans/2026-05-04-rolling-paper-write.md
@@ -12,8 +12,8 @@
 
 ## Decisions
 
-- 롤링페이퍼 작성 가능 시간은 `초대 토큰 유효 && party.createdAt + Party.ENDED_AFTER_DAYS 전`이다.
-- `PartyInvite.expiresAt`은 `party.createdAt + Party.ENDED_AFTER_DAYS`로 계산한다.
+- 롤링페이퍼 작성 가능 시간은 `초대 토큰 유효 && Party.endedAt() 전`이다.
+- `PartyInvite.expiresAt`은 `Party.endedAt()`으로 계산한다.
 - 성공 응답은 기존 `ApiResponse` 래퍼를 유지한다.
 - 기본 래퍼 이미지는 `src/main/resources/static/images/rolling-paper-wrappers/` 아래 정적 파일을 사용한다.
 - `RollingPaper.theme` / `theme_id`는 `wrapper` / `wrapper_id`로 변경한다.
@@ -53,7 +53,7 @@
 | `src/main/kotlin/com/team2/server/common/repository/ImageRepository.kt` | wrapper id 목록 기준 bulk image 조회 메서드 추가 |
 | `src/main/kotlin/com/team2/server/common/exception/ErrorCode.kt` | 롤링페이퍼 래퍼 없음, 닉네임 중복, 이미 작성 에러 추가 |
 | `src/main/kotlin/com/team2/server/auth/config/SecurityConfig.kt` | 래퍼 조회/롤링페이퍼 작성 공개 경로 추가 |
-| `src/main/kotlin/com/team2/server/party/service/PartyInviteService.kt` | 초대 토큰 만료를 파티 생성 후 7일 기준으로 변경 |
+| `src/main/kotlin/com/team2/server/party/service/PartyInviteService.kt` | 초대 토큰 만료를 파티 종료 시각 기준으로 변경 |
 | `src/test/kotlin/com/team2/server/party/service/PartyInviteServiceTest.kt` | 초대 토큰 만료 정책 테스트 갱신 |
 | `src/test/kotlin/com/team2/server/party/repository/ParticipantRepositoryTest.kt` | `RollingPaper` 생성자 변경 반영 |
 | `src/test/kotlin/com/team2/server/party/entity/PartyParticipationDomainTest.kt` | `RollingPaper` 생성자 변경 반영 |
@@ -140,7 +140,7 @@ Run:
 - Modify: `src/main/kotlin/com/team2/server/party/service/PartyInviteService.kt`
 - Test: `src/test/kotlin/com/team2/server/party/service/PartyInviteServiceTest.kt`
 
-- [ ] 새 초대 토큰의 `expiresAt`을 `party.createdAt.plusDays(Party.ENDED_AFTER_DAYS)`로 계산한다.
+- [ ] 새 초대 토큰의 `expiresAt`을 `party.endedAt()`으로 계산한다.
 - [ ] `PAPER_ONLY`, `REALTIME` 모두 같은 7일 기준을 사용한다.
 - [ ] 기존 유효 토큰 재사용 정책은 유지한다.
 - [ ] 실시간 라이브 종료 시각은 초대 토큰 만료 기준으로 사용하지 않는다.
@@ -163,7 +163,7 @@ Run:
 - [ ] 요청 DTO에 `@NotBlank`, `@Size(max = 10)`, `@Size(max = 100)`, `@field:Positive`를 적용한다.
 - [ ] 초대 토큰 없음은 `PARTY_NOT_FOUND`로 처리한다.
 - [ ] 초대 토큰 만료는 `INVITE_LINK_EXPIRED`로 처리한다.
-- [ ] `party.createdAt.plusDays(Party.ENDED_AFTER_DAYS)` 이후 작성은 `PARTY_ENDED`로 처리한다.
+- [ ] `party.endedAt()` 이후 작성은 `PARTY_ENDED`로 처리한다.
 - [ ] 회원이면 기존 participant를 조회하고, 없으면 생성한다.
 - [ ] 비회원이면 새 participant를 생성한다.
 - [ ] `isCelebrant = true` participant도 작성 가능하게 둔다.
@@ -210,7 +210,7 @@ Test cases:
 - [ ] 회원 participant가 이미 작성했으면 실패
 - [ ] 작성 성공 시 participant `hasWrittenPaper = true`
 - [ ] 만료된 초대 토큰 작성 실패
-- [ ] 생성 후 7일 지난 파티 작성 실패
+- [ ] 시작 후 7일 지난 파티 작성 실패
 - [ ] invalid Bearer token 401
 
 Run:

--- a/docs/superpowers/specs/2026-05-04-party-invite-lookup-design.md
+++ b/docs/superpowers/specs/2026-05-04-party-invite-lookup-design.md
@@ -122,7 +122,7 @@ GET /api/v1/party-invites/{inviteToken}
 | `partyOption` | 현재 코드의 `Party.partyOption` | 그대로 |
 | `partyEnded` | `Party.endedAt()` | `now >= Party.endedAt()` |
 | `rollingPaperWritten` | `Participant.hasWrittenPaper` | 식별 가능한 회원 participant가 있으면 해당 값, 없으면 false |
-| `partyStartDate` | `Party.createdAt` | `createdAt.toLocalDate()` |
+| `partyStartDate` | `Party.startedAt` | `startedAt.toLocalDate()` |
 | `partyEndDate` | `Party.endedAt()` | `Party.endedAt().toLocalDate()` |
 | `realtimeSchedule` | 실시간 파티 일정 기준 시각 | `REALTIME`이면 내려주고, `PAPER_ONLY`이면 null |
 | `realtimeSchedule.liveStartAt` | `Party.startedAt` | 실시간 파티 시작 시각 |

--- a/docs/superpowers/specs/2026-05-04-party-invite-lookup-design.md
+++ b/docs/superpowers/specs/2026-05-04-party-invite-lookup-design.md
@@ -50,6 +50,7 @@
 - 신규 회원 참여 API 경로는 `POST /api/v1/party-invites/{inviteToken}/participants/me`이다.
 - 응답은 초대장 조회 전용 응답이다.
 - `partyEnded`, `partyStartDate`, `partyEndDate`는 `endedAt` 전용 컬럼이 아니라 `Party.endedAt()` 기준으로 계산한다.
+  - 현재 `Party.endedAt()`는 파티 종류와 관계없이 `startedAt + 7일`이다.
 - `REALTIME` 파티는 조회 시점 상태값 대신 프론트가 버튼/카운트다운 상태를 계산할 기준 시각을 내려준다.
 
 ---
@@ -120,10 +121,10 @@ GET /api/v1/party-invites/{inviteToken}
 | `celebrantNickname` | `Party.celebrantNickname` | 컬럼명과 동일 의미 유지 |
 | `isHost` | `Party.ownerId` | 인증 회원이고 `party.ownerId == userId`이면 true, 비회원이면 false |
 | `partyOption` | 현재 코드의 `Party.partyOption` | 그대로 |
-| `partyEnded` | `Party.endedAt()` | `now >= Party.endedAt()` |
+| `partyEnded` | `Party.endedAt()` | `now >= Party.endedAt()` (`Party.endedAt()` = `startedAt + 7일`) |
 | `rollingPaperWritten` | `Participant.hasWrittenPaper` | 식별 가능한 회원 participant가 있으면 해당 값, 없으면 false |
 | `partyStartDate` | `Party.startedAt` | `startedAt.toLocalDate()` |
-| `partyEndDate` | `Party.endedAt()` | `Party.endedAt().toLocalDate()` |
+| `partyEndDate` | `Party.endedAt()` | `Party.endedAt().toLocalDate()` (`startedAt + 7일`) |
 | `realtimeSchedule` | 실시간 파티 일정 기준 시각 | `REALTIME`이면 내려주고, `PAPER_ONLY`이면 null |
 | `realtimeSchedule.liveStartAt` | `Party.startedAt` | 실시간 파티 시작 시각 |
 | `realtimeSchedule.enterableFrom` | `Party.startedAt - 5분` | 프론트 입장 버튼 활성화 기준 시작 시각 |

--- a/docs/superpowers/specs/2026-05-04-party-invite-lookup-design.md
+++ b/docs/superpowers/specs/2026-05-04-party-invite-lookup-design.md
@@ -49,7 +49,7 @@
 - 신규 조회 API 경로는 `GET /api/v1/party-invites/{inviteToken}`이다.
 - 신규 회원 참여 API 경로는 `POST /api/v1/party-invites/{inviteToken}/participants/me`이다.
 - 응답은 초대장 조회 전용 응답이다.
-- `partyEnded`, `partyStartDate`, `partyEndDate`는 `endedAt` 전용 컬럼이 아니라 `createdAt + 7일` 기준으로 계산한다.
+- `partyEnded`, `partyStartDate`, `partyEndDate`는 `endedAt` 전용 컬럼이 아니라 `Party.endedAt()` 기준으로 계산한다.
 - `REALTIME` 파티는 조회 시점 상태값 대신 프론트가 버튼/카운트다운 상태를 계산할 기준 시각을 내려준다.
 
 ---
@@ -120,10 +120,10 @@ GET /api/v1/party-invites/{inviteToken}
 | `celebrantNickname` | `Party.celebrantNickname` | 컬럼명과 동일 의미 유지 |
 | `isHost` | `Party.ownerId` | 인증 회원이고 `party.ownerId == userId`이면 true, 비회원이면 false |
 | `partyOption` | 현재 코드의 `Party.partyOption` | 그대로 |
-| `partyEnded` | `Party.createdAt` | `now >= createdAt.plusDays(7)` |
+| `partyEnded` | `Party.endedAt()` | `now >= Party.endedAt()` |
 | `rollingPaperWritten` | `Participant.hasWrittenPaper` | 식별 가능한 회원 participant가 있으면 해당 값, 없으면 false |
 | `partyStartDate` | `Party.createdAt` | `createdAt.toLocalDate()` |
-| `partyEndDate` | `Party.createdAt` | `createdAt.plusDays(7).toLocalDate()` |
+| `partyEndDate` | `Party.endedAt()` | `Party.endedAt().toLocalDate()` |
 | `realtimeSchedule` | 실시간 파티 일정 기준 시각 | `REALTIME`이면 내려주고, `PAPER_ONLY`이면 null |
 | `realtimeSchedule.liveStartAt` | `Party.startedAt` | 실시간 파티 시작 시각 |
 | `realtimeSchedule.enterableFrom` | `Party.startedAt - 5분` | 프론트 입장 버튼 활성화 기준 시작 시각 |
@@ -204,7 +204,7 @@ data class RealtimeSchedule(
 결정:
 
 - 기존 `PartyInviteService.activateInviteLink(...)`는 유효한 초대 토큰 재사용을 위해 `PartyInvite.expiresAt`을 사용한다.
-- 신규 기획은 "실시간 파티 종료 여부와 관계없이 `realtimeSchedule`을 내려준다"고 되어 있고, `partyEnded`는 `createdAt + 7일` 기준이다.
+- 신규 기획은 "실시간 파티 종료 여부와 관계없이 `realtimeSchedule`을 내려준다"고 되어 있고, `partyEnded`는 `Party.endedAt()` 기준이다.
 - 초대장 조회 API는 `PartyInvite.expiresAt`이 지났어도 조회 가능하게 한다.
 
 구현 기준:
@@ -346,7 +346,7 @@ src/main/kotlin/com/team2/server/party/usecase/LookupPartyInviteUseCase.kt
 1. `partyInviteRepository.findByToken(inviteToken)`
 2. 없으면 `BusinessException(ErrorCode.PARTY_NOT_FOUND)`
 3. `party = invite.party`
-4. `partyEndAt = party.createdAt.plusDays(7)`
+4. `partyEndAt = party.endedAt()`
 5. `isHost` 계산
 6. `rollingPaperWritten` 계산
 7. `realtimeSchedule` 계산
@@ -479,7 +479,7 @@ src/test/kotlin/com/team2/server/party/controller/PartyInviteLookupControllerTes
 - 종료된 파티로 회원 참여 API를 호출하면 participant 미생성 및 `PARTY_ENDED`
 - `PAPER_ONLY`는 `realtimeSchedule`이 null
 - `REALTIME`은 `realtimeSchedule.liveStartAt`, `enterableFrom`, `liveEndAt`, `liveDurationMinutes`가 내려감
-- `createdAt + 7일` 이상이면 `partyEnded = true`
+- `Party.endedAt()` 이상이면 `partyEnded = true`
 - 없는 token이면 404 `PARTY_NOT_FOUND`
 
 ### 8-2. UseCase 단위 테스트

--- a/docs/superpowers/specs/2026-05-04-party-invite-lookup-design.md
+++ b/docs/superpowers/specs/2026-05-04-party-invite-lookup-design.md
@@ -157,7 +157,7 @@ POST /api/v1/party-invites/{inviteToken}/participants/me
 - `inviteToken`으로 `PartyInvite`를 조회한다.
 - 토큰이 없으면 `PARTY_NOT_FOUND`.
 - `PartyInvite.expiresAt`이 지났으면 `INVITE_LINK_EXPIRED`.
-- `party.createdAt + 7일`이 지났으면 `PARTY_ENDED`.
+- `Party.endedAt()`(`startedAt + 7일`)이 지났으면 `PARTY_ENDED`.
 - 로그인 회원의 기존 participant가 있으면 그대로 반환한다.
 - 기존 participant가 없으면 `Participant(party, user)`를 생성한다.
 - 기존 participant를 반환할 때는 `hasWrittenPaper`, `isCelebrant` 등 기존 participant 필드를 변경하지 않는다.

--- a/docs/superpowers/specs/2026-05-04-rolling-paper-write-design.md
+++ b/docs/superpowers/specs/2026-05-04-rolling-paper-write-design.md
@@ -212,7 +212,7 @@ UseCase 진입 이후:
 1. `inviteToken`으로 `PartyInvite`를 조회한다.
 2. 토큰이 없으면 `PARTY_NOT_FOUND`.
 3. 초대 토큰이 만료됐으면 `INVITE_LINK_EXPIRED`.
-4. 파티 생성 시각 기준 7일이 지나 파티가 종료됐으면 `PARTY_ENDED`.
+4. 파티 시작 시각 기준 7일이 지나 파티가 종료됐으면 `PARTY_ENDED`.
 5. `wrapperId`로 `RollingPaperWrapper`를 조회한다.
 6. 래퍼가 없으면 `ROLLING_PAPER_WRAPPER_NOT_FOUND`.
 7. 회원이면 파티 내 회원 participant를 조회하고, 아직 없으면 생성한다.
@@ -328,7 +328,7 @@ image.target_id = rolling_paper_wrapper.id
 
 초대 토큰 만료 정책:
 
-- `PartyInvite.expiresAt`은 파티 생성 시각 `party.createdAt + Party.ENDED_AFTER_DAYS`로 계산한다.
+- `PartyInvite.expiresAt`은 `Party.endedAt()`으로 계산한다.
 - `PAPER_ONLY`, `REALTIME` 모두 같은 파티 기간 7일 기준을 사용한다.
 - 실시간 파티 입장 가능 시간은 `RealtimeParty.status()`와 별도 흐름에서 판단하고, 초대 토큰 자체의 만료 기준으로 사용하지 않는다.
 - 초대장 조회 API는 기존 정책대로 만료된 토큰도 조회할 수 있다.

--- a/docs/superpowers/specs/2026-05-05-rolling-paper-list-design.md
+++ b/docs/superpowers/specs/2026-05-05-rolling-paper-list-design.md
@@ -341,7 +341,7 @@ override fun hostViewableAt(): LocalDateTime =
 파티 자체 종료 시각은 `Party.endedAt()`을 사용한다.
 
 ```text
-Party.endedAt() = Party.createdAt + Party.ENDED_AFTER_DAYS
+Party.endedAt() = Party.startedAt + Party.ENDED_AFTER_DAYS
 ```
 
 `Party.ENDED_AFTER_DAYS`의 현재 값은 7일이다.

--- a/src/main/kotlin/com/team2/server/party/controller/MePartyApi.kt
+++ b/src/main/kotlin/com/team2/server/party/controller/MePartyApi.kt
@@ -1,0 +1,27 @@
+package com.team2.server.party.controller
+
+import com.team2.server.auth.principal.UserPrincipal
+import com.team2.server.common.response.ApiResponse
+import com.team2.server.common.swagger.AuthErrorResponses
+import com.team2.server.common.swagger.InternalServerErrorResponse
+import com.team2.server.party.dto.UpcomingPartyResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
+
+@Tag(name = "Party", description = "파티 API")
+interface MePartyApi {
+    @Operation(
+        summary = "홈 다가오는 파티 목록 조회",
+        description = "인증 회원이 참여 중이고 아직 종료되지 않은 파티 목록을 조회한다.",
+        security = [SecurityRequirement(name = "Bearer Authentication")],
+    )
+    @SwaggerApiResponse(responseCode = "200", description = "다가오는 파티 목록 조회 성공")
+    @AuthErrorResponses
+    @InternalServerErrorResponse
+    fun getUpcomingParties(
+        @Parameter(hidden = true) principal: UserPrincipal,
+    ): ApiResponse<List<UpcomingPartyResponse>>
+}

--- a/src/main/kotlin/com/team2/server/party/controller/MePartyController.kt
+++ b/src/main/kotlin/com/team2/server/party/controller/MePartyController.kt
@@ -1,0 +1,22 @@
+package com.team2.server.party.controller
+
+import com.team2.server.auth.principal.UserPrincipal
+import com.team2.server.common.response.ApiResponse
+import com.team2.server.party.dto.UpcomingPartyResponse
+import com.team2.server.party.usecase.GetUpcomingPartiesUseCase
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/me")
+class MePartyController(
+    private val getUpcomingPartiesUseCase: GetUpcomingPartiesUseCase,
+) : MePartyApi {
+    @GetMapping("/upcoming-parties")
+    override fun getUpcomingParties(
+        @AuthenticationPrincipal principal: UserPrincipal,
+    ): ApiResponse<List<UpcomingPartyResponse>> =
+        ApiResponse.success(getUpcomingPartiesUseCase.getUpcomingParties(principal.userId))
+}

--- a/src/main/kotlin/com/team2/server/party/dto/UpcomingPartyResponse.kt
+++ b/src/main/kotlin/com/team2/server/party/dto/UpcomingPartyResponse.kt
@@ -1,0 +1,45 @@
+package com.team2.server.party.dto
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.team2.server.party.entity.PartyOption
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(description = "홈 다가오는 파티 응답")
+data class UpcomingPartyResponse(
+    @Schema(description = "파티 ID", example = "1")
+    val partyId: Long,
+    @Schema(description = "롤링페이퍼 작성 등에 사용하는 초대 토큰. 유효한 토큰이 없으면 null", nullable = true)
+    val inviteToken: String?,
+    @Schema(
+        description = "파티 옵션. REALTIME: 실시간 파티, PAPER_ONLY: 롤링페이퍼 전용 파티",
+        allowableValues = ["REALTIME", "PAPER_ONLY"],
+        example = "REALTIME",
+    )
+    val partyOption: PartyOption,
+    @Schema(description = "파티 주인공 이름", example = "홍길동")
+    val celebrantNickname: String?,
+    @Schema(description = "파티 시작 시각", example = "2026-05-07T20:00:00")
+    val partyStartedAt: LocalDateTime,
+    @Schema(description = "파티 종료 시각", example = "2026-05-14T10:00:00")
+    val partyEndedAt: LocalDateTime,
+    @Schema(description = "현재 회원의 주최자 여부", example = "false")
+    val isHost: Boolean,
+    @Schema(description = "현재 회원의 롤링페이퍼 작성 여부", example = "false")
+    val rollingPaperWritten: Boolean,
+    @Schema(description = "주최자 롤링페이퍼 오픈 시각. 주최자가 아니면 null", nullable = true)
+    val hostRollingPaperOpenAt: LocalDateTime?,
+    @Schema(description = "실시간 파티 일정. PAPER_ONLY면 null", nullable = true)
+    val realtimeSchedule: UpcomingRealtimeScheduleResponse?,
+)
+
+@JsonInclude(JsonInclude.Include.ALWAYS)
+@Schema(description = "홈 다가오는 실시간 파티 일정")
+data class UpcomingRealtimeScheduleResponse(
+    @Schema(description = "실시간 파티 입장 가능 시작 시각", example = "2026-05-07T19:55:00")
+    val enterableFrom: LocalDateTime,
+    @Schema(description = "실시간 파티 시작 시각", example = "2026-05-07T20:00:00")
+    val liveStartAt: LocalDateTime,
+    @Schema(description = "실시간 파티 종료 시각", example = "2026-05-07T20:10:00")
+    val liveEndAt: LocalDateTime,
+)

--- a/src/main/kotlin/com/team2/server/party/dto/UpcomingPartyResponse.kt
+++ b/src/main/kotlin/com/team2/server/party/dto/UpcomingPartyResponse.kt
@@ -5,6 +5,7 @@ import com.team2.server.party.entity.PartyOption
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 
+@JsonInclude(JsonInclude.Include.ALWAYS)
 @Schema(description = "홈 다가오는 파티 응답")
 data class UpcomingPartyResponse(
     @Schema(description = "파티 ID", example = "1")

--- a/src/main/kotlin/com/team2/server/party/entity/Party.kt
+++ b/src/main/kotlin/com/team2/server/party/entity/Party.kt
@@ -41,7 +41,7 @@ abstract class Party(
 
     fun canHostViewRollingPapers(now: LocalDateTime): Boolean = !hostViewableAt().isAfter(now)
 
-    fun endedAt(): LocalDateTime = createdAt.plusDays(ENDED_AFTER_DAYS)
+    fun endedAt(): LocalDateTime = startedAt.plusDays(ENDED_AFTER_DAYS)
 
     fun isEnded(now: LocalDateTime = LocalDateTime.now()): Boolean = !endedAt().isAfter(now)
 

--- a/src/main/kotlin/com/team2/server/party/repository/ParticipantRepository.kt
+++ b/src/main/kotlin/com/team2/server/party/repository/ParticipantRepository.kt
@@ -4,6 +4,8 @@ import com.team2.server.party.entity.Participant
 import com.team2.server.party.entity.Party
 import com.team2.server.user.entity.User
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import java.time.LocalDateTime
 
 interface ParticipantRepository : JpaRepository<Participant, Long> {
     fun findByPartyAndUser(
@@ -27,4 +29,19 @@ interface ParticipantRepository : JpaRepository<Participant, Long> {
         partyId: Long,
         userId: Long,
     ): Participant?
+
+    @Query(
+        """
+        SELECT participant
+        FROM Participant participant
+        JOIN FETCH participant.party party
+        WHERE participant.user.id = :userId
+          AND party.createdAt > :endedAfter
+        ORDER BY party.startedAt ASC, party.id ASC
+        """,
+    )
+    fun findUpcomingByUserId(
+        userId: Long,
+        endedAfter: LocalDateTime,
+    ): List<Participant>
 }

--- a/src/main/kotlin/com/team2/server/party/repository/ParticipantRepository.kt
+++ b/src/main/kotlin/com/team2/server/party/repository/ParticipantRepository.kt
@@ -36,12 +36,12 @@ interface ParticipantRepository : JpaRepository<Participant, Long> {
         FROM Participant participant
         JOIN FETCH participant.party party
         WHERE participant.user.id = :userId
-          AND party.createdAt > :endedAfter
-        ORDER BY party.startedAt ASC, party.id ASC
+          AND party.createdAt > :createdAfter
+        ORDER BY participant.createdAt DESC, participant.id DESC
         """,
     )
-    fun findUpcomingByUserId(
+    fun findNotEndedByUserId(
         userId: Long,
-        endedAfter: LocalDateTime,
+        createdAfter: LocalDateTime,
     ): List<Participant>
 }

--- a/src/main/kotlin/com/team2/server/party/repository/ParticipantRepository.kt
+++ b/src/main/kotlin/com/team2/server/party/repository/ParticipantRepository.kt
@@ -36,12 +36,12 @@ interface ParticipantRepository : JpaRepository<Participant, Long> {
         FROM Participant participant
         JOIN FETCH participant.party party
         WHERE participant.user.id = :userId
-          AND party.createdAt > :createdAfter
+          AND party.startedAt > :startedAfter
         ORDER BY participant.createdAt DESC, participant.id DESC
         """,
     )
     fun findNotEndedByUserId(
         userId: Long,
-        createdAfter: LocalDateTime,
+        startedAfter: LocalDateTime,
     ): List<Participant>
 }

--- a/src/main/kotlin/com/team2/server/party/repository/PartyInviteRepository.kt
+++ b/src/main/kotlin/com/team2/server/party/repository/PartyInviteRepository.kt
@@ -3,6 +3,7 @@ package com.team2.server.party.repository
 import com.team2.server.party.entity.PartyInvite
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
 
@@ -13,6 +14,21 @@ interface PartyInviteRepository : JpaRepository<PartyInvite, Long> {
         partyId: Long,
         now: LocalDateTime,
     ): PartyInvite?
+
+    @Query(
+        """
+        SELECT invite
+        FROM PartyInvite invite
+        JOIN FETCH invite.party party
+        WHERE party.id IN :partyIds
+          AND invite.expiresAt > :now
+        ORDER BY invite.createdAt DESC, invite.id DESC
+        """,
+    )
+    fun findAllByPartyIdInAndExpiresAtAfter(
+        partyIds: List<Long>,
+        now: LocalDateTime,
+    ): List<PartyInvite>
 
     @Modifying
     @Transactional

--- a/src/main/kotlin/com/team2/server/party/repository/PartyInviteRepository.kt
+++ b/src/main/kotlin/com/team2/server/party/repository/PartyInviteRepository.kt
@@ -22,7 +22,7 @@ interface PartyInviteRepository : JpaRepository<PartyInvite, Long> {
         JOIN FETCH invite.party party
         WHERE party.id IN :partyIds
           AND invite.expiresAt > :now
-        ORDER BY invite.createdAt DESC, invite.id DESC
+        ORDER BY invite.expiresAt DESC, invite.createdAt DESC, invite.id DESC
         """,
     )
     fun findAllByPartyIdInAndExpiresAtAfter(

--- a/src/main/kotlin/com/team2/server/party/usecase/GetUpcomingPartiesUseCase.kt
+++ b/src/main/kotlin/com/team2/server/party/usecase/GetUpcomingPartiesUseCase.kt
@@ -20,9 +20,9 @@ class GetUpcomingPartiesUseCase(
     fun getUpcomingParties(userId: Long): List<UpcomingPartyResponse> {
         val now = LocalDateTime.now()
         val participants =
-            participantRepository.findUpcomingByUserId(
+            participantRepository.findNotEndedByUserId(
                 userId = userId,
-                endedAfter = now.minusDays(Party.ENDED_AFTER_DAYS),
+                createdAfter = now.minusDays(Party.ENDED_AFTER_DAYS),
             )
         val inviteTokenByPartyId = findInviteTokenByPartyId(participants.map { it.party }, now)
 
@@ -48,7 +48,7 @@ class GetUpcomingPartiesUseCase(
         parties: List<Party>,
         now: LocalDateTime,
     ): Map<Long, String> {
-        val partyIds = parties.map { it.id }
+        val partyIds = parties.map { it.id }.distinct()
         if (partyIds.isEmpty()) {
             return emptyMap()
         }

--- a/src/main/kotlin/com/team2/server/party/usecase/GetUpcomingPartiesUseCase.kt
+++ b/src/main/kotlin/com/team2/server/party/usecase/GetUpcomingPartiesUseCase.kt
@@ -22,7 +22,7 @@ class GetUpcomingPartiesUseCase(
         val participants =
             participantRepository.findNotEndedByUserId(
                 userId = userId,
-                createdAfter = now.minusDays(Party.ENDED_AFTER_DAYS),
+                startedAfter = now.minusDays(Party.ENDED_AFTER_DAYS),
             )
         val inviteTokenByPartyId = findInviteTokenByPartyId(participants.map { it.party }, now)
 

--- a/src/main/kotlin/com/team2/server/party/usecase/GetUpcomingPartiesUseCase.kt
+++ b/src/main/kotlin/com/team2/server/party/usecase/GetUpcomingPartiesUseCase.kt
@@ -39,7 +39,12 @@ class GetUpcomingPartiesUseCase(
                 isHost = isHost,
                 rollingPaperWritten = participant.hasWrittenPaper,
                 hostRollingPaperOpenAt = if (isHost) party.hostViewableAt() else null,
-                realtimeSchedule = if (party.partyOption == PartyOption.REALTIME) party.toRealtimeSchedule() else null,
+                realtimeSchedule =
+                    if (party.partyOption == PartyOption.REALTIME) {
+                        (party as RealtimeParty).toRealtimeSchedule()
+                    } else {
+                        null
+                    },
             )
         }
     }
@@ -60,7 +65,7 @@ class GetUpcomingPartiesUseCase(
         return tokenByPartyId
     }
 
-    private fun Party.toRealtimeSchedule(): UpcomingRealtimeScheduleResponse =
+    private fun RealtimeParty.toRealtimeSchedule(): UpcomingRealtimeScheduleResponse =
         UpcomingRealtimeScheduleResponse(
             enterableFrom = startedAt.minusMinutes(RealtimeParty.ENTERABLE_BEFORE_MINUTES),
             liveStartAt = startedAt,

--- a/src/main/kotlin/com/team2/server/party/usecase/GetUpcomingPartiesUseCase.kt
+++ b/src/main/kotlin/com/team2/server/party/usecase/GetUpcomingPartiesUseCase.kt
@@ -1,0 +1,69 @@
+package com.team2.server.party.usecase
+
+import com.team2.server.party.dto.UpcomingPartyResponse
+import com.team2.server.party.dto.UpcomingRealtimeScheduleResponse
+import com.team2.server.party.entity.Party
+import com.team2.server.party.entity.PartyOption
+import com.team2.server.party.entity.RealtimeParty
+import com.team2.server.party.repository.ParticipantRepository
+import com.team2.server.party.repository.PartyInviteRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service
+class GetUpcomingPartiesUseCase(
+    private val participantRepository: ParticipantRepository,
+    private val partyInviteRepository: PartyInviteRepository,
+) {
+    @Transactional(readOnly = true)
+    fun getUpcomingParties(userId: Long): List<UpcomingPartyResponse> {
+        val now = LocalDateTime.now()
+        val participants =
+            participantRepository.findUpcomingByUserId(
+                userId = userId,
+                endedAfter = now.minusDays(Party.ENDED_AFTER_DAYS),
+            )
+        val inviteTokenByPartyId = findInviteTokenByPartyId(participants.map { it.party }, now)
+
+        return participants.map { participant ->
+            val party = participant.party
+            val isHost = party.ownerId == userId
+            UpcomingPartyResponse(
+                partyId = party.id,
+                inviteToken = inviteTokenByPartyId[party.id],
+                partyOption = party.partyOption,
+                celebrantNickname = party.celebrantNickname,
+                partyStartedAt = party.startedAt,
+                partyEndedAt = party.endedAt(),
+                isHost = isHost,
+                rollingPaperWritten = participant.hasWrittenPaper,
+                hostRollingPaperOpenAt = if (isHost) party.hostViewableAt() else null,
+                realtimeSchedule = if (party.partyOption == PartyOption.REALTIME) party.toRealtimeSchedule() else null,
+            )
+        }
+    }
+
+    private fun findInviteTokenByPartyId(
+        parties: List<Party>,
+        now: LocalDateTime,
+    ): Map<Long, String> {
+        val partyIds = parties.map { it.id }
+        if (partyIds.isEmpty()) {
+            return emptyMap()
+        }
+
+        val tokenByPartyId = mutableMapOf<Long, String>()
+        partyInviteRepository
+            .findAllByPartyIdInAndExpiresAtAfter(partyIds, now)
+            .forEach { invite -> tokenByPartyId.putIfAbsent(invite.party.id, invite.token) }
+        return tokenByPartyId
+    }
+
+    private fun Party.toRealtimeSchedule(): UpcomingRealtimeScheduleResponse =
+        UpcomingRealtimeScheduleResponse(
+            enterableFrom = startedAt.minusMinutes(RealtimeParty.ENTERABLE_BEFORE_MINUTES),
+            liveStartAt = startedAt,
+            liveEndAt = startedAt.plusMinutes(RealtimeParty.LIVE_DURATION_MINUTES),
+        )
+}

--- a/src/main/kotlin/com/team2/server/party/usecase/LookupPartyInviteUseCase.kt
+++ b/src/main/kotlin/com/team2/server/party/usecase/LookupPartyInviteUseCase.kt
@@ -28,7 +28,7 @@ class LookupPartyInviteUseCase(
                 ?: throw BusinessException(ErrorCode.PARTY_NOT_FOUND)
 
         val now = LocalDateTime.now()
-        val partyEndAt = party.createdAt.plusDays(Party.ENDED_AFTER_DAYS)
+        val partyEndAt = party.endedAt()
         val isRealtime = party.partyOption == PartyOption.REALTIME
 
         return PartyInviteLookupResponse(

--- a/src/main/kotlin/com/team2/server/party/usecase/LookupPartyInviteUseCase.kt
+++ b/src/main/kotlin/com/team2/server/party/usecase/LookupPartyInviteUseCase.kt
@@ -38,7 +38,7 @@ class LookupPartyInviteUseCase(
             partyOption = party.partyOption,
             partyEnded = !now.isBefore(partyEndAt),
             rollingPaperWritten = hasWrittenPaper(party, userId),
-            partyStartDate = party.createdAt.toLocalDate(),
+            partyStartDate = party.startedAt.toLocalDate(),
             partyEndDate = partyEndAt.toLocalDate(),
             realtimeSchedule = if (isRealtime) createRealtimeSchedule(party) else null,
         )

--- a/src/test/kotlin/com/team2/server/party/controller/MePartyControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/party/controller/MePartyControllerTest.kt
@@ -99,10 +99,10 @@ class MePartyControllerTest
                     now.minusHours(1),
                 )
 
-            participantRepository.save(Participant(party = realtimeParty, user = user, hasWrittenPaper = true))
-            participantRepository.save(Participant(party = paperOnlyParty, user = user))
-            participantRepository.save(Participant(party = endedParty, user = user))
-            participantRepository.save(Participant(party = otherParty, user = other))
+            saveParticipant(realtimeParty, user, hasWrittenPaper = true, createdAt = now.minusMinutes(20))
+            saveParticipant(paperOnlyParty, user, createdAt = now.minusMinutes(5))
+            saveParticipant(endedParty, user, createdAt = now.minusMinutes(1))
+            saveParticipant(otherParty, other, createdAt = now)
             saveInvite(realtimeParty, "upcominglive001")
             saveInvite(paperOnlyParty, "upcomingpaper01")
 
@@ -112,8 +112,8 @@ class MePartyControllerTest
                 }.andExpect {
                     status { isOk() }
                     jsonPath("$.data.length()") { value(2) }
-                    expectRealtimeParty(realtimeParty, liveStartAt)
-                    expectPaperOnlyParty(paperOnlyParty)
+                    expectPaperOnlyParty(paperOnlyParty, index = 0)
+                    expectRealtimeParty(realtimeParty, liveStartAt, index = 1)
                 }
         }
 
@@ -131,7 +131,7 @@ class MePartyControllerTest
                     ),
                     now.minusHours(1),
                 )
-            participantRepository.save(Participant(party = party, user = user))
+            saveParticipant(party, user, createdAt = now)
             saveInvite(party, "expiredupcoming", now.minusMinutes(1))
 
             mockMvc
@@ -166,34 +166,53 @@ class MePartyControllerTest
                 ),
             )
 
+        private fun saveParticipant(
+            party: Party,
+            user: User,
+            hasWrittenPaper: Boolean = false,
+            createdAt: LocalDateTime,
+        ): Participant {
+            val saved =
+                participantRepository.saveAndFlush(
+                    Participant(
+                        party = party,
+                        user = user,
+                        hasWrittenPaper = hasWrittenPaper,
+                    ),
+                )
+            saved.createdAt = createdAt.truncatedTo(ChronoUnit.SECONDS)
+            return participantRepository.saveAndFlush(saved)
+        }
+
         private fun MockMvcResultMatchersDsl.expectRealtimeParty(
             party: Party,
             liveStartAt: LocalDateTime,
+            index: Int,
         ) {
-            jsonPath("$.data[0].partyId") { value(party.id) }
-            jsonPath("$.data[0].inviteToken") { value("upcominglive001") }
-            jsonPath("$.data[0].partyOption") { value("REALTIME") }
-            jsonPath("$.data[0].celebrantNickname") { value("실시간주인공") }
-            jsonPath("$.data[0].partyStartedAt") {
+            jsonPath("$.data[$index].partyId") { value(party.id) }
+            jsonPath("$.data[$index].inviteToken") { value("upcominglive001") }
+            jsonPath("$.data[$index].partyOption") { value("REALTIME") }
+            jsonPath("$.data[$index].celebrantNickname") { value("실시간주인공") }
+            jsonPath("$.data[$index].partyStartedAt") {
                 value(liveStartAt.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
             }
-            jsonPath("$.data[0].partyEndedAt") {
+            jsonPath("$.data[$index].partyEndedAt") {
                 value(party.endedAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
             }
-            jsonPath("$.data[0].isHost") { value(false) }
-            jsonPath("$.data[0].rollingPaperWritten") { value(true) }
-            jsonPath("$.data[0].hostRollingPaperOpenAt") { value(nullValue()) }
-            jsonPath("$.data[0].realtimeSchedule.enterableFrom") {
+            jsonPath("$.data[$index].isHost") { value(false) }
+            jsonPath("$.data[$index].rollingPaperWritten") { value(true) }
+            jsonPath("$.data[$index].hostRollingPaperOpenAt") { value(nullValue()) }
+            jsonPath("$.data[$index].realtimeSchedule.enterableFrom") {
                 value(
                     liveStartAt
                         .minusMinutes(RealtimeParty.ENTERABLE_BEFORE_MINUTES)
                         .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
                 )
             }
-            jsonPath("$.data[0].realtimeSchedule.liveStartAt") {
+            jsonPath("$.data[$index].realtimeSchedule.liveStartAt") {
                 value(liveStartAt.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
             }
-            jsonPath("$.data[0].realtimeSchedule.liveEndAt") {
+            jsonPath("$.data[$index].realtimeSchedule.liveEndAt") {
                 value(
                     liveStartAt
                         .plusMinutes(RealtimeParty.LIVE_DURATION_MINUTES)
@@ -202,16 +221,19 @@ class MePartyControllerTest
             }
         }
 
-        private fun MockMvcResultMatchersDsl.expectPaperOnlyParty(party: Party) {
-            jsonPath("$.data[1].partyId") { value(party.id) }
-            jsonPath("$.data[1].inviteToken") { value("upcomingpaper01") }
-            jsonPath("$.data[1].partyOption") { value("PAPER_ONLY") }
-            jsonPath("$.data[1].isHost") { value(true) }
-            jsonPath("$.data[1].rollingPaperWritten") { value(false) }
-            jsonPath("$.data[1].hostRollingPaperOpenAt") {
+        private fun MockMvcResultMatchersDsl.expectPaperOnlyParty(
+            party: Party,
+            index: Int,
+        ) {
+            jsonPath("$.data[$index].partyId") { value(party.id) }
+            jsonPath("$.data[$index].inviteToken") { value("upcomingpaper01") }
+            jsonPath("$.data[$index].partyOption") { value("PAPER_ONLY") }
+            jsonPath("$.data[$index].isHost") { value(true) }
+            jsonPath("$.data[$index].rollingPaperWritten") { value(false) }
+            jsonPath("$.data[$index].hostRollingPaperOpenAt") {
                 value(party.hostViewableAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
             }
-            jsonPath("$.data[1].realtimeSchedule") { value(nullValue()) }
+            jsonPath("$.data[$index].realtimeSchedule") { value(nullValue()) }
         }
 
         private fun saveUser(

--- a/src/test/kotlin/com/team2/server/party/controller/MePartyControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/party/controller/MePartyControllerTest.kt
@@ -1,0 +1,230 @@
+package com.team2.server.party.controller
+
+import com.team2.server.auth.config.JwtProperties
+import com.team2.server.auth.jwt.JwtTokenProvider
+import com.team2.server.party.entity.PaperOnlyParty
+import com.team2.server.party.entity.Participant
+import com.team2.server.party.entity.Party
+import com.team2.server.party.entity.PartyInvite
+import com.team2.server.party.entity.RealtimeParty
+import com.team2.server.party.repository.ParticipantRepository
+import com.team2.server.party.repository.PartyInviteRepository
+import com.team2.server.party.repository.PartyRepository
+import com.team2.server.user.entity.AuthProvider
+import com.team2.server.user.entity.User
+import com.team2.server.user.repository.UserRepository
+import org.hamcrest.Matchers.nullValue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.MockMvcResultMatchersDsl
+import org.springframework.test.web.servlet.get
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class MePartyControllerTest
+    @Autowired
+    constructor(
+        private val mockMvc: MockMvc,
+        private val partyRepository: PartyRepository,
+        private val participantRepository: ParticipantRepository,
+        private val partyInviteRepository: PartyInviteRepository,
+        private val userRepository: UserRepository,
+        private val jwtProperties: JwtProperties,
+    ) {
+        private val tokenProvider = JwtTokenProvider(jwtProperties)
+
+        @BeforeEach
+        fun setUp() {
+            partyInviteRepository.deleteAll()
+            participantRepository.deleteAll()
+            partyRepository.deleteAll()
+            userRepository.deleteAll()
+        }
+
+        @Test
+        fun `인증 없이 다가오는 파티 목록 조회 시 401`() {
+            mockMvc.get("/api/v1/me/upcoming-parties").andExpect {
+                status { isUnauthorized() }
+            }
+        }
+
+        @Test
+        fun `내가 참여 중이고 종료되지 않은 파티 목록을 조회한다`() {
+            val user = saveUser("kakao-upcoming-member", "upcoming-member@kakao.local")
+            val other = saveUser("kakao-upcoming-other", "upcoming-other@kakao.local")
+            val token = tokenProvider.issue(user)
+            val now = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS)
+            val liveStartAt = now.plusHours(3)
+            val realtimeParty =
+                saveParty(
+                    RealtimeParty(
+                        ownerId = other.id,
+                        celebrantNickname = "실시간주인공",
+                        startedAt = liveStartAt,
+                    ),
+                    now.minusDays(1),
+                )
+            val paperOnlyParty =
+                saveParty(
+                    PaperOnlyParty(
+                        ownerId = user.id,
+                        celebrantNickname = "롤페주인공",
+                        startedAt = now.toLocalDate().plusDays(2).atStartOfDay(),
+                    ),
+                    now.minusHours(2),
+                )
+            val endedParty =
+                saveParty(
+                    PaperOnlyParty(
+                        ownerId = other.id,
+                        celebrantNickname = "종료주인공",
+                        startedAt = now.minusDays(8).toLocalDate().atStartOfDay(),
+                    ),
+                    now.minusDays(8),
+                )
+            val otherParty =
+                saveParty(
+                    PaperOnlyParty(
+                        ownerId = other.id,
+                        celebrantNickname = "다른회원주인공",
+                        startedAt = now.toLocalDate().plusDays(2).atStartOfDay(),
+                    ),
+                    now.minusHours(1),
+                )
+
+            participantRepository.save(Participant(party = realtimeParty, user = user, hasWrittenPaper = true))
+            participantRepository.save(Participant(party = paperOnlyParty, user = user))
+            participantRepository.save(Participant(party = endedParty, user = user))
+            participantRepository.save(Participant(party = otherParty, user = other))
+            saveInvite(realtimeParty, "upcominglive001")
+            saveInvite(paperOnlyParty, "upcomingpaper01")
+
+            mockMvc
+                .get("/api/v1/me/upcoming-parties") {
+                    header("Authorization", "Bearer $token")
+                }.andExpect {
+                    status { isOk() }
+                    jsonPath("$.data.length()") { value(2) }
+                    expectRealtimeParty(realtimeParty, liveStartAt)
+                    expectPaperOnlyParty(paperOnlyParty)
+                }
+        }
+
+        @Test
+        fun `유효한 초대 토큰이 없으면 inviteToken 은 null`() {
+            val user = saveUser("kakao-upcoming-no-invite", "upcoming-no-invite@kakao.local")
+            val token = tokenProvider.issue(user)
+            val now = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS)
+            val party =
+                saveParty(
+                    PaperOnlyParty(
+                        ownerId = user.id,
+                        celebrantNickname = "토큰없음",
+                        startedAt = now.toLocalDate().plusDays(1).atStartOfDay(),
+                    ),
+                    now.minusHours(1),
+                )
+            participantRepository.save(Participant(party = party, user = user))
+            saveInvite(party, "expiredupcoming", now.minusMinutes(1))
+
+            mockMvc
+                .get("/api/v1/me/upcoming-parties") {
+                    header("Authorization", "Bearer $token")
+                }.andExpect {
+                    status { isOk() }
+                    jsonPath("$.data.length()") { value(1) }
+                    jsonPath("$.data[0].inviteToken") { value(nullValue()) }
+                }
+        }
+
+        private fun saveParty(
+            party: Party,
+            createdAt: LocalDateTime,
+        ): Party {
+            val saved = partyRepository.saveAndFlush(party)
+            saved.createdAt = createdAt.truncatedTo(ChronoUnit.SECONDS)
+            return partyRepository.saveAndFlush(saved)
+        }
+
+        private fun saveInvite(
+            party: Party,
+            token: String,
+            expiresAt: LocalDateTime = LocalDateTime.now().plusDays(1),
+        ): PartyInvite =
+            partyInviteRepository.save(
+                PartyInvite(
+                    party = party,
+                    token = token,
+                    expiresAt = expiresAt,
+                ),
+            )
+
+        private fun MockMvcResultMatchersDsl.expectRealtimeParty(
+            party: Party,
+            liveStartAt: LocalDateTime,
+        ) {
+            jsonPath("$.data[0].partyId") { value(party.id) }
+            jsonPath("$.data[0].inviteToken") { value("upcominglive001") }
+            jsonPath("$.data[0].partyOption") { value("REALTIME") }
+            jsonPath("$.data[0].celebrantNickname") { value("실시간주인공") }
+            jsonPath("$.data[0].partyStartedAt") {
+                value(liveStartAt.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+            }
+            jsonPath("$.data[0].partyEndedAt") {
+                value(party.endedAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+            }
+            jsonPath("$.data[0].isHost") { value(false) }
+            jsonPath("$.data[0].rollingPaperWritten") { value(true) }
+            jsonPath("$.data[0].hostRollingPaperOpenAt") { value(nullValue()) }
+            jsonPath("$.data[0].realtimeSchedule.enterableFrom") {
+                value(
+                    liveStartAt
+                        .minusMinutes(RealtimeParty.ENTERABLE_BEFORE_MINUTES)
+                        .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
+                )
+            }
+            jsonPath("$.data[0].realtimeSchedule.liveStartAt") {
+                value(liveStartAt.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+            }
+            jsonPath("$.data[0].realtimeSchedule.liveEndAt") {
+                value(
+                    liveStartAt
+                        .plusMinutes(RealtimeParty.LIVE_DURATION_MINUTES)
+                        .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
+                )
+            }
+        }
+
+        private fun MockMvcResultMatchersDsl.expectPaperOnlyParty(party: Party) {
+            jsonPath("$.data[1].partyId") { value(party.id) }
+            jsonPath("$.data[1].inviteToken") { value("upcomingpaper01") }
+            jsonPath("$.data[1].partyOption") { value("PAPER_ONLY") }
+            jsonPath("$.data[1].isHost") { value(true) }
+            jsonPath("$.data[1].rollingPaperWritten") { value(false) }
+            jsonPath("$.data[1].hostRollingPaperOpenAt") {
+                value(party.hostViewableAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+            }
+            jsonPath("$.data[1].realtimeSchedule") { value(nullValue()) }
+        }
+
+        private fun saveUser(
+            providerId: String,
+            email: String,
+        ): User =
+            userRepository.save(
+                User(
+                    name = "조회자",
+                    birthDay = "01-01",
+                    provider = AuthProvider.KAKAO,
+                    providerId = providerId,
+                    email = email,
+                ),
+            )
+    }

--- a/src/test/kotlin/com/team2/server/party/controller/MePartyControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/party/controller/MePartyControllerTest.kt
@@ -228,6 +228,13 @@ class MePartyControllerTest
             jsonPath("$.data[$index].partyId") { value(party.id) }
             jsonPath("$.data[$index].inviteToken") { value("upcomingpaper01") }
             jsonPath("$.data[$index].partyOption") { value("PAPER_ONLY") }
+            jsonPath("$.data[$index].celebrantNickname") { value(party.celebrantNickname) }
+            jsonPath("$.data[$index].partyStartedAt") {
+                value(party.startedAt.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+            }
+            jsonPath("$.data[$index].partyEndedAt") {
+                value(party.endedAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+            }
             jsonPath("$.data[$index].isHost") { value(true) }
             jsonPath("$.data[$index].rollingPaperWritten") { value(false) }
             jsonPath("$.data[$index].hostRollingPaperOpenAt") {

--- a/src/test/kotlin/com/team2/server/party/controller/PartyInviteLookupControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/party/controller/PartyInviteLookupControllerTest.kt
@@ -72,11 +72,11 @@ class PartyInviteLookupControllerTest
                 jsonPath("$.data.partyOption") { value("PAPER_ONLY") }
                 jsonPath("$.data.partyEnded") { value(false) }
                 jsonPath("$.data.rollingPaperWritten") { value(false) }
-                jsonPath("$.data.partyStartDate") { value(createdAt.toLocalDate().toString()) }
+                jsonPath("$.data.partyStartDate") { value(party.startedAt.toLocalDate().toString()) }
                 jsonPath("$.data.partyEndDate") {
                     value(
-                        createdAt
-                            .plusDays(Party.ENDED_AFTER_DAYS)
+                        party
+                            .endedAt()
                             .toLocalDate()
                             .toString(),
                     )
@@ -88,7 +88,7 @@ class PartyInviteLookupControllerTest
         }
 
         @Test
-        fun `생성 후 7일이 지난 파티는 partyEnded true`() {
+        fun `시작 후 7일이 지난 파티는 partyEnded true`() {
             val createdAt = LocalDateTime.now().minusDays(8).truncatedTo(ChronoUnit.SECONDS)
             val party =
                 saveParty(

--- a/src/test/kotlin/com/team2/server/party/entity/PartyDomainTest.kt
+++ b/src/test/kotlin/com/team2/server/party/entity/PartyDomainTest.kt
@@ -47,13 +47,14 @@ class PartyDomainTest {
     }
 
     @Test
-    fun `Party는 생성 후 7일을 종료 시각으로 가진다`() {
+    fun `Party는 시작 시각 후 7일을 종료 시각으로 가진다`() {
         val createdAt = LocalDateTime.of(2026, 5, 1, 12, 0)
-        val party = RealtimeParty(ownerId = 1L, startedAt = defaultStartedAt)
+        val startedAt = LocalDateTime.of(2026, 6, 1, 14, 0)
+        val party = RealtimeParty(ownerId = 1L, startedAt = startedAt)
         party.createdAt = createdAt
 
-        assertEquals(createdAt.plusDays(Party.ENDED_AFTER_DAYS), party.endedAt())
-        assertFalse(party.isEnded(createdAt.plusDays(Party.ENDED_AFTER_DAYS).minusNanos(1)))
-        assertTrue(party.isEnded(createdAt.plusDays(Party.ENDED_AFTER_DAYS)))
+        assertEquals(startedAt.plusDays(Party.ENDED_AFTER_DAYS), party.endedAt())
+        assertFalse(party.isEnded(startedAt.plusDays(Party.ENDED_AFTER_DAYS).minusNanos(1)))
+        assertTrue(party.isEnded(startedAt.plusDays(Party.ENDED_AFTER_DAYS)))
     }
 }

--- a/src/test/kotlin/com/team2/server/party/entity/PartyStatusTest.kt
+++ b/src/test/kotlin/com/team2/server/party/entity/PartyStatusTest.kt
@@ -56,16 +56,16 @@ class PartyStatusTest {
     }
 
     @Test
-    fun `PaperOnlyParty - 생성일 +7일 직전은 OPEN`() {
+    fun `PaperOnlyParty - 시작일 +7일 직전은 OPEN`() {
         val party = paperParty()
-        val now = createdAt.plusDays(7).minusMinutes(1)
+        val now = birthday.atStartOfDay().plusDays(7).minusMinutes(1)
         assertEquals(PaperOnlyPartyStatus.OPEN, party.status(now))
     }
 
     @Test
-    fun `PaperOnlyParty - 생성일 +7일 이후는 CLOSED`() {
+    fun `PaperOnlyParty - 시작일 +7일 이후는 CLOSED`() {
         val party = paperParty()
-        val now = createdAt.plusDays(7)
+        val now = birthday.atStartOfDay().plusDays(7)
         assertEquals(PaperOnlyPartyStatus.CLOSED, party.status(now))
     }
 
@@ -117,9 +117,9 @@ class PartyStatusTest {
     }
 
     @Test
-    fun `RealtimeParty - 생성일 +7일 이후는 ROLLING_PAPER_CLOSED`() {
+    fun `RealtimeParty - 라이브 시작 +7일 이후는 ROLLING_PAPER_CLOSED`() {
         val party = realtimeParty()
-        val now = createdAt.plusDays(7)
+        val now = liveStart.plusDays(7)
         assertEquals(RealtimePartyStatus.ROLLING_PAPER_CLOSED, party.status(now))
     }
 

--- a/src/test/kotlin/com/team2/server/party/service/PartyInviteServiceTest.kt
+++ b/src/test/kotlin/com/team2/server/party/service/PartyInviteServiceTest.kt
@@ -114,7 +114,7 @@ class PartyInviteServiceTest {
     }
 
     @Test
-    fun `초대 링크 만료 시간은 파티 생성 후 7일`() {
+    fun `초대 링크 만료 시간은 파티 시작 후 7일`() {
         val createdAt = LocalDateTime.now().minusDays(1)
         val startedAt = LocalDateTime.now().plusDays(1)
         val party = makeParty(startedAt = startedAt, createdAt = createdAt)
@@ -129,17 +129,17 @@ class PartyInviteServiceTest {
 
         service.activateInviteLink(1L, 1L)
 
-        assertEquals(createdAt.plusDays(Party.ENDED_AFTER_DAYS), savedInvite!!.expiresAt)
+        assertEquals(startedAt.plusDays(Party.ENDED_AFTER_DAYS), savedInvite!!.expiresAt)
     }
 
     @Test
-    fun `파티 생성 후 7일이 지나면 새 초대링크를 만들지 않는다`() {
-        val createdAt =
+    fun `파티 시작 후 7일이 지나면 새 초대링크를 만들지 않는다`() {
+        val startedAt =
             LocalDateTime
                 .now()
                 .minusDays(Party.ENDED_AFTER_DAYS)
                 .minusSeconds(1)
-        val party = makeParty(createdAt = createdAt)
+        val party = makeParty(startedAt = startedAt)
         whenever(partyRepository.findById(1L)).thenReturn(Optional.of(party))
         whenever(participantRepository.existsByPartyIdAndUserId(1L, 1L)).thenReturn(true)
         whenever(partyInviteRepository.findByPartyIdAndExpiresAtAfter(any(), any())).thenReturn(null)

--- a/src/test/kotlin/com/team2/server/rollingpaper/controller/RollingPaperControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/rollingpaper/controller/RollingPaperControllerTest.kt
@@ -262,7 +262,7 @@ class RollingPaperControllerTest
         }
 
         @Test
-        fun `생성 후 7일 지난 파티면 실패`() {
+        fun `시작 후 7일 지난 파티면 실패`() {
             val party = saveParty(createdAt = LocalDateTime.now().minusDays(8))
             val invite = saveInvite(party, "endedwrite00001")
             val wrapper = saveWrapper()

--- a/src/test/kotlin/com/team2/server/rollingpaper/controller/RollingPaperListControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/rollingpaper/controller/RollingPaperListControllerTest.kt
@@ -191,7 +191,7 @@ class RollingPaperListControllerTest
                 }.andExpect {
                     status { isOk() }
                     jsonPath("$.data.celebrantNickname") { value("홍길동") }
-                    jsonPath("$.data.partyEndAt") { value("2026-05-12T14:30:00") }
+                    jsonPath("$.data.partyEndAt") { value("2020-01-08T00:00:00") }
                     jsonPath("$.data.page") { value(1) }
                     jsonPath("$.data.totalCount") { value(1) }
                     jsonPath("$.data.totalPages") { value(1) }


### PR DESCRIPTION
## 🔗 Issue
- closes #114

## 💬 Context
홈 화면에서 사용하던 하드코딩 파티 목록을 서버 API로 대체하기 위해, 로그인 회원이 참여 중이고 아직 종료되지 않은 파티 목록을 조회하는 API를 추가했습니다.

파티 종료 기준은 실제 파티 시작 시각인 `startedAt + 7일`로 정리했습니다. 기획상 실시간 파티는 라이브 종료 후에도 7일 동안 롤링페이퍼 작성이 가능해야 하므로, 파티 생성 시각인 `createdAt`을 기준으로 삼으면 미래 예약 파티에서 작성 가능 기간이 의도보다 짧아질 수 있습니다. 따라서 PaperOnly/Realtime 모두 사용자가 체감하는 파티 시작 시각인 `startedAt` 기준으로 종료 시각을 통일했습니다.

## 🛠 Changes
- `GET /api/v1/me/upcoming-parties` API 추가
- 회원이 참여한 미종료 파티 목록 조회 및 최신 참여 순 정렬
- 초대 토큰, 파티 유형, 주최 여부, 롤링페이퍼 작성 여부, 주최자 오픈 시각 응답 추가
- 실시간 파티 입장 가능 시각, 시작 시각, 종료 시각 응답 추가
- `Party.endedAt()` 기준을 `startedAt + 7일`로 통일하고 관련 조회/문서/테스트 갱신

## 👀 Review Focus
- 홈 다가오는 파티 응답 필드가 FE 요구 계약에 충분한지
- 미종료 파티 필터가 `Party.startedAt + 7일` 기준으로 일관되게 적용되는지
- 초대 토큰 조회와 참여자 목록 조회 쿼리가 불필요한 N+1 없이 동작하는지

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 인증된 사용자가 참여한 다가오는 파티 목록을 조회할 수 있는 엔드포인트 추가

* **Documentation**
  * 파티 상태 정의 및 상태 전환 기준 업데이트 (생성일 기반 → 시작일 기반)
  * 롤링페이퍼 작성, 파티 초대 조회, 목록 조회 API 설계 스펙 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->