### PR TITLE
[Feat] 롤링페이퍼 목록 상세 데이터 계약 정리

### DIFF
--- a/docs/superpowers/plans/2026-05-06-rolling-paper-list.md
+++ b/docs/superpowers/plans/2026-05-06-rolling-paper-list.md
@@ -2,11 +2,13 @@
 
 ## Summary
 
-롤링페이퍼 목록 조회 API를 참가자용과 주최자용으로 분리해 추가한다.
+롤링페이퍼 목록 조회 API를 참가자용과 주최자용으로 분리해 유지하되, 목록 item을 상세 오버레이의 데이터 소스로 확장한다.
 
 - 참가자용은 초대 토큰 기반 공개 조회다.
 - 주최자용은 인증된 파티 소유자만 조회할 수 있다.
-- 두 API는 공통 목록 item을 사용한다.
+- 두 API는 `content`, `position`을 포함하는 공통 목록 item을 사용한다.
+- 상세 오버레이는 기본적으로 목록 page 응답으로 렌더링한다.
+- 주최자용 상세 조회 API는 딥링크, 새로고침 복구, 운영성 조회 같은 보조 플로우를 위해 유지한다.
 - 목록은 표준 page 기반 페이지네이션으로 조회하고, 응답 시각은 기존 API와 맞춰 KST 기준 `LocalDateTime` 문자열을 유지한다.
 
 Spec: `docs/superpowers/specs/2026-05-05-rolling-paper-list-design.md`
@@ -23,7 +25,8 @@ Spec: `docs/superpowers/specs/2026-05-05-rolling-paper-list-design.md`
 - 초대 토큰이 없으면 `PARTY_NOT_FOUND`, 404로 응답한다.
 - 초대 토큰 만료 여부와 파티 자체 종료 여부는 목록 조회를 막지 않는다.
 - `PAPER_ONLY`는 `liveEndAt = null`로 응답한다.
-- 참가자 응답에는 `totalCount`, `pageSize`, `partyEndAt`을 포함하지 않는다.
+- 참가자 응답에는 상세 오버레이의 `1 / N` 표시에 필요한 `totalCount`를 포함한다.
+- 참가자 응답에는 `pageSize`, `partyEndAt`을 포함하지 않는다.
 
 Response data:
 
@@ -32,12 +35,15 @@ Response data:
   "partyOption": "REALTIME",
   "liveEndAt": "2026-05-05T22:10:00",
   "page": 1,
+  "totalCount": 12,
   "totalPages": 2,
   "hasNext": true,
   "items": [
     {
       "rollingPaperId": 10,
+      "position": 1,
       "writerNickname": "축하요정",
+      "content": "생일 축하해요!",
       "wrapperImageUrl": "/images/rolling-paper-wrappers/Topping_Candle.svg"
     }
   ]
