### PR TITLE
[Refactor] @SpringBootTest 컨테이너 ServiceConnection 전환

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,13 @@
 - PR 템플릿(`.github/PULL_REQUEST_TEMPLATE.md`) 필수 준수
 - 빌드 + 테스트 통과 후 PR 생성
 
+## 테스트
+
+- 테스트 작성·실행 규칙은 [docs/testing-rules.md](docs/testing-rules.md) 참고
+- `@SpringBootTest` / `@DataJpaTest`는 반드시 `TestcontainersConfiguration` 경유 (`@Import` 또는 base class 상속)
+- 단일 테스트: `./gradlew test --tests "<FQCN>"`
+- 컨테이너 누수 검증: `docker ps -a --filter "label=org.testcontainers"` → 0개
+
 ## 금지 사항
 
 - `--no-verify` 사용 금지

--- a/docs/testing-rules.md
+++ b/docs/testing-rules.md
@@ -1,0 +1,114 @@
+# 테스트 규칙
+
+> Spring Boot 통합/슬라이스 테스트와 Testcontainers 운용 규칙. 신규 테스트 작성 시 이 문서를 따른다.
+
+## 목차
+
+- [컨테이너 설정 (Testcontainers)](#컨테이너-설정-testcontainers)
+- [통합 테스트 작성](#통합-테스트-작성)
+- [JPA 슬라이스 테스트 작성](#jpa-슬라이스-테스트-작성)
+- [Flyway 마이그레이션 테스트](#flyway-마이그레이션-테스트)
+- [컨텍스트 캐싱 보호](#컨텍스트-캐싱-보호)
+- [검증 명령어](#검증-명령어)
+- [선택 최적화 (개인 설정)](#선택-최적화-개인-설정)
+
+---
+
+## 컨테이너 설정 (Testcontainers)
+
+- **IMPORTANT**: `jdbc:tc:` JDBC URL 드라이버 방식 **사용 금지**. JVM shutdown hook으로만 컨테이너가 정리되어 Gradle daemon / IDE JVM 재사용 시 누수가 발생한다.
+- **ALWAYS** `@ServiceConnection` 기반 `TestcontainersConfiguration` (`src/test/.../config/TestcontainersConfiguration.kt`)을 통해 MySQL 컨테이너를 사용한다. Ryuk reaper가 lifecycle을 보장한다.
+- 테스트 프로파일 `src/test/resources/application.yml`에서 `spring.flyway.enabled: false`를 유지한다. schema는 Hibernate `ddl-auto: create-drop`이 담당하고, Flyway 마이그레이션 검증은 `FlywayMigrationTest`만 직접 호출한다.
+
+## 통합 테스트 작성
+
+`@SpringBootTest`가 필요한 테스트는 다음 두 패턴 중 하나만 사용한다.
+
+| 케이스 | 패턴 |
+|---|---|
+| 추가 어노테이션 (`@AutoConfigureMockMvc` 등) 필요 없음 | `IntegrationTestSupport` 상속 |
+| MockMvc 등 어노테이션 조합 필요 | `@SpringBootTest + @AutoConfigureMockMvc + @Import(TestcontainersConfiguration::class)` 직접 부여 |
+
+```kotlin
+// 패턴 1: base 상속 (단순 컨텍스트 로딩)
+class ServerApplicationTests : IntegrationTestSupport()
+
+// 패턴 2: @Import 직접 부여 (MockMvc 컨트롤러 테스트)
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import(TestcontainersConfiguration::class)
+class PartyControllerTest @Autowired constructor(
+    private val mockMvc: MockMvc,
+    // ...
+)
+```
+
+## JPA 슬라이스 테스트 작성
+
+`@DataJpaTest`가 필요한 Repository 테스트는 `JpaSliceTestSupport` 상속.
+
+```kotlin
+class UserRepositoryTest @Autowired constructor(
+    private val userRepository: UserRepository,
+) : JpaSliceTestSupport()
+```
+
+## Flyway 마이그레이션 테스트
+
+`FlywayMigrationTest`처럼 Flyway를 직접 검증하는 raw JDBC 테스트는 자체 `MySQLContainer`를 띄우되 **반드시 unique label**을 부여한다.
+
+```kotlin
+private companion object {
+    @JvmStatic
+    private val MYSQL: MySQLContainer<*> =
+        MySQLContainer(DockerImageName.parse("mysql:8.0"))
+            .withLabel("purpose", "flyway-migration-test")  // IMPORTANT: reuse 격리
+            .withReuse(true)
+            .also { it.start() }
+}
+```
+
+**WHY**: `TestcontainersConfiguration`과 동일한 이미지·옵션이면 reuse hash가 매칭되어 같은 컨테이너를 공유한다. Flyway가 만든 FK (`fk_party_owner` 등) 가 통합 테스트로 누출되면 `ddl-auto: create-drop`이 FK를 모르고 drop하지 못해 데이터 무결성 충돌이 발생한다.
+
+## 컨텍스트 캐싱 보호
+
+Spring TestContext 캐시는 어노테이션 조합 (fingerprint) 이 정확히 일치할 때만 컨텍스트를 재사용한다. 다음 패턴은 컨텍스트를 분리시키므로 **불가피한 경우가 아니면 사용 금지**.
+
+- `@MockBean`, `@SpyBean`, `@MockitoBean` — 빈 교체 시 컨텍스트 분리
+- `@TestPropertySource`, `@ActiveProfiles` — 프로파일·프로퍼티 분리
+- `@SpringBootTest(properties = [...], classes = [...])` — 옵션 차이 분리
+
+현재 캐싱되는 컨텍스트는 3개다. 새 통합 테스트는 이 fingerprint 중 하나에 정확히 맞춰야 한다.
+
+| Fingerprint | 적용 테스트 |
+|---|---|
+| `@SpringBootTest + @Import(TC)` | `IntegrationTestSupport` 상속 |
+| `@SpringBootTest + @AutoConfigureMockMvc + @Import(TC)` | MockMvc 컨트롤러 테스트들 |
+| `@DataJpaTest + @Import(TC)` | `JpaSliceTestSupport` 상속 |
+
+## 검증 명령어
+
+```bash
+# 전체 테스트
+./gradlew test
+
+# 단일 테스트 클래스
+./gradlew test --tests "com.team2.server.party.controller.PartyControllerTest"
+
+# 단일 테스트 메서드 (한글 백틱 이름)
+./gradlew test --tests "com.team2.server.party.controller.PartyControllerTest.인증 없이*"
+
+# 컨테이너 누수 확인 — 테스트 종료 후 잔존 컨테이너 0개여야 정상
+docker ps -a --filter "label=org.testcontainers"
+```
+
+## 선택 최적화 (개인 설정)
+
+본인 머신에서만 적용되는 옵션. 팀 공통 설정 아님.
+
+```properties
+# ~/.testcontainers.properties
+testcontainers.reuse.enable=true
+```
+
+활성화 시 2차 실행부터 컨테이너 재사용으로 ~25% 단축 (1m 24s → 1m 3s, 213 tests 기준).

--- a/src/test/kotlin/com/team2/server/ServerApplicationTests.kt
+++ b/src/test/kotlin/com/team2/server/ServerApplicationTests.kt
@@ -1,10 +1,9 @@
 package com.team2.server
 
+import com.team2.server.support.IntegrationTestSupport
 import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
 
-@SpringBootTest
-class ServerApplicationTests {
+class ServerApplicationTests : IntegrationTestSupport() {
     @Test
     @Suppress("EmptyFunctionBlock")
     fun contextLoads() {

--- a/src/test/kotlin/com/team2/server/auth/SecurityIntegrationTest.kt
+++ b/src/test/kotlin/com/team2/server/auth/SecurityIntegrationTest.kt
@@ -3,6 +3,7 @@ package com.team2.server.auth
 import com.team2.server.auth.config.JwtProperties
 import com.team2.server.auth.jwt.JwtTokenProvider
 import com.team2.server.common.DatabaseCleanup
+import com.team2.server.config.TestcontainersConfiguration
 import com.team2.server.user.entity.AuthProvider
 import com.team2.server.user.entity.User
 import com.team2.server.user.repository.UserRepository
@@ -11,11 +12,13 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.context.annotation.Import
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@Import(TestcontainersConfiguration::class)
 class SecurityIntegrationTest
     @Autowired
     constructor(

--- a/src/test/kotlin/com/team2/server/chat/controller/ChatControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/chat/controller/ChatControllerTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.team2.server.auth.config.JwtProperties
 import com.team2.server.auth.jwt.JwtTokenProvider
 import com.team2.server.chat.repository.ChatMessageRepository
+import com.team2.server.config.TestcontainersConfiguration
 import com.team2.server.party.entity.Character
 import com.team2.server.party.entity.PartyInvite
 import com.team2.server.party.entity.RealtimeParty
@@ -21,6 +22,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.MvcResult
@@ -30,6 +32,7 @@ import java.util.UUID
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@Import(TestcontainersConfiguration::class)
 class ChatControllerTest
     @Autowired
     constructor(

--- a/src/test/kotlin/com/team2/server/common/config/SwaggerConfigTest.kt
+++ b/src/test/kotlin/com/team2/server/common/config/SwaggerConfigTest.kt
@@ -1,10 +1,12 @@
 package com.team2.server.common.config
 
 import com.jayway.jsonpath.JsonPath
+import com.team2.server.config.TestcontainersConfiguration
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.context.annotation.Import
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import kotlin.test.assertEquals
@@ -12,6 +14,7 @@ import kotlin.test.assertTrue
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@Import(TestcontainersConfiguration::class)
 class SwaggerConfigTest
     @Autowired
     constructor(

--- a/src/test/kotlin/com/team2/server/config/TestcontainersConfiguration.kt
+++ b/src/test/kotlin/com/team2/server/config/TestcontainersConfiguration.kt
@@ -1,0 +1,20 @@
+package com.team2.server.config
+
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection
+import org.springframework.context.annotation.Bean
+import org.testcontainers.containers.MySQLContainer
+import org.testcontainers.utility.DockerImageName
+
+@TestConfiguration(proxyBeanMethods = false)
+class TestcontainersConfiguration {
+    @Bean
+    @ServiceConnection
+    fun mysqlContainer(): MySQLContainer<*> =
+        MySQLContainer(DockerImageName.parse(MYSQL_IMAGE))
+            .withReuse(true)
+
+    private companion object {
+        private const val MYSQL_IMAGE = "mysql:8.0"
+    }
+}

--- a/src/test/kotlin/com/team2/server/db/FlywayMigrationTest.kt
+++ b/src/test/kotlin/com/team2/server/db/FlywayMigrationTest.kt
@@ -42,6 +42,7 @@ class FlywayMigrationTest {
         @JvmStatic
         private val MYSQL: MySQLContainer<*> =
             MySQLContainer(DockerImageName.parse("mysql:8.0"))
+                .withLabel("purpose", "flyway-migration-test")
                 .withReuse(true)
                 .also { it.start() }
     }

--- a/src/test/kotlin/com/team2/server/db/FlywayMigrationTest.kt
+++ b/src/test/kotlin/com/team2/server/db/FlywayMigrationTest.kt
@@ -2,18 +2,22 @@ package com.team2.server.db
 
 import org.flywaydb.core.Flyway
 import org.junit.jupiter.api.Test
+import org.testcontainers.containers.MySQLContainer
+import org.testcontainers.utility.DockerImageName
 import java.sql.DriverManager
 import kotlin.test.assertEquals
 
 class FlywayMigrationTest {
     @Test
     fun `Flyway migration creates schema and seeds default assets`() {
-        DriverManager.getConnection(DATABASE_URL, USERNAME, PASSWORD).use { connection ->
+        DriverManager.getConnection(MYSQL.jdbcUrl, MYSQL.username, MYSQL.password).use { connection ->
             Flyway
                 .configure()
-                .dataSource(DATABASE_URL, USERNAME, PASSWORD)
+                .dataSource(MYSQL.jdbcUrl, MYSQL.username, MYSQL.password)
                 .locations("classpath:db/migration")
+                .cleanDisabled(false)
                 .load()
+                .also { it.clean() }
                 .migrate()
 
             assertEquals(5, connection.countRows("avatar"))
@@ -34,8 +38,11 @@ class FlywayMigrationTest {
 
     private companion object {
         private val COUNTABLE_TABLES = setOf("avatar", "rolling_paper_wrapper", "image")
-        private const val DATABASE_URL = "jdbc:tc:mysql:8.0:///flyway_migration_test"
-        private const val USERNAME = "test"
-        private const val PASSWORD = "test"
+
+        @JvmStatic
+        private val MYSQL: MySQLContainer<*> =
+            MySQLContainer(DockerImageName.parse("mysql:8.0"))
+                .withReuse(true)
+                .also { it.start() }
     }
 }

--- a/src/test/kotlin/com/team2/server/party/controller/CharacterControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/party/controller/CharacterControllerTest.kt
@@ -4,6 +4,7 @@ import com.team2.server.common.DatabaseCleanup
 import com.team2.server.common.entity.Image
 import com.team2.server.common.entity.ImageTargetType
 import com.team2.server.common.repository.ImageRepository
+import com.team2.server.config.TestcontainersConfiguration
 import com.team2.server.party.entity.Character
 import com.team2.server.party.repository.CharacterRepository
 import org.junit.jupiter.api.BeforeEach
@@ -11,11 +12,13 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.context.annotation.Import
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@Import(TestcontainersConfiguration::class)
 class CharacterControllerTest
     @Autowired
     constructor(

--- a/src/test/kotlin/com/team2/server/party/controller/MePartyControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/party/controller/MePartyControllerTest.kt
@@ -2,6 +2,7 @@ package com.team2.server.party.controller
 
 import com.team2.server.auth.config.JwtProperties
 import com.team2.server.auth.jwt.JwtTokenProvider
+import com.team2.server.config.TestcontainersConfiguration
 import com.team2.server.party.entity.PaperOnlyParty
 import com.team2.server.party.entity.Participant
 import com.team2.server.party.entity.Party
@@ -19,6 +20,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.context.annotation.Import
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.MockMvcResultMatchersDsl
 import org.springframework.test.web.servlet.get
@@ -28,6 +30,7 @@ import java.time.temporal.ChronoUnit
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@Import(TestcontainersConfiguration::class)
 class MePartyControllerTest
     @Autowired
     constructor(

--- a/src/test/kotlin/com/team2/server/party/controller/PartyControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/party/controller/PartyControllerTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.team2.server.auth.config.JwtProperties
 import com.team2.server.auth.jwt.JwtTokenProvider
 import com.team2.server.common.DatabaseCleanup
+import com.team2.server.config.TestcontainersConfiguration
 import com.team2.server.party.entity.Character
 import com.team2.server.party.repository.CharacterRepository
 import com.team2.server.party.repository.ParticipantRepository
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.delete
@@ -24,6 +26,7 @@ import kotlin.test.assertEquals
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@Import(TestcontainersConfiguration::class)
 class PartyControllerTest
     @Autowired
     constructor(

--- a/src/test/kotlin/com/team2/server/party/controller/PartyInviteLookupControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/party/controller/PartyInviteLookupControllerTest.kt
@@ -3,6 +3,7 @@ package com.team2.server.party.controller
 import com.team2.server.auth.config.JwtProperties
 import com.team2.server.auth.jwt.JwtTokenProvider
 import com.team2.server.common.DatabaseCleanup
+import com.team2.server.config.TestcontainersConfiguration
 import com.team2.server.party.entity.PaperOnlyParty
 import com.team2.server.party.entity.Participant
 import com.team2.server.party.entity.Party
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.context.annotation.Import
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
@@ -31,6 +33,7 @@ import kotlin.test.assertNotNull
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@Import(TestcontainersConfiguration::class)
 class PartyInviteLookupControllerTest
     @Autowired
     constructor(

--- a/src/test/kotlin/com/team2/server/party/repository/ParticipantRepositoryTest.kt
+++ b/src/test/kotlin/com/team2/server/party/repository/ParticipantRepositoryTest.kt
@@ -7,6 +7,7 @@ import com.team2.server.party.entity.RealtimeParticipantProfile
 import com.team2.server.party.entity.RealtimeParty
 import com.team2.server.rollingpaper.entity.RollingPaper
 import com.team2.server.rollingpaper.entity.RollingPaperWrapper
+import com.team2.server.support.JpaSliceTestSupport
 import com.team2.server.user.entity.AuthProvider
 import com.team2.server.user.entity.User
 import com.team2.server.user.repository.UserRepository
@@ -14,14 +15,12 @@ import jakarta.persistence.EntityManager
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest
 import java.time.LocalDateTime
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-@DataJpaTest
 class ParticipantRepositoryTest
     @Autowired
     constructor(
@@ -30,7 +29,7 @@ class ParticipantRepositoryTest
         private val realtimeParticipantProfileRepository: RealtimeParticipantProfileRepository,
         private val userRepository: UserRepository,
         private val entityManager: EntityManager,
-    ) {
+    ) : JpaSliceTestSupport() {
         private lateinit var party: Party
         private lateinit var user: User
 

--- a/src/test/kotlin/com/team2/server/rollingpaper/controller/RollingPaperControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/rollingpaper/controller/RollingPaperControllerTest.kt
@@ -2,6 +2,7 @@ package com.team2.server.rollingpaper.controller
 
 import com.team2.server.auth.config.JwtProperties
 import com.team2.server.auth.jwt.JwtTokenProvider
+import com.team2.server.config.TestcontainersConfiguration
 import com.team2.server.party.entity.PaperOnlyParty
 import com.team2.server.party.entity.Participant
 import com.team2.server.party.entity.Party
@@ -21,6 +22,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.context.annotation.Import
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
@@ -33,6 +35,7 @@ import kotlin.test.assertTrue
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@Import(TestcontainersConfiguration::class)
 class RollingPaperControllerTest
     @Autowired
     constructor(

--- a/src/test/kotlin/com/team2/server/rollingpaper/controller/RollingPaperListControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/rollingpaper/controller/RollingPaperListControllerTest.kt
@@ -6,6 +6,7 @@ import com.team2.server.common.DatabaseCleanup
 import com.team2.server.common.entity.Image
 import com.team2.server.common.entity.ImageTargetType
 import com.team2.server.common.repository.ImageRepository
+import com.team2.server.config.TestcontainersConfiguration
 import com.team2.server.party.entity.PaperOnlyParty
 import com.team2.server.party.entity.Participant
 import com.team2.server.party.entity.Party
@@ -28,12 +29,14 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.context.annotation.Import
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import java.time.LocalDateTime
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@Import(TestcontainersConfiguration::class)
 class RollingPaperListControllerTest
     @Autowired
     constructor(

--- a/src/test/kotlin/com/team2/server/rollingpaper/controller/RollingPaperWrapperControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/rollingpaper/controller/RollingPaperWrapperControllerTest.kt
@@ -4,6 +4,7 @@ import com.team2.server.common.DatabaseCleanup
 import com.team2.server.common.entity.Image
 import com.team2.server.common.entity.ImageTargetType
 import com.team2.server.common.repository.ImageRepository
+import com.team2.server.config.TestcontainersConfiguration
 import com.team2.server.rollingpaper.entity.RollingPaperWrapper
 import com.team2.server.rollingpaper.repository.RollingPaperWrapperRepository
 import org.junit.jupiter.api.BeforeEach
@@ -11,11 +12,13 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.context.annotation.Import
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@Import(TestcontainersConfiguration::class)
 class RollingPaperWrapperControllerTest
     @Autowired
     constructor(

--- a/src/test/kotlin/com/team2/server/support/IntegrationTestSupport.kt
+++ b/src/test/kotlin/com/team2/server/support/IntegrationTestSupport.kt
@@ -1,0 +1,9 @@
+package com.team2.server.support
+
+import com.team2.server.config.TestcontainersConfiguration
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+
+@SpringBootTest
+@Import(TestcontainersConfiguration::class)
+abstract class IntegrationTestSupport

--- a/src/test/kotlin/com/team2/server/support/JpaSliceTestSupport.kt
+++ b/src/test/kotlin/com/team2/server/support/JpaSliceTestSupport.kt
@@ -1,0 +1,9 @@
+package com.team2.server.support
+
+import com.team2.server.config.TestcontainersConfiguration
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest
+import org.springframework.context.annotation.Import
+
+@DataJpaTest
+@Import(TestcontainersConfiguration::class)
+abstract class JpaSliceTestSupport

--- a/src/test/kotlin/com/team2/server/user/UserRepositoryTest.kt
+++ b/src/test/kotlin/com/team2/server/user/UserRepositoryTest.kt
@@ -1,23 +1,22 @@
 package com.team2.server.user
 
+import com.team2.server.support.JpaSliceTestSupport
 import com.team2.server.user.entity.AuthProvider
 import com.team2.server.user.entity.User
 import com.team2.server.user.repository.UserRepository
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest
 import org.springframework.dao.DataIntegrityViolationException
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
-@DataJpaTest
 class UserRepositoryTest
     @Autowired
     constructor(
         private val userRepository: UserRepository,
-    ) {
+    ) : JpaSliceTestSupport() {
         private fun newUser(
             providerId: String,
             email: String = "$providerId@kakao.local",

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -3,9 +3,8 @@ spring:
     name: team2-backend-test
   profiles:
     active: test
-  datasource:
-    url: jdbc:tc:mysql:8.0:///testdb
-    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+  flyway:
+    enabled: false
   jpa:
     hibernate:
       ddl-auto: create-drop


### PR DESCRIPTION
## 🔗 Issue
- closes #121

## 💬 Context

`@SpringBootTest` 기반 통합 테스트가 `jdbc:tc:mysql:8.0:///testdb` JDBC URL 드라이버 방식을 사용하여 두 가지 문제가 있었다.

1. **컨테이너 누수** — `ContainerDatabaseDriver`는 JVM shutdown hook으로만 컨테이너를 정리하는데, Gradle daemon이나 IDE 테스트 러너 JVM이 살아있으면 컨테이너가 종료되지 않고 누적됨
2. **개선 여지** — 매 Spring 컨텍스트마다 컨테이너 lifecycle 관리가 비효율적이고, 전역 reuse 활용 불가

Spring Boot 3.1+ 권장 방식인 `@ServiceConnection` + 싱글톤 `MySQLContainer` 패턴으로 전환하여 Ryuk reaper가 lifecycle을 보장하게 하고, 통합 테스트들이 컨테이너 1개를 공유하도록 한다.

## 🛠 Changes

- **`TestcontainersConfiguration`** 신규 — `@ServiceConnection MySQLContainer("mysql:8.0").withReuse(true)` 빈
- **`IntegrationTestSupport` / `JpaSliceTestSupport`** base class 신규 — `@SpringBootTest` / `@DataJpaTest` 공통 베이스
- **`src/test/resources/application.yml`** 정리 — `jdbc:tc:` URL + `ContainerDatabaseDriver` 제거 (`@ServiceConnection`이 동적 주입), 테스트 프로파일에서 `spring.flyway.enabled: false` (기존 `ddl-auto: create-drop` 동작과 일치)
- **통합 테스트 13개 마이그레이션** — base 상속 3개 (`ServerApplicationTests`, `UserRepositoryTest`, `ParticipantRepositoryTest`) + `@Import(TestcontainersConfiguration::class)` 추가 10개 (MockMvc 컨트롤러 테스트)
- **`FlywayMigrationTest`** 별도 패턴 — companion에 `MySQLContainer` 싱글톤 + `purpose=flyway-migration-test` 라벨 부여하여 통합 테스트 컨테이너와 reuse hash 격리

## 📊 결과

213 tests / 0 failures / 16 skipped

| 환경 | 시간 | 비고 |
|---|---|---|
| 베이스라인 (`develop`, `jdbc:tc`) | 1m 24s | 누수 위험 존재 |
| 마이그레이션 후 (reuse off) | 1m 23s | 컨테이너 1개 공유, 누수 0 |
| 마이그레이션 후 + 전역 reuse 2차+ | **1m 3s** | ✨ ~25% 단축 |

- **컨테이너 누수 0** (`docker ps -a --filter label=org.testcontainers` 검증)
- 본인 머신에서 `~/.testcontainers.properties`에 `testcontainers.reuse.enable=true` 한 줄 추가하면 2차 실행부터 ~21초 절약 (옵션, 본인 환경만 영향)

## 👀 Review Focus

- **`TestcontainersConfiguration`** — `@ServiceConnection` 어노테이션이 `spring.datasource.*` 프로퍼티를 자동 주입하는지, `withReuse(true)` 적용 위치가 적절한지
- **`application.yml`의 Flyway 비활성화** — 기존 `jdbc:tc:` + `ddl-auto: create-drop` 조합도 Hibernate가 schema를 만들고 FK 없는 상태였음. `FlywayMigrationTest`가 Flyway 검증을 그대로 담당하므로 회귀 없음
- **`FlywayMigrationTest` 라벨 분리** — 전역 reuse 활성화 시 통합 테스트 컨테이너와 schema 충돌(FK 누적) 방지 목적. 같은 이미지·옵션이면 reuse hash가 매칭되는 testcontainers 동작 특성
- **base class 도입 vs `@Import` 직접 추가** — `@AutoConfigureMockMvc` 필요한 컨트롤러 테스트는 어노테이션 보존 위해 `@Import` 직접 적용, 옵션 단순한 케이스만 base 상속

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견