### PR TITLE
[Fix] nginx 배포 검증 안정화

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -210,13 +210,8 @@ reload_nginx() {
     docker exec team2-nginx nginx -s reload
 }
 
-verify_nginx_route() {
+verify_nginx_route_once() {
     local app_env="$1"
-
-    if ! command -v curl &>/dev/null; then
-        echo "ERROR: curl is required on the deployment host for nginx route verification."
-        return 1
-    fi
 
     if [ "$app_env" = "dev" ]; then
         curl -fsS --connect-timeout 3 --max-time 10 http://127.0.0.1:8081/actuator/health >/dev/null ||
@@ -224,6 +219,33 @@ verify_nginx_route() {
     else
         curl -kfsS --connect-timeout 3 --max-time 10 --resolve api.hapalin.com:443:127.0.0.1 https://api.hapalin.com/actuator/health >/dev/null
     fi
+}
+
+verify_nginx_route() {
+    local app_env="$1"
+    local max_attempts=10
+    local interval=2
+
+    if ! command -v curl &>/dev/null; then
+        echo "ERROR: curl is required on the deployment host for nginx route verification."
+        return 1
+    fi
+
+    for i in $(seq 1 "$max_attempts"); do
+        if verify_nginx_route_once "$app_env"; then
+            return 0
+        fi
+
+        if [ "$i" -lt "$max_attempts" ]; then
+            echo "  [$i/$max_attempts] nginx route for $app_env is not ready; retrying in ${interval}s..."
+            sleep "$interval"
+        fi
+    done
+
+    echo "ERROR: nginx route verification failed after $max_attempts attempts for $app_env."
+    echo "==> Active upstream file for $app_env:"
+    cat "$(active_upstreams_file "$app_env")" || true
+    return 1
 }
 
 switch_nginx_to_slot() {

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -109,10 +109,12 @@ nginx_has_mount_destination() {
     local destination="$1"
 
     docker inspect -f '{{range .Mounts}}{{println .Destination}}{{end}}' team2-nginx 2>/dev/null |
-        grep -qx "$destination"
+        grep -Fxq "$destination"
 }
 
 ensure_nginx_blue_green_ready() {
+    local nginx_dump
+
     if ! docker ps --filter 'name=^/team2-nginx$' --format '{{.Names}}' | grep -qx 'team2-nginx'; then
         echo "ERROR: team2-nginx is not running. Run ./scripts/deploy-nginx.sh before app deployment."
         return 1
@@ -134,15 +136,23 @@ ensure_nginx_blue_green_ready() {
     fi
 
     # These sentinels confirm team2-nginx is using the blue/green nginx configuration.
-    if ! docker exec team2-nginx sh -c "nginx -T 2>/dev/null | grep -q 'dev_api_upstream'" ||
-        ! docker exec team2-nginx sh -c "nginx -T 2>/dev/null | grep -q 'prod_api_upstream'"; then
+    if ! nginx_dump="$(docker exec team2-nginx nginx -T 2>/dev/null)"; then
+        echo "ERROR: failed to dump team2-nginx configuration."
+        echo "Run ./scripts/deploy-nginx.sh before app deployment."
+        return 1
+    fi
+
+    if ! grep -q 'dev_api_upstream' <<< "$nginx_dump" ||
+        ! grep -q 'prod_api_upstream' <<< "$nginx_dump"; then
         echo "ERROR: team2-nginx is not using the current blue/green nginx configuration."
         echo "Run ./scripts/deploy-nginx.sh before app deployment."
         return 1
     fi
+
+    echo "==> nginx blue/green preflight: OK"
 }
 
-ensure_nginx_blue_green_ready
+ensure_nginx_blue_green_ready || exit 1
 
 profiles_for_env() {
     local app_env="$1"
@@ -251,19 +261,31 @@ reload_nginx() {
 
 verify_nginx_route_once() {
     local app_env="$1"
+    local output_mode="${2:-show}"
 
     if [ "$app_env" = "dev" ]; then
-        curl -fsS --connect-timeout 3 --max-time 10 http://127.0.0.1:8081/actuator/health >/dev/null ||
+        if curl -fsS --connect-timeout 3 --max-time 10 http://127.0.0.1:8081/actuator/health >/dev/null 2>&1; then
+            return 0
+        fi
+
+        if [ "$output_mode" = "quiet" ]; then
+            curl -kfsS --connect-timeout 3 --max-time 10 --resolve dev-api.hapalin.com:443:127.0.0.1 https://dev-api.hapalin.com/actuator/health >/dev/null 2>&1
+        else
             curl -kfsS --connect-timeout 3 --max-time 10 --resolve dev-api.hapalin.com:443:127.0.0.1 https://dev-api.hapalin.com/actuator/health >/dev/null
+        fi
     else
-        curl -kfsS --connect-timeout 3 --max-time 10 --resolve api.hapalin.com:443:127.0.0.1 https://api.hapalin.com/actuator/health >/dev/null
+        if [ "$output_mode" = "quiet" ]; then
+            curl -kfsS --connect-timeout 3 --max-time 10 --resolve api.hapalin.com:443:127.0.0.1 https://api.hapalin.com/actuator/health >/dev/null 2>&1
+        else
+            curl -kfsS --connect-timeout 3 --max-time 10 --resolve api.hapalin.com:443:127.0.0.1 https://api.hapalin.com/actuator/health >/dev/null
+        fi
     fi
 }
 
 verify_nginx_route() {
     local app_env="$1"
-    local max_attempts=10
-    local interval=2
+    local max_attempts="${NGINX_ROUTE_VERIFY_MAX_ATTEMPTS:-10}"
+    local interval="${NGINX_ROUTE_VERIFY_INTERVAL:-2}"
 
     if ! command -v curl &>/dev/null; then
         echo "ERROR: curl is required on the deployment host for nginx route verification."
@@ -271,13 +293,17 @@ verify_nginx_route() {
     fi
 
     for i in $(seq 1 "$max_attempts"); do
-        if verify_nginx_route_once "$app_env"; then
-            return 0
-        fi
-
         if [ "$i" -lt "$max_attempts" ]; then
+            if verify_nginx_route_once "$app_env" quiet; then
+                return 0
+            fi
+
             echo "  [$i/$max_attempts] nginx route for $app_env is not ready; retrying in ${interval}s..."
             sleep "$interval"
+        elif verify_nginx_route_once "$app_env"; then
+            return 0
+        else
+            echo "  [$i/$max_attempts] nginx route for $app_env is not ready."
         fi
     done
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -282,6 +282,16 @@ verify_nginx_route_once() {
     fi
 }
 
+validate_positive_integer() {
+    local name="$1"
+    local value="$2"
+
+    if [[ ! "$value" =~ ^[1-9][0-9]*$ ]]; then
+        echo "ERROR: $name must be a positive integer greater than 0."
+        return 1
+    fi
+}
+
 verify_nginx_route() {
     local app_env="$1"
     local max_attempts="${NGINX_ROUTE_VERIFY_MAX_ATTEMPTS:-10}"
@@ -291,6 +301,9 @@ verify_nginx_route() {
         echo "ERROR: curl is required on the deployment host for nginx route verification."
         return 1
     fi
+
+    validate_positive_integer "NGINX_ROUTE_VERIFY_MAX_ATTEMPTS" "$max_attempts" || return 1
+    validate_positive_integer "NGINX_ROUTE_VERIFY_INTERVAL" "$interval" || return 1
 
     for i in $(seq 1 "$max_attempts"); do
         if [ "$i" -lt "$max_attempts" ]; then

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -125,6 +125,7 @@ ensure_nginx_blue_green_ready() {
         return 1
     fi
 
+    # nginx.conf references both dev/prod maps even for a single-environment deploy.
     if ! docker exec team2-nginx test -f /etc/nginx/conf.d/team2-active-upstreams-dev.conf ||
         ! docker exec team2-nginx test -f /etc/nginx/conf.d/team2-active-upstreams-prod.conf; then
         echo "ERROR: team2-nginx cannot see active upstream files."
@@ -132,7 +133,9 @@ ensure_nginx_blue_green_ready() {
         return 1
     fi
 
-    if ! docker exec team2-nginx sh -c "nginx -T 2>/dev/null | grep -q 'prod_api_upstream'"; then
+    # These sentinels confirm team2-nginx is using the blue/green nginx configuration.
+    if ! docker exec team2-nginx sh -c "nginx -T 2>/dev/null | grep -q 'dev_api_upstream'" ||
+        ! docker exec team2-nginx sh -c "nginx -T 2>/dev/null | grep -q 'prod_api_upstream'"; then
         echo "ERROR: team2-nginx is not using the current blue/green nginx configuration."
         echo "Run ./scripts/deploy-nginx.sh before app deployment."
         return 1

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -105,6 +105,42 @@ for network in dev-network prod-network; do
     fi
 done
 
+nginx_has_mount_destination() {
+    local destination="$1"
+
+    docker inspect -f '{{range .Mounts}}{{println .Destination}}{{end}}' team2-nginx 2>/dev/null |
+        grep -qx "$destination"
+}
+
+ensure_nginx_blue_green_ready() {
+    if ! docker ps --filter 'name=^/team2-nginx$' --format '{{.Names}}' | grep -qx 'team2-nginx'; then
+        echo "ERROR: team2-nginx is not running. Run ./scripts/deploy-nginx.sh before app deployment."
+        return 1
+    fi
+
+    if ! nginx_has_mount_destination /etc/nginx/nginx.conf ||
+        ! nginx_has_mount_destination /etc/nginx/conf.d; then
+        echo "ERROR: team2-nginx is not using the blue/green nginx mounts."
+        echo "Run ./scripts/deploy-nginx.sh before app deployment."
+        return 1
+    fi
+
+    if ! docker exec team2-nginx test -f /etc/nginx/conf.d/team2-active-upstreams-dev.conf ||
+        ! docker exec team2-nginx test -f /etc/nginx/conf.d/team2-active-upstreams-prod.conf; then
+        echo "ERROR: team2-nginx cannot see active upstream files."
+        echo "Run ./scripts/deploy-nginx.sh before app deployment."
+        return 1
+    fi
+
+    if ! docker exec team2-nginx sh -c "nginx -T 2>/dev/null | grep -q 'prod_api_upstream'"; then
+        echo "ERROR: team2-nginx is not using the current blue/green nginx configuration."
+        echo "Run ./scripts/deploy-nginx.sh before app deployment."
+        return 1
+    fi
+}
+
+ensure_nginx_blue_green_ready
+
 profiles_for_env() {
     local app_env="$1"
     echo "$app_env,secret-$app_env"


### PR DESCRIPTION
## 🔗 Issue
- closes #124

## 💬 Context
- MVP prod 배포 중 app/DB는 정상 기동됐지만 nginx route verification 단계에서 503으로 배포가 실패 처리됐습니다.
- nginx가 blue/green 배포 설정을 사용하지 않는 상태라면 app 배포 전에 중단하도록 방어 로직을 추가합니다.

## 🛠 Changes
- nginx blue/green 설정 preflight 추가
- nginx route verification retry 추가
- 재시도 중 curl stderr 노이즈 정리
- 실패 시 active upstream 파일 출력
- retry 횟수/간격 환경변수 오버라이드 및 값 검증 추가

## 👀 Review Focus
- nginx preflight 조건이 dev/prod 공용 nginx 구조와 맞는지
- route verification retry와 rollback 흐름이 적절한지

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인
- [x] CodeRabbit review 통과
- [x] 로컬 정적 검증 통과
- [x] 서버 비파괴 route 검증 통과

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견