@@ -66,12 +72,25 @@ Response data:
   "items": [
     {
       "rollingPaperId": 10,
+      "position": 1,
       "writerNickname": "축하요정",
+      "content": "생일 축하해요!",
       "wrapperImageUrl": "/images/rolling-paper-wrappers/Topping_Candle.svg"
     }
   ]
 }
 ```
+
+### Owner Detail
+
+`GET /api/v1/parties/{partyId}/rolling-papers/{rollingPaperId}`
+
+- 인증 필수다.
+- `party.ownerId == principal.userId`가 아니면 `PARTY_FORBIDDEN`, 403으로 응답한다.
+- 주최자 열람 가능 시각 전이면 `ROLLING_PAPER_NOT_VIEWABLE`, 403으로 응답한다.
+- 목록 화면에서 토핑을 눌러 상세 오버레이를 여는 기본 플로우에는 사용하지 않는다.
+- 특정 롤링페이퍼 ID로 바로 진입해야 하는 딥링크, 푸시 알림, 새로고침 복구, 운영성 조회 같은 보조 플로우에 사용한다.
+- 상세 오버레이의 좌우 이동은 목록 page 캐시와 인접 page 조회로 처리한다.
 
 ## Implementation Steps
 
@@ -92,12 +111,20 @@ Response data:
    - `page < 1`은 1로 보정한다.
    - `totalCount = 0`이면 `totalPages = 0`, `items = []`, `hasNext = false`다.
    - `page > totalPages`이면 요청 page를 유지하고 `items = []`, `hasNext = false`다.
+   - 참가자용과 주최자용 모두 `totalCount`를 응답한다.
+   - item의 `position`은 `(page - 1) * 7 + index + 1`로 계산한다.
+   - item에는 상세 오버레이용 `content`를 포함한다.
    - wrapper 이미지는 bulk 조회 후 `sortOrder ASC` 첫 번째 이미지를 매핑한다.
 
 4. DTO, UseCase, Controller를 추가한다.
    - 참가자용 GET 경로는 `SecurityConfig`에 method/path-specific `permitAll`로 추가한다.
    - 주최자용 GET 경로는 기본 authenticated 정책을 사용한다.
    - Swagger에는 200, 401, 403, 404, 500과 주요 ErrorCode 예시를 명시한다.
+
+5. 주최자용 상세 조회 API를 보조 플로우로 정리한다.
+   - 기본 상세 오버레이 플로우는 목록 응답을 사용하도록 문서와 Swagger 설명을 맞춘다.
+   - 상세 API는 직접 ID 진입과 복구 조회 용도임을 명시한다.
+   - 상세 API 삭제는 딥링크/복구 요구가 사라진 뒤 별도 과제로 판단한다.
 
 ## Test Plan
 
@@ -109,7 +136,8 @@ Response data:
   - `REALTIME`이면 `liveEndAt = startedAt + LIVE_DURATION_MINUTES`
   - `PAPER_ONLY`이면 `liveEndAt = null`
   - 파티 자체 종료 후에도 조회 성공
-  - `totalCount`는 응답하지 않음
+  - `totalCount` 응답
+  - item에 `position`, `content` 응답
 
 - 주최자용 목록
   - 소유자 조회 성공
@@ -119,6 +147,7 @@ Response data:
   - `PAPER_ONLY`는 22:00 기준 열람 가능
   - `REALTIME`은 live 종료 시각 기준 열람 가능
   - `celebrantNickname`, `partyEndAt`, `totalCount`, `totalPages` 응답 확인
+  - item에 `position`, `content` 응답
 
 - 공통 목록/페이지네이션
   - 최신순 `createdAt DESC, id DESC`
@@ -126,8 +155,15 @@ Response data:
   - `page < 1`은 1로 보정
   - 빈 목록: `totalPages = 0`, `items = []`
   - 초과 페이지: 요청 page 유지, `items = []`, `hasNext = false`
+  - `position`은 전체 최신순 목록 기준 순번
   - wrapper 이미지는 bulk 조회 결과 중 `sortOrder ASC` 첫 번째 URL 사용
   - 이미지 없으면 `wrapperImageUrl = null`
+
+- 주최자용 상세
+  - 특정 롤링페이퍼 ID로 상세 조회 성공
+  - 해당 파티의 롤링페이퍼가 아니면 404
+  - 소유자가 아니면 403
+  - 열람 가능 전이면 403
 
 ## Verification
 

--- a/docs/superpowers/plans/2026-05-06-rolling-paper-list.md
+++ b/docs/superpowers/plans/2026-05-06-rolling-paper-list.md
@@ -9,7 +9,9 @@
 - 두 API는 `content`, `position`을 포함하는 공통 목록 item을 사용한다.
 - 상세 오버레이는 기본적으로 목록 page 응답으로 렌더링한다.
 - 주최자용 상세 조회 API는 딥링크, 새로고침 복구, 운영성 조회 같은 보조 플로우를 위해 유지한다.
-- 목록은 표준 page 기반 페이지네이션으로 조회하고, 응답 시각은 기존 API와 맞춰 KST 기준 `LocalDateTime` 문자열을 유지한다.
+- 목록은 표준 page 기반 페이지네이션으로 조회하고, `PAGE_SIZE = 7`을 사용한다.
+- `content`는 작성 API의 기존 제한과 동일하게 최대 100자다.
+- 응답 시각은 기존 API와 맞춰 KST 기준 `LocalDateTime` 문자열을 유지한다.
 
 Spec: `docs/superpowers/specs/2026-05-05-rolling-paper-list-design.md`
 
@@ -27,6 +29,7 @@ Spec: `docs/superpowers/specs/2026-05-05-rolling-paper-list-design.md`
 - `PAPER_ONLY`는 `liveEndAt = null`로 응답한다.
 - 참가자 응답에는 상세 오버레이의 `1 / N` 표시에 필요한 `totalCount`를 포함한다.
 - 참가자 응답에는 `pageSize`, `partyEndAt`을 포함하지 않는다.
+- 참가자용 상세 단건 조회 API는 이번 계약에 추가하지 않는다. 특정 롤링페이퍼 ID로 바로 진입하는 참가자 딥링크/복구 요구가 생기면 별도 계약으로 추가한다.
 
 Response data:
 
@@ -91,6 +94,7 @@ Response data:
 - 목록 화면에서 토핑을 눌러 상세 오버레이를 여는 기본 플로우에는 사용하지 않는다.
 - 특정 롤링페이퍼 ID로 바로 진입해야 하는 딥링크, 푸시 알림, 새로고침 복구, 운영성 조회 같은 보조 플로우에 사용한다.
 - 상세 오버레이의 좌우 이동은 목록 page 캐시와 인접 page 조회로 처리한다.
+- `previousRollingPaperId`, `nextRollingPaperId`는 목록 page 캐시가 없는 직접 진입 상황에서 인접 항목 안내용으로 유지한다.
 
 ## Implementation Steps
 
@@ -107,13 +111,15 @@ Response data:
 
 3. 목록 조회 기반을 추가한다.
    - `RollingPaperRepository.findAllByParty(..., Pageable): Page<RollingPaper>`를 추가한다.
-   - 정렬은 `createdAt DESC, id DESC`, 페이지 크기는 7로 고정한다.
+   - 정렬은 `createdAt DESC, id DESC`, 페이지 크기는 `PAGE_SIZE = 7`로 고정한다.
    - `page < 1`은 1로 보정한다.
    - `totalCount = 0`이면 `totalPages = 0`, `items = []`, `hasNext = false`다.
    - `page > totalPages`이면 요청 page를 유지하고 `items = []`, `hasNext = false`다.
    - 참가자용과 주최자용 모두 `totalCount`를 응답한다.
-   - item의 `position`은 `(page - 1) * 7 + index + 1`로 계산한다.
+   - item의 `position`은 `(page - 1) * PAGE_SIZE + index + 1`로 계산한다.
    - item에는 상세 오버레이용 `content`를 포함한다.
+   - item의 `content`는 작성 API의 `@Size(max = 100)` 제한을 그대로 따른다.
+   - `position`과 `totalCount`는 목록 응답 시점의 snapshot 기준이며, 상세 오버레이를 보는 동안 새 롤링페이퍼가 추가되는 eventual consistency는 허용한다.
    - wrapper 이미지는 bulk 조회 후 `sortOrder ASC` 첫 번째 이미지를 매핑한다.
 
 4. DTO, UseCase, Controller를 추가한다.
@@ -138,6 +144,7 @@ Response data:
   - 파티 자체 종료 후에도 조회 성공
   - `totalCount` 응답
   - item에 `position`, `content` 응답
+  - item `content`는 최대 100자 계약을 따른다.
 
 - 주최자용 목록
   - 소유자 조회 성공
@@ -148,14 +155,16 @@ Response data:
   - `REALTIME`은 live 종료 시각 기준 열람 가능
   - `celebrantNickname`, `partyEndAt`, `totalCount`, `totalPages` 응답 확인
   - item에 `position`, `content` 응답
+  - item `content`는 최대 100자 계약을 따른다.
 
 - 공통 목록/페이지네이션
   - 최신순 `createdAt DESC, id DESC`
-  - 7개 고정 페이지
+  - `PAGE_SIZE = 7` 고정 페이지
   - `page < 1`은 1로 보정
   - 빈 목록: `totalPages = 0`, `items = []`
   - 초과 페이지: 요청 page 유지, `items = []`, `hasNext = false`
   - `position`은 전체 최신순 목록 기준 순번
+  - 조회 이후 새 롤링페이퍼 추가로 인한 cached `position` / `totalCount`의 eventual consistency 허용
   - wrapper 이미지는 bulk 조회 결과 중 `sortOrder ASC` 첫 번째 URL 사용
   - 이미지 없으면 `wrapperImageUrl = null`
 

--- a/docs/superpowers/plans/2026-05-06-rolling-paper-list.md
+++ b/docs/superpowers/plans/2026-05-06-rolling-paper-list.md
@@ -94,7 +94,7 @@ Response data:
 - 목록 화면에서 토핑을 눌러 상세 오버레이를 여는 기본 플로우에는 사용하지 않는다.
 - 특정 롤링페이퍼 ID로 바로 진입해야 하는 딥링크, 푸시 알림, 새로고침 복구, 운영성 조회 같은 보조 플로우에 사용한다.
 - 상세 오버레이의 좌우 이동은 목록 page 캐시와 인접 page 조회로 처리한다.
-- `previousRollingPaperId`, `nextRollingPaperId`는 목록 page 캐시가 없는 직접 진입 상황에서 인접 항목 안내용으로 유지한다.
+- 상세 API는 단건 복구에 필요한 `content`, `writerNickname`, `position`, `totalCount`만 제공하고 이전/다음 롤링페이퍼 ID는 제공하지 않는다.
 
 ## Implementation Steps
 
@@ -170,6 +170,8 @@ Response data:
 
 - 주최자용 상세
   - 특정 롤링페이퍼 ID로 상세 조회 성공
+  - `rollingPaperId`, `content`, `writerNickname`, `position`, `totalCount` 응답
+  - `previousRollingPaperId`, `nextRollingPaperId`는 응답하지 않음
   - 해당 파티의 롤링페이퍼가 아니면 404
   - 소유자가 아니면 403
   - 열람 가능 전이면 403

--- a/docs/superpowers/specs/2026-05-05-rolling-paper-list-design.md
+++ b/docs/superpowers/specs/2026-05-05-rolling-paper-list-design.md
@@ -1,8 +1,8 @@
 # Rolling Paper List API Design
 
 - 작성일: 2026-05-05
-- 기준 브랜치: `feature/rolling-paper-list-api`
-- 목적: 롤링페이퍼 목록 리스트 조회 API의 참가자용/주최자용 계약과 화면 요구사항 정리
+- 기준 브랜치: `feature/rolling-paper-list-detail-contract`
+- 목적: 롤링페이퍼 목록 조회 API의 참가자용/주최자용 계약과 상세 오버레이 데이터 제공 방식 정리
 - 구현 전 확인 상태: 이 문서는 구현 전 설계 확인용이며, 승인 전에는 Kotlin 코드를 변경하지 않는다.
 
 ---
@@ -11,19 +11,25 @@
 
 롤링페이퍼 목록 조회 API는 참가자용과 주최자용을 분리한다.
 
+상세 오버레이는 기본적으로 목록 조회 응답을 데이터 소스로 사용한다.
+
 이유:
 
 - 참가자 화면은 초대 링크 기반 흐름이고, 주최자 화면은 인증된 파티 소유자 흐름이다.
 - 두 화면은 목록 카드 필드는 같지만, 열람 조건과 화면 메타가 다르다.
 - 주최자 화면은 아직 열람 가능 시간이 아니면 예외로 처리하는 편이 자연스럽다.
 - `isOwner`, `viewerRole` 같은 분기 필드를 하나의 응답에 섞지 않아도 된다.
+- 목록 화면에서 토핑을 누르면 같은 컬렉션을 상세 오버레이로 보여주는 UX이므로, 상세 본문을 별도 API로 매번 다시 조회하지 않는다.
+- 상세 오버레이의 좌우 이동은 현재 로딩된 목록 page의 `items`로 처리하고, page 경계를 넘을 때 다음 또는 이전 page를 추가 조회한다.
 
 목록 item 응답은 두 API에서 공통으로 사용한다.
 
 공통 item:
 
 - `rollingPaperId`
+- `position`
 - `writerNickname`
+- `content`
 - `wrapperImageUrl`
 
 정렬과 페이지네이션도 두 API가 같은 규칙을 사용한다.
@@ -42,6 +48,8 @@
 2. 사용자가 롤링페이퍼를 작성하거나, 이미 작성한 이후 받은 롤링페이퍼 목록 화면으로 이동한다.
 3. 프론트는 `inviteToken`으로 참가자용 목록 API를 호출한다.
 4. 프론트는 목록 item을 최신순으로 렌더링한다.
+5. 사용자가 토핑을 누르면 이미 받은 목록 item의 `content`와 `writerNickname`으로 상세 오버레이를 연다.
+6. 상세 오버레이에서 좌우 이동 시 현재 page 안에서는 추가 API 호출 없이 이동하고, page 경계를 넘으면 인접 page를 조회한다.
 
 참가자용 화면에서는 파티 자체 종료 후에도 롤링페이퍼 조회를 허용한다.
 다만 이 정책은 확정 요구사항이 바뀌면 조정될 수 있다.
@@ -57,8 +65,9 @@
 2. 프론트는 인증 토큰과 `partyId`로 주최자용 목록 API를 호출한다.
 3. 서버는 현재 사용자가 해당 파티의 소유자인지 검증한다.
 4. 서버는 주최자가 롤링페이퍼를 열람할 수 있는 시점인지 검증한다.
-5. 열람 가능하면 목록과 `partyEndAt`을 내려준다.
+5. 열람 가능하면 목록, 상세 오버레이에 필요한 item 데이터, `partyEndAt`을 내려준다.
 6. 열람 불가하면 예외로 응답한다.
+7. 사용자가 토핑을 누르면 프론트는 목록 item 데이터로 상세 오버레이를 연다.
 
 주최자용 화면의 공유하기 버튼은 목록 API에 포함하지 않는다.
 
@@ -97,12 +106,15 @@ GET /api/v1/party-invites/{inviteToken}/rolling-papers?page=1
   "partyOption": "REALTIME",
   "liveEndAt": "2026-05-05T22:10:00",
   "page": 1,
+  "totalCount": 12,
   "totalPages": 2,
   "hasNext": true,
   "items": [
     {
       "rollingPaperId": 10,
+      "position": 1,
       "writerNickname": "축하요정",
+      "content": "생일 축하해요!",
       "wrapperImageUrl": "/images/rolling-paper-wrappers/Topping_Candle.svg"
     }
   ]
@@ -116,12 +128,15 @@ GET /api/v1/party-invites/{inviteToken}/rolling-papers?page=1
   "partyOption": "PAPER_ONLY",
   "liveEndAt": null,
   "page": 1,
+  "totalCount": 12,
   "totalPages": 2,
   "hasNext": true,
   "items": [
     {
       "rollingPaperId": 10,
+      "position": 1,
       "writerNickname": "축하요정",
+      "content": "생일 축하해요!",
       "wrapperImageUrl": "/images/rolling-paper-wrappers/Topping_Candle.svg"
     }
   ]
@@ -135,18 +150,20 @@ GET /api/v1/party-invites/{inviteToken}/rolling-papers?page=1
 | `partyOption` | `REALTIME`, `PAPER_ONLY`. `liveEndAt = null`의 의미를 명확히 하기 위해 유지한다. |
 | `liveEndAt` | 실시간 파티 종료 시각. `PAPER_ONLY`이면 `null`. |
 | `page` | 요청한 페이지 번호. 1부터 시작한다. |
+| `totalCount` | 전체 롤링페이퍼 수. 상세 오버레이의 `1 / 12` 표시에 사용한다. |
 | `totalPages` | 페이지 번호 UI 계산용 전체 페이지 수. |
 | `hasNext` | 다음 페이지 존재 여부. |
 | `items` | 롤링페이퍼 카드 목록. |
 | `items[].rollingPaperId` | 롤링페이퍼 식별자. |
+| `items[].position` | 최신순 기준 현재 롤링페이퍼 순번. 1부터 시작한다. |
 | `items[].writerNickname` | 롤링페이퍼 작성 당시 닉네임 스냅샷. |
+| `items[].content` | 롤링페이퍼 상세 오버레이에 표시할 본문. |
 | `items[].wrapperImageUrl` | 카드 렌더링용 래퍼 이미지 URL. 이미지가 없으면 `null`. |
 
 응답에서 제외하는 필드:
 
 | 제외 필드 | 제외 이유 |
 |---|---|
-| `totalCount` | 참가자 화면에서 총 개수를 표시하지 않는다. 서버는 `totalPages` 계산을 위해 내부적으로만 count를 사용한다. |
 | `pageSize` | 한 페이지 기준은 7개로 고정이므로 응답에 반복해서 내려주지 않는다. |
 | `partyEndAt` | 참가자용 목록 화면에서는 파티 자체 종료 시각을 표시하지 않는다. |
 
@@ -183,7 +200,9 @@ GET /api/v1/parties/{partyId}/rolling-papers?page=1
   "items": [
     {
       "rollingPaperId": 10,
+      "position": 1,
       "writerNickname": "축하요정",
+      "content": "생일 축하해요!",
       "wrapperImageUrl": "/images/rolling-paper-wrappers/Topping_Candle.svg"
     }
   ]
@@ -202,7 +221,9 @@ GET /api/v1/parties/{partyId}/rolling-papers?page=1
 | `hasNext` | 다음 페이지 존재 여부. |
 | `items` | 롤링페이퍼 카드 목록. |
 | `items[].rollingPaperId` | 롤링페이퍼 식별자. |
+| `items[].position` | 최신순 기준 현재 롤링페이퍼 순번. 1부터 시작한다. |
 | `items[].writerNickname` | 롤링페이퍼 작성 당시 닉네임 스냅샷. |
+| `items[].content` | 롤링페이퍼 상세 오버레이에 표시할 본문. |
 | `items[].wrapperImageUrl` | 카드 렌더링용 래퍼 이미지 URL. 이미지가 없으면 `null`. |
 
 응답에서 제외하는 필드:
@@ -212,6 +233,40 @@ GET /api/v1/parties/{partyId}/rolling-papers?page=1
 | `partyOption` | 주최자 목록 화면의 응답 요구사항에는 필요하지 않다. 열람 가능 여부는 서버가 검증한다. |
 | `pageSize` | 한 페이지 기준은 7개로 고정이므로 응답에 반복해서 내려주지 않는다. |
 | `inviteToken`, `shareLink` | 공유하기 버튼 클릭 시 기존 초대 링크 API를 별도로 호출한다. |
+
+### 3-3. 주최자용 상세 조회
+
+```http
+GET /api/v1/parties/{partyId}/rolling-papers/{rollingPaperId}
+```
+
+인증:
+
+- 인증 필수.
+- `party.ownerId == principal.userId`가 아니면 403.
+- 주최자 열람 가능 시각 전이면 403.
+
+역할:
+
+- 목록 화면에서 토핑을 눌러 상세 오버레이를 여는 기본 플로우에는 사용하지 않는다.
+- 특정 롤링페이퍼 ID로 바로 상세를 열어야 하는 딥링크, 푸시 알림, 새로고침 복구, 운영성 조회 같은 보조 플로우를 위해 유지한다.
+- 상세 오버레이의 좌우 이동은 이 API의 이전/다음 ID에 의존하지 않고 목록 page 캐시와 인접 page 조회로 처리한다.
+
+응답:
+
+```json
+{
+  "rollingPaperId": 10,
+  "content": "생일 축하해요!",
+  "writerNickname": "축하요정",
+  "position": 1,
+  "totalCount": 12,
+  "previousRollingPaperId": null,
+  "nextRollingPaperId": 9
+}
+```
+
+향후 딥링크/복구 요구가 사라지면 상세 API는 제거할 수 있다.
 
 ---
 
@@ -300,8 +355,15 @@ override fun hostViewableAt(): LocalDateTime =
 페이지 요청은 1부터 시작하고, `page`가 1보다 작으면 서버에서 1로 보정한다.
 한 페이지 기준 개수는 7개 고정이며, 정렬은 `createdAt DESC, id DESC`다.
 
-서버는 `totalPages` 계산을 위해 내부적으로 `totalCount`를 조회한다.
-참가자용 응답에는 `totalCount`를 내려주지 않고, 주최자용 응답에는 전체 개수 표시를 위해 `totalCount`를 내려준다.
+서버는 `totalPages` 계산과 상세 오버레이의 `1 / N` 표시를 위해 `totalCount`를 조회한다.
+참가자용과 주최자용 응답 모두 `totalCount`를 내려준다.
+
+각 item의 `position`은 최신순 전체 목록 기준 1부터 시작한다.
+목록 page 응답에서는 별도 count 쿼리로 개별 위치를 계산하지 않고, 현재 page와 index로 계산한다.
+
+```text
+position = (page - 1) * 7 + itemIndex + 1
+```
 
 응답 invariant:
 
@@ -309,6 +371,7 @@ override fun hostViewableAt(): LocalDateTime =
 - 빈 목록이어도 `page`는 보정된 요청 page를 그대로 응답한다.
 - `page > totalPages`이면 `page`는 요청값 그대로 응답하고, `items = []`, `hasNext = false`로 응답한다.
 - 서버는 상한 초과 page를 마지막 페이지로 보정하지 않는다.
+- `items = []`이면 item별 `position`도 응답하지 않는다.
 
 커서 기반 페이지네이션은 이번 API 계약에서는 사용하지 않는다.
 
@@ -350,11 +413,12 @@ Party.endedAt() = Party.startedAt + Party.ENDED_AFTER_DAYS
 
 ## 7. 이미지 URL 정책
 
-목록 item은 `wrapperImageUrl`을 내려준다.
+목록 item은 `wrapperImageUrl`과 상세 오버레이에 필요한 `content`를 내려준다.
 
 이유:
 
 - 목록 화면은 카드를 렌더링하는 화면이므로 프론트가 별도 래퍼 캐시를 강제하지 않는 편이 좋다.
+- 상세 오버레이는 같은 롤링페이퍼 컬렉션을 확대 표시하는 화면이므로 본문을 목록 page 응답에 함께 포함하는 편이 호출 수와 프론트 상태 관리를 줄인다.
 - 이미 래퍼 조회 API도 `wrapperId`, `wrapperImageUrl`을 내려주는 계약이다.
 - 작성 API는 `wrapperId`를 받고, 목록 API는 렌더링용 이미지 URL을 내려주는 역할 분리가 명확하다.
 
@@ -402,8 +466,7 @@ ROLLING_PAPER_NOT_VIEWABLE(HttpStatus.FORBIDDEN, "아직 롤링페이퍼를 확�
 참가자용 목록:
 
 - 초대 토큰으로 목록 조회 성공
-- `partyOption`, `liveEndAt`, `page`, `totalPages`, `hasNext`, `items` 응답
-- `totalCount`는 응답하지 않음
+- `partyOption`, `liveEndAt`, `page`, `totalCount`, `totalPages`, `hasNext`, `items` 응답
 - `PAPER_ONLY`이면 `liveEndAt = null`
 - `REALTIME`이면 `liveEndAt = startedAt + RealtimeParty.LIVE_DURATION_MINUTES`
 - 파티 자체 종료 이후에도 목록 조회 성공. 단, 정책 변경 가능성이 있음을 문서에 남김
@@ -426,10 +489,20 @@ ROLLING_PAPER_NOT_VIEWABLE(HttpStatus.FORBIDDEN, "아직 롤링페이퍼를 확�
 
 - 최신순 정렬
 - 같은 `createdAt`이면 `id DESC` 정렬
-- `rollingPaperId`, `writerNickname`, `wrapperImageUrl` 응답
+- `rollingPaperId`, `position`, `writerNickname`, `content`, `wrapperImageUrl` 응답
+- `position`은 최신순 전체 목록 기준으로 계산
+- `content`는 상세 오버레이에서 별도 상세 조회 없이 표시할 수 있어야 함
 - 이미지가 없으면 `wrapperImageUrl = null`
 - 여러 이미지가 있으면 `sort_order ASC` 첫 번째 이미지 사용
 - 래퍼 이미지는 `wrapper_id IN (...)`으로 bulk 조회해 N+1을 방지
+
+주최자용 상세:
+
+- 특정 롤링페이퍼 ID로 상세 조회 성공
+- 상세 조회는 목록 기반 상세 오버레이의 기본 플로우가 아니라 보조 플로우임
+- 해당 파티의 롤링페이퍼가 아니면 404
+- 소유자가 아니면 403
+- 열람 가능 전이면 403 `ROLLING_PAPER_NOT_VIEWABLE`
 
 페이지네이션:
 

--- a/docs/superpowers/specs/2026-05-05-rolling-paper-list-design.md
+++ b/docs/superpowers/specs/2026-05-05-rolling-paper-list-design.md
@@ -35,8 +35,17 @@
 정렬과 페이지네이션도 두 API가 같은 규칙을 사용한다.
 
 - 최신순
-- 한 페이지 기준 7개
+- 한 페이지 기준 `PAGE_SIZE = 7`
 - 표준 페이지네이션을 사용한다.
+
+문서에서 `PAGE_SIZE`는 7을 의미한다.
+구현도 같은 상수명으로 관리해 위치 계산과 page 조회 크기가 어긋나지 않게 한다.
+
+`content`는 작성 API의 기존 제한을 따른다.
+
+- 필수, blank 불가
+- 최대 100자
+- 서버는 앞뒤 공백을 제거한 내용을 저장한다.
 
 ---
 
@@ -157,14 +166,14 @@ GET /api/v1/party-invites/{inviteToken}/rolling-papers?page=1
 | `items[].rollingPaperId` | 롤링페이퍼 식별자. |
 | `items[].position` | 최신순 기준 현재 롤링페이퍼 순번. 1부터 시작한다. |
 | `items[].writerNickname` | 롤링페이퍼 작성 당시 닉네임 스냅샷. |
-| `items[].content` | 롤링페이퍼 상세 오버레이에 표시할 본문. |
+| `items[].content` | 롤링페이퍼 상세 오버레이에 표시할 본문. 작성 API 기준 최대 100자. |
 | `items[].wrapperImageUrl` | 카드 렌더링용 래퍼 이미지 URL. 이미지가 없으면 `null`. |
 
 응답에서 제외하는 필드:
 
 | 제외 필드 | 제외 이유 |
 |---|---|
-| `pageSize` | 한 페이지 기준은 7개로 고정이므로 응답에 반복해서 내려주지 않는다. |
+| `pageSize` | 한 페이지 기준은 `PAGE_SIZE = 7`로 고정이므로 응답에 반복해서 내려주지 않는다. |
 | `partyEndAt` | 참가자용 목록 화면에서는 파티 자체 종료 시각을 표시하지 않는다. |
 
 참가자용은 실시간 파티 종료 여부 boolean 대신 `liveEndAt`을 내려준다.
@@ -174,6 +183,14 @@ GET /api/v1/party-invites/{inviteToken}/rolling-papers?page=1
 - `liveEndAt`은 서버 응답 시점의 boolean보다 캐시와 시간 경과에 덜 취약하다.
 - 프론트는 화면 진입 시 한 번 현재 시각과 `liveEndAt`을 비교해 필요한 분기를 계산할 수 있다.
 - 기존 초대장 조회 API도 실시간 파티 종료 판단 기준으로 `realtimeSchedule.liveEndAt`을 내려준다.
+
+참가자용 상세 단건 조회 API는 이번 계약에 추가하지 않는다.
+
+이유:
+
+- 참가자 화면은 초대 링크로 목록에 진입한 뒤 목록 item 데이터로 상세 오버레이를 여는 흐름이다.
+- 현재 요구사항에는 참가자에게 특정 롤링페이퍼 ID로 바로 진입하는 딥링크나 푸시 알림 복구 시나리오가 없다.
+- 해당 요구가 생기면 초대 토큰 기반 참가자용 상세 API를 별도 계약으로 추가한다.
 
 ### 3-2. 주최자용 목록 조회
 
@@ -223,7 +240,7 @@ GET /api/v1/parties/{partyId}/rolling-papers?page=1
 | `items[].rollingPaperId` | 롤링페이퍼 식별자. |
 | `items[].position` | 최신순 기준 현재 롤링페이퍼 순번. 1부터 시작한다. |
 | `items[].writerNickname` | 롤링페이퍼 작성 당시 닉네임 스냅샷. |
-| `items[].content` | 롤링페이퍼 상세 오버레이에 표시할 본문. |
+| `items[].content` | 롤링페이퍼 상세 오버레이에 표시할 본문. 작성 API 기준 최대 100자. |
 | `items[].wrapperImageUrl` | 카드 렌더링용 래퍼 이미지 URL. 이미지가 없으면 `null`. |
 
 응답에서 제외하는 필드:
@@ -231,7 +248,7 @@ GET /api/v1/parties/{partyId}/rolling-papers?page=1
 | 제외 필드 | 제외 이유 |
 |---|---|
 | `partyOption` | 주최자 목록 화면의 응답 요구사항에는 필요하지 않다. 열람 가능 여부는 서버가 검증한다. |
-| `pageSize` | 한 페이지 기준은 7개로 고정이므로 응답에 반복해서 내려주지 않는다. |
+| `pageSize` | 한 페이지 기준은 `PAGE_SIZE = 7`로 고정이므로 응답에 반복해서 내려주지 않는다. |
 | `inviteToken`, `shareLink` | 공유하기 버튼 클릭 시 기존 초대 링크 API를 별도로 호출한다. |
 
 ### 3-3. 주최자용 상세 조회
@@ -251,6 +268,7 @@ GET /api/v1/parties/{partyId}/rolling-papers/{rollingPaperId}
 - 목록 화면에서 토핑을 눌러 상세 오버레이를 여는 기본 플로우에는 사용하지 않는다.
 - 특정 롤링페이퍼 ID로 바로 상세를 열어야 하는 딥링크, 푸시 알림, 새로고침 복구, 운영성 조회 같은 보조 플로우를 위해 유지한다.
 - 상세 오버레이의 좌우 이동은 이 API의 이전/다음 ID에 의존하지 않고 목록 page 캐시와 인접 page 조회로 처리한다.
+- `previousRollingPaperId`, `nextRollingPaperId`는 딥링크나 새로고침 복구처럼 목록 page 캐시가 없는 상태에서 인접 항목을 안내하기 위한 보조 메타데이터다.
 
 응답:
 
@@ -353,7 +371,7 @@ override fun hostViewableAt(): LocalDateTime =
 ## 5. 페이지네이션 규칙
 
 페이지 요청은 1부터 시작하고, `page`가 1보다 작으면 서버에서 1로 보정한다.
-한 페이지 기준 개수는 7개 고정이며, 정렬은 `createdAt DESC, id DESC`다.
+한 페이지 기준 개수는 `PAGE_SIZE = 7`로 고정이며, 정렬은 `createdAt DESC, id DESC`다.
 
 서버는 `totalPages` 계산과 상세 오버레이의 `1 / N` 표시를 위해 `totalCount`를 조회한다.
 참가자용과 주최자용 응답 모두 `totalCount`를 내려준다.
@@ -362,8 +380,13 @@ override fun hostViewableAt(): LocalDateTime =
 목록 page 응답에서는 별도 count 쿼리로 개별 위치를 계산하지 않고, 현재 page와 index로 계산한다.
 
 ```text
