### PR TITLE
[Docs] Git 규칙 문서 분리

### DIFF
--- a/.claude/rules/git.md
+++ b/.claude/rules/git.md
@@ -1,0 +1,34 @@
+# Git 규칙
+
+## 커밋 컨벤션
+
+- 포맷: `<type>: <한국어 설명>`
+- type: feat, fix, chore, docs, test, refactor, perf, ci
+- scope 사용하지 않음
+- 한국어 명사형 종결 ("~추가", "~수정", "~구현")
+- 50자 이내, 마침표 없음
+
+## 브랜치 컨벤션
+
+- `feature/<영문-kebab-case>` — 새 기능
+- `fix/<영문-kebab-case>` — 버그 수정
+- `chore/<영문-kebab-case>` — 설정, 유지보수
+- `refactor/<영문-kebab-case>` — 리팩토링
+- `docs/<영문-kebab-case>` — 문서
+- `test/<영문-kebab-case>` — 테스트
+
+## PR 규칙
+
+- 기능 단위로 PR 생성 (하나의 PR = 하나의 기능)
+- base 브랜치: `develop`
+- PR 템플릿(`.github/PULL_REQUEST_TEMPLATE.md`) 필수 준수
+- 빌드 + 테스트 통과 후 PR 생성
+
+## 금지 사항
+
+- `--no-verify` 사용 금지
+- `main` 브랜치 직접 커밋/푸시 금지 (마스터 브랜치, 보호 대상)
+- `develop` 브랜치 직접 커밋 금지
+- `git add -A` / `git add .` 사용 금지 (파일 개별 지정)
+- 시크릿 파일 커밋 금지 (`.env`, `application-*.yml`, `*.pem`, `*.key` 등)
+- 영문 커밋 메시지 금지

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,38 +6,9 @@
 - Gradle (Kotlin DSL)
 - JPA / Hibernate
 
-## 커밋 컨벤션
+## 규칙
 
-- 포맷: `<type>: <한국어 설명>`
-- type: feat, fix, chore, docs, test, refactor, perf, ci
-- scope 사용하지 않음
-- 한국어 명사형 종결 ("~추가", "~수정", "~구현")
-- 50자 이내, 마침표 없음
-
-## 브랜치 컨벤션
-
-- `feature/<영문-kebab-case>` — 새 기능
-- `fix/<영문-kebab-case>` — 버그 수정
-- `chore/<영문-kebab-case>` — 설정, 유지보수
-- `refactor/<영문-kebab-case>` — 리팩토링
-- `docs/<영문-kebab-case>` — 문서
-- `test/<영문-kebab-case>` — 테스트
-
-## PR 규칙
-
-- 기능 단위로 PR 생성 (하나의 PR = 하나의 기능)
-- base 브랜치: `develop`
-- PR 템플릿(`.github/PULL_REQUEST_TEMPLATE.md`) 필수 준수
-- 빌드 + 테스트 통과 후 PR 생성
-
-## 금지 사항
-
-- `--no-verify` 사용 금지
-- `main` 브랜치 직접 커밋/푸시 금지 (마스터 브랜치, 보호 대상)
-- `develop` 브랜치 직접 커밋 금지
-- `git add -A` / `git add .` 사용 금지 (파일 개별 지정)
-- 시크릿 파일 커밋 금지 (`.env`, `application-*.yml`, `*.pem`, `*.key` 등)
-- 영문 커밋 메시지 금지
+- [Git 규칙](.claude/rules/git.md) — 커밋/브랜치/PR 컨벤션, 금지 사항
 
 ## 팀 스킬
 


### PR DESCRIPTION
## 🔗 Issue
- closes #137

## 💬 Context
CLAUDE.md에 커밋/브랜치/PR 컨벤션과 금지 사항이 직접 나열되어 있어 파일이 길어지고 다른 규칙 추가 시 가독성이 떨어진다. 규칙 문서를 별도 파일로 분리하여 CLAUDE.md는 진입점(인덱스) 역할만 하도록 정리한다.

## 🛠 Changes
- `.claude/rules/git.md` 추가 — 커밋 컨벤션, 브랜치 컨벤션, PR 규칙, 금지 사항
- `CLAUDE.md`의 git 관련 4개 섹션을 제거하고 `## 규칙` 섹션에 링크로 대체

## 👀 Review Focus
- 분리된 `.claude/rules/git.md`의 내용이 기존 CLAUDE.md 내용과 누락 없이 동일한지
- CLAUDE.md의 링크 경로(`.claude/rules/git.md`)가 의도한 위치를 가리키는지

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서화**
  * Git 커밋/브랜치/PR 규칙을 별도 문서로 정리하여 개발 규칙을 일원화했습니다.
  * 기존 상단 가이드에서 세부 규칙을 제거하고 새 규칙 문서로 참조를 전환했습니다.

**참고:** 개발 워크플로우 문서 정비로 사용자 환경에는 직접적인 영향이 없습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/18th-team2-server/pull/138)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->