### PR TITLE
[Fix] 블루그린 모니터링 대상 수정

### DIFF
--- a/monitoring/grafana/dashboards/spring-boot.json
+++ b/monitoring/grafana/dashboards/spring-boot.json
@@ -20,7 +20,7 @@
       "targets": [
         {
           "expr": "rate(http_server_requests_seconds_count{job=\"team2-backend-$env\"}[1m])",
-          "legendFormat": "{{method}} {{uri}} {{status}}",
+          "legendFormat": "{{slot}} {{method}} {{uri}} {{status}}",
           "refId": "A"
         }
       ],
@@ -39,7 +39,7 @@
       "targets": [
         {
           "expr": "rate(http_server_requests_seconds_sum{job=\"team2-backend-$env\"}[1m]) / rate(http_server_requests_seconds_count{job=\"team2-backend-$env\"}[1m])",
-          "legendFormat": "{{method}} {{uri}}",
+          "legendFormat": "{{slot}} {{method}} {{uri}}",
           "refId": "A"
         }
       ],
@@ -58,7 +58,7 @@
       "targets": [
         {
           "expr": "jvm_memory_used_bytes{job=\"team2-backend-$env\"}",
-          "legendFormat": "{{area}} - {{id}}",
+          "legendFormat": "{{slot}} {{area}} - {{id}}",
           "refId": "A"
         }
       ],
@@ -77,7 +77,7 @@
       "targets": [
         {
           "expr": "rate(process_cpu_usage{job=\"team2-backend-$env\"}[1m])",
-          "legendFormat": "CPU 사용률",
+          "legendFormat": "{{slot}} CPU 사용률",
           "refId": "A"
         }
       ],

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -6,9 +6,23 @@ scrape_configs:
   - job_name: 'team2-backend-dev'
     metrics_path: '/actuator/prometheus'
     static_configs:
-      - targets: ['team2-app-dev:8080']
+      - targets: ['team2-app-dev-blue:8080']
+        labels:
+          env: 'dev'
+          slot: 'blue'
+      - targets: ['team2-app-dev-green:8080']
+        labels:
+          env: 'dev'
+          slot: 'green'
 
   - job_name: 'team2-backend-prod'
     metrics_path: '/actuator/prometheus'
     static_configs:
-      - targets: ['team2-app-prod:8080']
+      - targets: ['team2-app-prod-blue:8080']
+        labels:
+          env: 'prod'
+          slot: 'blue'
+      - targets: ['team2-app-prod-green:8080']
+        labels:
+          env: 'prod'
+          slot: 'green'


### PR DESCRIPTION
## 🔗 Issue
- closes #130

## 💬 Context
블루그린 배포 이후 애플리케이션 컨테이너가 `team2-app-{env}-{slot}` 형태로 생성되면서 기존 Prometheus scrape target인 `team2-app-dev:8080`, `team2-app-prod:8080`이 더 이상 실제 컨테이너를 가리키지 못했습니다.

## 🛠 Changes
- Prometheus scrape target을 dev/prod 각각 blue, green 슬롯 컨테이너로 확장
- 슬롯별 target에 `env`, `slot` label 추가
- Grafana Spring Boot 대시보드 legend에 slot label 표시

## 👀 Review Focus
- blue/green 슬롯 중 한쪽만 떠 있는 상황에서도 Prometheus target 구성이 적절한지
- Grafana 쿼리의 기존 `team2-backend-$env` job 기준을 유지하는 방향이 괜찮은지

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [ ] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견