-position = (page - 1) * 7 + itemIndex + 1
+position = (page - 1) * PAGE_SIZE + itemIndex + 1
 ```
+
+`position`과 `totalCount`는 해당 목록 API 응답 시점의 snapshot 기준이다.
+사용자가 상세 오버레이를 보고 있는 동안 새 롤링페이퍼가 추가되면 이미 캐시된 page의 `position`과 `totalCount`가 최신 DB 상태와 달라질 수 있다.
+이번 화면은 실시간 동기화보다 page 기반 탐색과 전체 페이지 표시를 우선하므로 이 정도의 eventual consistency를 허용한다.
+프론트가 최신 개수를 반드시 다시 보여줘야 하는 시점에는 목록 page를 재조회한다.
 
 응답 invariant:
 
@@ -414,6 +437,7 @@ Party.endedAt() = Party.startedAt + Party.ENDED_AFTER_DAYS
 ## 7. 이미지 URL 정책
 
 목록 item은 `wrapperImageUrl`과 상세 오버레이에 필요한 `content`를 내려준다.
+`content`는 작성 API와 엔티티의 기존 제한에 따라 최대 100자다.
 
 이유:
 
@@ -507,10 +531,10 @@ ROLLING_PAPER_NOT_VIEWABLE(HttpStatus.FORBIDDEN, "아직 롤링페이퍼를 확�
 페이지네이션:
 
 - totalCount 0이면 `totalPages = 0`, `items = []`
-- totalCount 7이면 1페이지 7개
-- totalCount 8이면 1페이지 7개, 2페이지 1개
-- totalCount 14이면 1페이지 7개, 2페이지 7개
-- totalCount 15이면 1페이지 7개, 2페이지 7개, 3페이지 1개
+- totalCount가 `PAGE_SIZE`이면 1페이지 `PAGE_SIZE`개
+- totalCount가 `PAGE_SIZE + 1`이면 1페이지 `PAGE_SIZE`개, 2페이지 1개
+- totalCount가 `PAGE_SIZE * 2`이면 1페이지 `PAGE_SIZE`개, 2페이지 `PAGE_SIZE`개
+- totalCount가 `PAGE_SIZE * 2 + 1`이면 1페이지 `PAGE_SIZE`개, 2페이지 `PAGE_SIZE`개, 3페이지 1개
 - `page`가 1보다 작으면 1페이지로 보정
 - 존재하지 않는 페이지 요청 시 `page`는 요청값 그대로, `items = []`, `hasNext = false`
 

--- a/docs/superpowers/specs/2026-05-05-rolling-paper-list-design.md
+++ b/docs/superpowers/specs/2026-05-05-rolling-paper-list-design.md
@@ -267,8 +267,8 @@ GET /api/v1/parties/{partyId}/rolling-papers/{rollingPaperId}
 
 - 목록 화면에서 토핑을 눌러 상세 오버레이를 여는 기본 플로우에는 사용하지 않는다.
 - 특정 롤링페이퍼 ID로 바로 상세를 열어야 하는 딥링크, 푸시 알림, 새로고침 복구, 운영성 조회 같은 보조 플로우를 위해 유지한다.
-- 상세 오버레이의 좌우 이동은 이 API의 이전/다음 ID에 의존하지 않고 목록 page 캐시와 인접 page 조회로 처리한다.
-- `previousRollingPaperId`, `nextRollingPaperId`는 딥링크나 새로고침 복구처럼 목록 page 캐시가 없는 상태에서 인접 항목을 안내하기 위한 보조 메타데이터다.
+- 상세 오버레이의 좌우 이동은 목록 page 캐시와 인접 page 조회로 처리한다.
+- 상세 API는 단건 복구에 필요한 내용과 `1 / N` 표시용 위치 정보만 제공하고, 이전/다음 롤링페이퍼 ID는 제공하지 않는다.
 
 응답:
 
@@ -278,9 +278,7 @@ GET /api/v1/parties/{partyId}/rolling-papers/{rollingPaperId}
   "content": "생일 축하해요!",
   "writerNickname": "축하요정",
   "position": 1,
-  "totalCount": 12,
-  "previousRollingPaperId": null,
-  "nextRollingPaperId": 9
+  "totalCount": 12
 }
 ```
 
@@ -524,6 +522,8 @@ ROLLING_PAPER_NOT_VIEWABLE(HttpStatus.FORBIDDEN, "아직 롤링페이퍼를 확�
 
 - 특정 롤링페이퍼 ID로 상세 조회 성공
 - 상세 조회는 목록 기반 상세 오버레이의 기본 플로우가 아니라 보조 플로우임
+- `rollingPaperId`, `content`, `writerNickname`, `position`, `totalCount` 응답
+- `previousRollingPaperId`, `nextRollingPaperId`는 응답하지 않음
 - 해당 파티의 롤링페이퍼가 아니면 404
 - 소유자가 아니면 403
 - 열람 가능 전이면 403 `ROLLING_PAPER_NOT_VIEWABLE`

--- a/src/main/kotlin/com/team2/server/rollingpaper/controller/RollingPaperApi.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/controller/RollingPaperApi.kt
@@ -23,7 +23,7 @@ interface RollingPaperApi {
     @Operation(
         summary = "참가자용 롤링페이퍼 목록 조회",
         description =
-            "초대 토큰으로 롤링페이퍼 목록을 조회한다. 인증 없이도 조회 가능하다. " +
+            "초대 토큰으로 롤링페이퍼 목록과 상세 오버레이용 본문을 조회한다. 인증 없이도 조회 가능하다. " +
                 "Authorization header를 보낼 경우 유효한 Bearer token이어야 한다.",
         security = [
             SecurityRequirement(name = "Bearer Authentication"),

--- a/src/main/kotlin/com/team2/server/rollingpaper/controller/RollingPaperOwnerApi.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/controller/RollingPaperOwnerApi.kt
@@ -20,7 +20,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
 interface RollingPaperOwnerApi {
     @Operation(
         summary = "주최자용 롤링페이퍼 목록 조회",
-        description = "인증된 파티 소유자가 롤링페이퍼 목록을 조회한다.",
+        description = "인증된 파티 소유자가 롤링페이퍼 목록과 상세 오버레이용 본문을 조회한다.",
         security = [SecurityRequirement(name = "Bearer Authentication")],
     )
     @SwaggerApiResponse(
@@ -97,7 +97,7 @@ interface RollingPaperOwnerApi {
 
     @Operation(
         summary = "주최자용 롤링페이퍼 상세 조회",
-        description = "인증된 파티 소유자가 롤링페이퍼 상세 내용을 조회한다.",
+        description = "딥링크나 새로고침 복구처럼 목록 page 캐시가 없는 경우 롤링페이퍼 상세 내용을 조회한다.",
         security = [SecurityRequirement(name = "Bearer Authentication")],
     )
     @SwaggerApiResponse(

--- a/src/main/kotlin/com/team2/server/rollingpaper/dto/OwnerRollingPaperDetailResponse.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/dto/OwnerRollingPaperDetailResponse.kt
@@ -14,8 +14,4 @@ data class OwnerRollingPaperDetailResponse(
     val position: Long,
     @Schema(description = "파티의 전체 롤링페이퍼 수", example = "12")
     val totalCount: Long,
-    @Schema(description = "최신순 화면 순서상 바로 이전 롤링페이퍼 ID. 첫 번째 롤링페이퍼면 null", example = "11")
-    val previousRollingPaperId: Long?,
-    @Schema(description = "최신순 화면 순서상 바로 다음 롤링페이퍼 ID. 마지막 롤링페이퍼면 null", example = "9")
-    val nextRollingPaperId: Long?,
 )

--- a/src/main/kotlin/com/team2/server/rollingpaper/dto/RollingPaperListResponse.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/dto/RollingPaperListResponse.kt
@@ -18,6 +18,8 @@ data class ParticipantRollingPaperListResponse(
     val liveEndAt: LocalDateTime?,
     @Schema(description = "현재 페이지. page가 1보다 작으면 1로 보정합니다.", example = "1")
     val page: Int,
+    @Schema(description = "전체 롤링페이퍼 수", example = "12")
+    val totalCount: Long,
     @Schema(description = "전체 페이지 수. 롤링페이퍼가 없으면 0입니다.", example = "2")
     val totalPages: Int,
     @Schema(description = "다음 페이지 존재 여부", example = "true")
@@ -50,8 +52,12 @@ data class OwnerRollingPaperListResponse(
 data class RollingPaperListItemResponse(
     @Schema(description = "롤링페이퍼 ID", example = "10")
     val rollingPaperId: Long,
+    @Schema(description = "최신순 기준 현재 롤링페이퍼 순번. 1부터 시작합니다.", example = "1")
+    val position: Long,
     @Schema(description = "롤링페이퍼 작성자 닉네임", example = "축하요정")
     val writerNickname: String,
+    @Schema(description = "롤링페이퍼 내용. 최대 100자입니다.", example = "생일 축하해요!")
+    val content: String,
     @Schema(
         description = "롤링페이퍼 래퍼 이미지 URL. 이미지가 없으면 null",
         nullable = true,

--- a/src/main/kotlin/com/team2/server/rollingpaper/repository/RollingPaperRepository.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/repository/RollingPaperRepository.kt
@@ -48,44 +48,6 @@ interface RollingPaperRepository : JpaRepository<RollingPaper, Long> {
         @Param("rollingPaperId") rollingPaperId: Long,
     ): Long
 
-    @Query(
-        """
-            SELECT rp.id
-            FROM RollingPaper rp
-            WHERE rp.party = :party
-              AND (
-                rp.createdAt > :createdAt OR
-                (rp.createdAt = :createdAt AND rp.id > :rollingPaperId)
-              )
-            ORDER BY rp.createdAt ASC, rp.id ASC
-        """,
-    )
-    fun findPreviousIdsByParty(
-        @Param("party") party: Party,
-        @Param("createdAt") createdAt: LocalDateTime,
-        @Param("rollingPaperId") rollingPaperId: Long,
-        pageable: Pageable,
-    ): List<Long>
-
-    @Query(
-        """
-            SELECT rp.id
-            FROM RollingPaper rp
-            WHERE rp.party = :party
-              AND (
-                rp.createdAt < :createdAt OR
-                (rp.createdAt = :createdAt AND rp.id < :rollingPaperId)
-              )
-            ORDER BY rp.createdAt DESC, rp.id DESC
-        """,
-    )
-    fun findNextIdsByParty(
-        @Param("party") party: Party,
-        @Param("createdAt") createdAt: LocalDateTime,
-        @Param("rollingPaperId") rollingPaperId: Long,
-        pageable: Pageable,
-    ): List<Long>
-
     @Modifying
     @Transactional
     fun deleteAllByPartyId(partyId: Long)

--- a/src/main/kotlin/com/team2/server/rollingpaper/usecase/GetRollingPaperDetailUseCase.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/usecase/GetRollingPaperDetailUseCase.kt
@@ -7,7 +7,6 @@ import com.team2.server.party.repository.PartyRepository
 import com.team2.server.rollingpaper.dto.OwnerRollingPaperDetailResponse
 import com.team2.server.rollingpaper.entity.RollingPaper
 import com.team2.server.rollingpaper.repository.RollingPaperRepository
-import org.springframework.data.domain.PageRequest
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
@@ -35,8 +34,6 @@ class GetRollingPaperDetailUseCase(
                 ?: throw BusinessException(ErrorCode.ROLLING_PAPER_NOT_FOUND)
         val totalCount = rollingPaperRepository.countByParty(party)
         val position = calculatePosition(party, rollingPaper)
-        val previousRollingPaperId = findPreviousRollingPaperId(party, rollingPaper)
-        val nextRollingPaperId = findNextRollingPaperId(party, rollingPaper)
 
         return OwnerRollingPaperDetailResponse(
             rollingPaperId = rollingPaper.id,
@@ -44,8 +41,6 @@ class GetRollingPaperDetailUseCase(
             writerNickname = rollingPaper.writerNickname,
             position = position,
             totalCount = totalCount,
-            previousRollingPaperId = previousRollingPaperId,
-            nextRollingPaperId = nextRollingPaperId,
         )
     }
 
@@ -73,32 +68,4 @@ class GetRollingPaperDetailUseCase(
             createdAt = rollingPaper.createdAt,
             rollingPaperId = rollingPaper.id,
         ) + 1
-
-    private fun findPreviousRollingPaperId(
-        party: Party,
-        rollingPaper: RollingPaper,
-    ): Long? =
-        rollingPaperRepository
-            .findPreviousIdsByParty(
-                party = party,
-                createdAt = rollingPaper.createdAt,
-                rollingPaperId = rollingPaper.id,
-                pageable = FIRST_RESULT,
-            ).firstOrNull()
-
-    private fun findNextRollingPaperId(
-        party: Party,
-        rollingPaper: RollingPaper,
-    ): Long? =
-        rollingPaperRepository
-            .findNextIdsByParty(
-                party = party,
-                createdAt = rollingPaper.createdAt,
-                rollingPaperId = rollingPaper.id,
-                pageable = FIRST_RESULT,
-            ).firstOrNull()
-
-    companion object {
-        private val FIRST_RESULT = PageRequest.of(0, 1)
-    }
 }

--- a/src/main/kotlin/com/team2/server/rollingpaper/usecase/GetRollingPaperListUseCase.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/usecase/GetRollingPaperListUseCase.kt
@@ -45,6 +45,7 @@ class GetRollingPaperListUseCase(
                     null
                 },
             page = pageResult.page,
+            totalCount = pageResult.totalCount,
             totalPages = pageResult.totalPages,
             hasNext = pageResult.hasNext,
             items = pageResult.items,
@@ -113,15 +114,22 @@ class GetRollingPaperListUseCase(
             totalPages = rollingPaperPage.totalPages,
             hasNext = rollingPaperPage.hasNext(),
             items =
-                rollingPapers.map { rollingPaper ->
+                rollingPapers.mapIndexed { index, rollingPaper ->
                     RollingPaperListItemResponse(
                         rollingPaperId = rollingPaper.id,
+                        position = calculatePosition(page, index),
                         writerNickname = rollingPaper.writerNickname,
+                        content = rollingPaper.content,
                         wrapperImageUrl = imageUrlByWrapperId[rollingPaper.wrapper.id],
                     )
                 },
         )
     }
+
+    private fun calculatePosition(
+        page: Int,
+        index: Int,
+    ): Long = ((page - 1) * PAGE_SIZE + index + 1).toLong()
 
     private fun findImageUrlByWrapperId(rollingPapers: List<RollingPaper>): Map<Long, String> =
         imageQueryService.findFirstImageUrlByTargetIds(

--- a/src/test/kotlin/com/team2/server/rollingpaper/controller/RollingPaperListControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/rollingpaper/controller/RollingPaperListControllerTest.kt
@@ -2,6 +2,7 @@ package com.team2.server.rollingpaper.controller
 
 import com.team2.server.auth.config.JwtProperties
 import com.team2.server.auth.jwt.JwtTokenProvider
+import com.team2.server.common.DatabaseCleanup
 import com.team2.server.common.entity.Image
 import com.team2.server.common.entity.ImageTargetType
 import com.team2.server.common.repository.ImageRepository
@@ -45,8 +46,10 @@ class RollingPaperListControllerTest
         private val partyRepository: PartyRepository,
         private val userRepository: UserRepository,
         private val jwtProperties: JwtProperties,
+        private val databaseCleanup: DatabaseCleanup,
     ) {
         private val tokenProvider = JwtTokenProvider(jwtProperties)
+        private var defaultOwnerSequence = 0
 
         @BeforeEach
         fun setUp() {
@@ -69,6 +72,7 @@ class RollingPaperListControllerTest
                     wrapper = wrapper,
                     writerNickname = "작성자$index",
                     createdAt = DEFAULT_NOW.plusMinutes(index.toLong()),
+                    content = "축하해요$index",
                 )
             }
 
@@ -80,13 +84,17 @@ class RollingPaperListControllerTest
                     jsonPath("$.data.partyOption") { value("REALTIME") }
                     jsonPath("$.data.liveEndAt") { value("2026-05-06T22:10:00") }
                     jsonPath("$.data.page") { value(1) }
+                    jsonPath("$.data.totalCount") { value(8) }
                     jsonPath("$.data.totalPages") { value(2) }
                     jsonPath("$.data.hasNext") { value(true) }
-                    jsonPath("$.data.totalCount") { doesNotExist() }
                     jsonPath("$.data.items.length()") { value(7) }
+                    jsonPath("$.data.items[0].position") { value(1) }
                     jsonPath("$.data.items[0].writerNickname") { value("작성자8") }
+                    jsonPath("$.data.items[0].content") { value("축하해요8") }
                     jsonPath("$.data.items[0].wrapperImageUrl") { value("/images/rolling-paper-wrappers/first.svg") }
+                    jsonPath("$.data.items[6].position") { value(7) }
                     jsonPath("$.data.items[6].writerNickname") { value("작성자2") }
+                    jsonPath("$.data.items[6].content") { value("축하해요2") }
                 }
 
             mockMvc
@@ -95,9 +103,12 @@ class RollingPaperListControllerTest
                 }.andExpect {
                     status { isOk() }
                     jsonPath("$.data.page") { value(2) }
+                    jsonPath("$.data.totalCount") { value(8) }
                     jsonPath("$.data.hasNext") { value(false) }
                     jsonPath("$.data.items.length()") { value(1) }
+                    jsonPath("$.data.items[0].position") { value(8) }
                     jsonPath("$.data.items[0].writerNickname") { value("작성자1") }
+                    jsonPath("$.data.items[0].content") { value("축하해요1") }
                 }
         }
 
@@ -132,7 +143,7 @@ class RollingPaperListControllerTest
                     jsonPath("$.data.totalPages") { value(0) }
                     jsonPath("$.data.hasNext") { value(false) }
                     jsonPath("$.data.items.length()") { value(0) }
-                    jsonPath("$.data.totalCount") { doesNotExist() }
+                    jsonPath("$.data.totalCount") { value(0) }
                 }
         }
 
@@ -196,7 +207,9 @@ class RollingPaperListControllerTest
                     jsonPath("$.data.totalCount") { value(1) }
                     jsonPath("$.data.totalPages") { value(1) }
                     jsonPath("$.data.hasNext") { value(false) }
+                    jsonPath("$.data.items[0].position") { value(1) }
                     jsonPath("$.data.items[0].writerNickname") { value("축하요정") }
+                    jsonPath("$.data.items[0].content") { value("축하해요") }
                 }
         }
 
@@ -423,14 +436,15 @@ class RollingPaperListControllerTest
         }
 
         private fun savePaperOnlyParty(
-            ownerId: Long = 1L,
+            ownerId: Long? = null,
             createdAt: LocalDateTime = DEFAULT_NOW.minusDays(1),
             startedAt: LocalDateTime = DEFAULT_NOW.toLocalDate().atStartOfDay(),
         ): Party {
+            val actualOwnerId = ownerId ?: saveDefaultOwner().id
             val saved =
                 partyRepository.saveAndFlush(
                     PaperOnlyParty(
-                        ownerId = ownerId,
+                        ownerId = actualOwnerId,
                         celebrantNickname = "홍길동",
                         startedAt = startedAt,
                     ),
@@ -440,14 +454,15 @@ class RollingPaperListControllerTest
         }
 
         private fun saveRealtimeParty(
-            ownerId: Long = 1L,
+            ownerId: Long? = null,
             createdAt: LocalDateTime = DEFAULT_NOW.minusDays(1),
             startedAt: LocalDateTime = DEFAULT_NOW.withHour(20).withMinute(0),
         ): Party {
+            val actualOwnerId = ownerId ?: saveDefaultOwner().id
             val saved =
                 partyRepository.saveAndFlush(
                     RealtimeParty(
-                        ownerId = ownerId,
+                        ownerId = actualOwnerId,
                         celebrantNickname = "홍길동",
                         startedAt = startedAt,
                     ),
@@ -526,14 +541,13 @@ class RollingPaperListControllerTest
                 ),
             )
 
+        private fun saveDefaultOwner(): User {
+            defaultOwnerSequence += 1
+            return saveUser("default-owner-$defaultOwnerSequence")
+        }
+
         private fun clearDatabase() {
-            rollingPaperRepository.deleteAll()
-            imageRepository.deleteAll()
-            rollingPaperWrapperRepository.deleteAll()
-            partyInviteRepository.deleteAll()
-            participantRepository.deleteAll()
-            partyRepository.deleteAll()
-            userRepository.deleteAll()
+            databaseCleanup.execute()
         }
 
         companion object {

--- a/src/test/kotlin/com/team2/server/rollingpaper/controller/RollingPaperListControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/rollingpaper/controller/RollingPaperListControllerTest.kt
@@ -278,12 +278,10 @@ class RollingPaperListControllerTest
                     startedAt = ALWAYS_VIEWABLE_STARTED_AT,
                 )
             val wrapper = saveWrapperWithImages()
-            val first =
-                saveRollingPaper(party, wrapper, "첫번째", DEFAULT_NOW.plusMinutes(1), content = "첫 번째 축하")
+            saveRollingPaper(party, wrapper, "첫번째", DEFAULT_NOW.plusMinutes(1), content = "첫 번째 축하")
             val target =
                 saveRollingPaper(party, wrapper, "두번째", DEFAULT_NOW.plusMinutes(2), content = "두 번째 축하")
-            val latest =
-                saveRollingPaper(party, wrapper, "세번째", DEFAULT_NOW.plusMinutes(3), content = "세 번째 축하")
+            saveRollingPaper(party, wrapper, "세번째", DEFAULT_NOW.plusMinutes(3), content = "세 번째 축하")
 
             mockMvc
                 .get("/api/v1/parties/${party.id}/rolling-papers/${target.id}") {
@@ -295,8 +293,6 @@ class RollingPaperListControllerTest
                     jsonPath("$.data.writerNickname") { value("두번째") }
                     jsonPath("$.data.position") { value(2) }
                     jsonPath("$.data.totalCount") { value(3) }
-                    jsonPath("$.data.previousRollingPaperId") { value(latest.id) }
-                    jsonPath("$.data.nextRollingPaperId") { value(first.id) }
                 }
         }
 
@@ -319,8 +315,6 @@ class RollingPaperListControllerTest
                     status { isOk() }
                     jsonPath("$.data.position") { value(2) }
                     jsonPath("$.data.totalCount") { value(2) }
-                    jsonPath("$.data.previousRollingPaperId") { value(latest.id) }
-                    jsonPath("$.data.nextRollingPaperId") { value(nullValue()) }
                 }
 
             mockMvc
@@ -330,8 +324,6 @@ class RollingPaperListControllerTest
                     status { isOk() }
                     jsonPath("$.data.position") { value(1) }
                     jsonPath("$.data.totalCount") { value(2) }
-                    jsonPath("$.data.previousRollingPaperId") { value(nullValue()) }
-                    jsonPath("$.data.nextRollingPaperId") { value(old.id) }
                 }
         }
 


### PR DESCRIPTION
## 🔗 Issue
- closes #134

## 💬 Context
롤링페이퍼 목록 화면에서 상세 오버레이를 목록 응답 중심으로 처리하도록 계약을 정리했습니다.

## 🛠 Changes
- 목록 기반 상세 오버레이 처리에 필요한 응답 계약 반영
- 상세 단건 조회 API 역할을 보조 조회 용도로 정리
- 관련 설계 문서와 테스트 갱신

## 👀 Review Focus
- 목록/상세 API 역할 분리가 화면 흐름에 맞는지
- 기존 상세 단건 조회 API를 보조 API로 유지하는 방향이 적절한지

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 롤링페이퍼 목록 응답에 각 항목의 전체 순번(`position`)과 본문 내용(`content`) 추가
  * 목록 응답에 전체 개수(`totalCount`) 포함으로 페이지네이션 정보 강화

* **문서**
  * 롤링페이퍼 목록 조회 API 계약 및 명세 업데이트
  * API 동작 방식 및 응답 필드 명확화

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/18th-team2-server/pull/135)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->