### PR TITLE
[Feat] 파티 참여자 목록 조회 API 설계 문서 추가

### DIFF
--- a/docs/superpowers/plans/2026-05-14-party-participants-list.md
+++ b/docs/superpowers/plans/2026-05-14-party-participants-list.md
@@ -1,0 +1,1133 @@
+# 파티 참여자 목록 조회 API Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 실시간 파티 진행 기본화면용 참여자 목록 조회 API (`GET /api/v1/parties/{partyId}/participants`) 를 RealtimeParty 전용으로 추가한다.
+
+**Architecture:** Archive(#127) PR 패턴을 따라 Controller 는 `party/api/`, UseCase 는 `party/application/usecase/`, Application DTO 는 `party/dto/` (Result 접미사), Response DTO 는 `party/api/dto/` 에 배치. Service 는 기존 `party/service/`, Repository 는 `party/repository/` 그대로 활용. Controller → UseCase → (PartyService + ParticipantService) → Repository 의 단방향 의존만 사용한다.
+
+**Tech Stack:** Kotlin 2.x, Spring Boot 3.x, Spring Data JPA, JPQL JOIN FETCH, Testcontainers (MySQL 8.0), JUnit 5, MockMvc.
+
+---
+
+> **Spec 과 실제 패키지 차이**: spec 문서는 향후 리팩토링 후 새 레이아웃 (`domain/entity/`, `infrastructure/persistence/`, `application/service/`) 을 가정했으나, 현재 develop 은 옛 레이아웃 (`entity/`, `repository/`, `service/`) 이라 본 plan 은 실제 경로 기준이다. 의도된 기능·API 형태·에러 정책은 spec 과 동일.
+
+## File Map
+
+| 종류 | 경로 |
+|---|---|
+| 수정 | `src/main/kotlin/com/team2/server/common/exception/ErrorCode.kt` |
+| 수정 | `src/main/kotlin/com/team2/server/party/entity/RealtimeParty.kt` |
+| 수정 | `src/main/kotlin/com/team2/server/party/repository/RealtimeParticipantProfileRepository.kt` |
+| 수정 | `src/main/kotlin/com/team2/server/party/service/PartyService.kt` |
+| 수정 | `src/main/kotlin/com/team2/server/party/service/ParticipantService.kt` |
+| 신규 | `src/main/kotlin/com/team2/server/party/dto/PartyParticipantsResult.kt` |
+| 신규 | `src/main/kotlin/com/team2/server/party/dto/PartyParticipantResult.kt` |
+| 신규 | `src/main/kotlin/com/team2/server/party/application/usecase/GetPartyParticipantsUseCase.kt` |
+| 신규 | `src/main/kotlin/com/team2/server/party/api/dto/PartyParticipantsResponse.kt` |
+| 신규 | `src/main/kotlin/com/team2/server/party/api/dto/PartyParticipantResponse.kt` |
+| 신규 | `src/main/kotlin/com/team2/server/party/api/ParticipantApi.kt` |
+| 신규 | `src/main/kotlin/com/team2/server/party/api/ParticipantController.kt` |
+| 신규 | `src/test/kotlin/com/team2/server/party/repository/RealtimeParticipantProfileRepositoryTest.kt` |
+| 신규 | `src/test/kotlin/com/team2/server/party/application/usecase/GetPartyParticipantsUseCaseTest.kt` |
+| 신규 | `src/test/kotlin/com/team2/server/party/api/ParticipantControllerTest.kt` |
+
+---
+
+## Task 1: ErrorCode 추가 (`PARTY_NOT_REALTIME`)
+
+**Files:**
+- Modify: `src/main/kotlin/com/team2/server/common/exception/ErrorCode.kt`
+
+- [ ] **Step 1: enum 항목 추가**
+
+`PARTY_ENDED` 줄 바로 아래에 추가:
+
+```kotlin
+PARTY_NOT_REALTIME(HttpStatus.BAD_REQUEST, "실시간 파티가 아닙니다"),
+```
+
+- [ ] **Step 2: 컴파일 확인**
+
+```bash
+./gradlew compileKotlin
+```
+
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/main/kotlin/com/team2/server/common/exception/ErrorCode.kt
+git commit -m "feat: PARTY_NOT_REALTIME 에러 코드 추가"
+```
+
+---
+
+## Task 2: RealtimeParty MAX_PARTICIPANTS 상수 추가
+
+**Files:**
+- Modify: `src/main/kotlin/com/team2/server/party/entity/RealtimeParty.kt`
+
+- [ ] **Step 1: companion object 상수 추가**
+
+기존 `companion object` 블록을 다음으로 교체:
+
+```kotlin
+    companion object {
+        const val LIVE_DURATION_MINUTES: Long = 10
+        const val ENTERABLE_BEFORE_MINUTES: Long = 5
+        const val MAX_PARTICIPANTS: Int = 14
+    }
+```
+
+- [ ] **Step 2: 컴파일 확인**
+
+```bash
+./gradlew compileKotlin
+```
+
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/main/kotlin/com/team2/server/party/entity/RealtimeParty.kt
+git commit -m "feat: RealtimeParty 최대 참가자 수 상수 추가"
+```
+
+---
+
+## Task 3: RealtimeParticipantProfileRepository 쿼리 추가 + 테스트
+
+**Files:**
+- Modify: `src/main/kotlin/com/team2/server/party/repository/RealtimeParticipantProfileRepository.kt`
+- Create: `src/test/kotlin/com/team2/server/party/repository/RealtimeParticipantProfileRepositoryTest.kt`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+새 파일 `src/test/kotlin/com/team2/server/party/repository/RealtimeParticipantProfileRepositoryTest.kt`:
+
+```kotlin
+package com.team2.server.party.repository
+
+import com.team2.server.config.TestcontainersConfiguration
+import com.team2.server.party.entity.Character
+import com.team2.server.party.entity.Participant
+import com.team2.server.party.entity.RealtimeParticipantProfile
+import com.team2.server.party.entity.RealtimeParty
+import com.team2.server.user.entity.AuthProvider
+import com.team2.server.user.entity.User
+import com.team2.server.user.repository.UserRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import java.time.LocalDateTime
+
+@DataJpaTest
+@Import(TestcontainersConfiguration::class)
+class RealtimeParticipantProfileRepositoryTest
+    @Autowired
+    constructor(
+        private val profileRepository: RealtimeParticipantProfileRepository,
+        private val participantRepository: ParticipantRepository,
+        private val partyRepository: PartyRepository,
+        private val characterRepository: CharacterRepository,
+        private val userRepository: UserRepository,
+    ) {
+        @Test
+        fun `partyId 기준 입장 순서대로 프로필을 조회한다`() {
+            val owner = userRepository.save(User(provider = AuthProvider.GOOGLE, providerId = "o", email = "o@e", name = "o"))
+            val party =
+                partyRepository.save(
+                    RealtimeParty(
+                        ownerId = owner.id,
+                        celebrantNickname = "주최자",
+                        startedAt = LocalDateTime.now().plusHours(1),
+                    ),
+                )
+            val character = characterRepository.save(Character(name = "octopus"))
+            val ownerParticipant =
+                participantRepository.save(Participant(party = party, user = owner, isCelebrant = true))
+            val ownerProfile =
+                profileRepository.save(
+                    RealtimeParticipantProfile(
+                        participant = ownerParticipant,
+                        nickname = "주최자",
+                        character = character,
+                    ),
+                )
+            val memberUser =
+                userRepository.save(User(provider = AuthProvider.GOOGLE, providerId = "m", email = "m@e", name = "m"))
+            val memberParticipant =
+                participantRepository.save(Participant(party = party, user = memberUser))
+            val memberProfile =
+                profileRepository.save(
+                    RealtimeParticipantProfile(
+                        participant = memberParticipant,
+                        nickname = "참가자A",
+                        character = character,
+                    ),
+                )
+
+            val result = profileRepository.findAllByPartyIdOrderByParticipantIdAsc(party.id)
+
+            assertThat(result).extracting<Long> { it.participant.id }
+                .containsExactly(ownerParticipant.id, memberParticipant.id)
+            assertThat(result).extracting<String> { it.nickname }
+                .containsExactly("주최자", "참가자A")
+            assertThat(result[0].id).isEqualTo(ownerProfile.id)
+            assertThat(result[1].id).isEqualTo(memberProfile.id)
+        }
+
+        @Test
+        fun `다른 파티의 프로필은 제외된다`() {
+            val owner = userRepository.save(User(provider = AuthProvider.GOOGLE, providerId = "o", email = "o@e", name = "o"))
+            val partyA =
+                partyRepository.save(
+                    RealtimeParty(
+                        ownerId = owner.id,
+                        celebrantNickname = "A",
+                        startedAt = LocalDateTime.now().plusHours(1),
+                    ),
+                )
+            val partyB =
+                partyRepository.save(
+                    RealtimeParty(
+                        ownerId = owner.id,
+                        celebrantNickname = "B",
+                        startedAt = LocalDateTime.now().plusHours(2),
+                    ),
+                )
+            val character = characterRepository.save(Character(name = "octopus"))
+            val pA = participantRepository.save(Participant(party = partyA, user = owner, isCelebrant = true))
+            profileRepository.save(RealtimeParticipantProfile(participant = pA, nickname = "A주최", character = character))
+            val pB = participantRepository.save(Participant(party = partyB, user = owner, isCelebrant = true))
+            profileRepository.save(RealtimeParticipantProfile(participant = pB, nickname = "B주최", character = character))
+
+            val result = profileRepository.findAllByPartyIdOrderByParticipantIdAsc(partyA.id)
+
+            assertThat(result).hasSize(1)
+            assertThat(result[0].nickname).isEqualTo("A주최")
+        }
+    }
+```
+
+- [ ] **Step 2: 테스트 실행으로 실패 확인**
+
+```bash
+DOCKER_HOST=unix:///Users/choetaegyu/.colima/default/docker.sock \
+TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock \
+./gradlew test --tests "com.team2.server.party.repository.RealtimeParticipantProfileRepositoryTest"
+```
+
+Expected: 컴파일 실패 — `findAllByPartyIdOrderByParticipantIdAsc` 메서드 없음
+
+- [ ] **Step 3: Repository 메서드 추가**
+
+`RealtimeParticipantProfileRepository.kt` 의 인터페이스 body 끝에 추가:
+
+```kotlin
+    @org.springframework.data.jpa.repository.Query(
+        """
+        SELECT rpp
+        FROM RealtimeParticipantProfile rpp
+        JOIN FETCH rpp.participant participant
+        LEFT JOIN FETCH participant.user
+        LEFT JOIN FETCH rpp.character
+        WHERE participant.party.id = :partyId
+        ORDER BY participant.id ASC
+        """,
+    )
+    fun findAllByPartyIdOrderByParticipantIdAsc(partyId: Long): List<RealtimeParticipantProfile>
+```
+
+> 기존 import 의 `@Query` 가 없다면 파일 상단 import 에 `import org.springframework.data.jpa.repository.Query` 를 추가하고 어노테이션을 `@Query(...)` 로 줄여도 좋다.
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+```bash
+DOCKER_HOST=unix:///Users/choetaegyu/.colima/default/docker.sock \
+TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock \
+./gradlew test --tests "com.team2.server.party.repository.RealtimeParticipantProfileRepositoryTest"
+```
+
+Expected: BUILD SUCCESSFUL, 2 tests passed
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/main/kotlin/com/team2/server/party/repository/RealtimeParticipantProfileRepository.kt \
+        src/test/kotlin/com/team2/server/party/repository/RealtimeParticipantProfileRepositoryTest.kt
+git commit -m "feat: 파티 ID 기준 RealtimeParticipantProfile 순서 조회 쿼리 추가"
+```
+
+---
+
+## Task 4: PartyService.requireRealtimeParty 추가
+
+**Files:**
+- Modify: `src/main/kotlin/com/team2/server/party/service/PartyService.kt`
+
+- [ ] **Step 1: import 추가 (필요시)**
+
+`PartyService.kt` 상단 import 에 다음이 없으면 추가:
+
+```kotlin
+import com.team2.server.party.entity.PartyOption
+import org.hibernate.Hibernate
+```
+
+- [ ] **Step 2: 메서드 추가**
+
+`findUser` 메서드 위 (private 메서드 그룹 바로 위) 에 추가:
+
+```kotlin
+    fun requireRealtimeParty(partyId: Long): RealtimeParty {
+        val party = findParty(partyId)
+        if (party.partyOption != PartyOption.REALTIME) {
+            throw BusinessException(ErrorCode.PARTY_NOT_REALTIME)
+        }
+        return Hibernate.unproxy(party) as RealtimeParty
+    }
+```
+
+- [ ] **Step 3: 컴파일 확인**
+
+```bash
+./gradlew compileKotlin
+```
+
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add src/main/kotlin/com/team2/server/party/service/PartyService.kt
+git commit -m "feat: PartyService 에 실시간 파티 검증 메서드 추가"
+```
+
+---
+
+## Task 5: ParticipantService 에 requireParticipant + findOrderedProfiles 추가
+
+**Files:**
+- Modify: `src/main/kotlin/com/team2/server/party/service/ParticipantService.kt`
+
+- [ ] **Step 1: import 및 의존성 추가**
+
+`ParticipantService.kt` 상단 import 에 추가:
+
+```kotlin
+import com.team2.server.common.exception.BusinessException
+import com.team2.server.common.exception.ErrorCode
+import com.team2.server.party.entity.RealtimeParticipantProfile
+import com.team2.server.party.repository.RealtimeParticipantProfileRepository
+```
+
+생성자 파라미터에 의존성 추가:
+
+```kotlin
+@Service
+class ParticipantService(
+    private val participantRepository: ParticipantRepository,
+    private val realtimeParticipantProfileRepository: RealtimeParticipantProfileRepository,
+) {
+```
+
+- [ ] **Step 2: 메서드 추가**
+
+클래스 body 끝(`companion object` 직전) 에 추가:
+
+```kotlin
+    fun requireParticipant(
+        partyId: Long,
+        userId: Long,
+    ) {
+        if (!participantRepository.existsByPartyIdAndUserId(partyId, userId)) {
+            throw BusinessException(ErrorCode.PARTY_FORBIDDEN)
+        }
+    }
+
+    fun findOrderedProfiles(partyId: Long): List<RealtimeParticipantProfile> =
+        realtimeParticipantProfileRepository.findAllByPartyIdOrderByParticipantIdAsc(partyId)
+```
+
+- [ ] **Step 3: 컴파일 확인**
+
+```bash
+./gradlew compileKotlin
+```
+
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add src/main/kotlin/com/team2/server/party/service/ParticipantService.kt
+git commit -m "feat: ParticipantService 에 참여자 검증·정렬 조회 메서드 추가"
+```
+
+---
+
+## Task 6: Application DTO (`PartyParticipantsResult`, `PartyParticipantResult`)
+
+**Files:**
+- Create: `src/main/kotlin/com/team2/server/party/dto/PartyParticipantResult.kt`
+- Create: `src/main/kotlin/com/team2/server/party/dto/PartyParticipantsResult.kt`
+
+- [ ] **Step 1: PartyParticipantResult 생성**
+
+```kotlin
+package com.team2.server.party.dto
+
+data class PartyParticipantResult(
+    val participantId: Long,
+    val joinOrder: Int,
+    val nickname: String,
+    val characterId: Long?,
+    val characterImageUrl: String?,
+    val isOwner: Boolean,
+    val isCelebrant: Boolean,
+    val isMe: Boolean,
+)
+```
+
+- [ ] **Step 2: PartyParticipantsResult 생성**
+
+```kotlin
+package com.team2.server.party.dto
+
+data class PartyParticipantsResult(
+    val totalCount: Int,
+    val maxCount: Int,
+    val participants: List<PartyParticipantResult>,
+)
+```
+
+- [ ] **Step 3: 컴파일 확인**
+
+```bash
+./gradlew compileKotlin
+```
+
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add src/main/kotlin/com/team2/server/party/dto/PartyParticipantResult.kt \
+        src/main/kotlin/com/team2/server/party/dto/PartyParticipantsResult.kt
+git commit -m "feat: 파티 참여자 목록 응용 DTO 추가"
+```
+
+---
+
+## Task 7: GetPartyParticipantsUseCase + 단위 테스트
+
+**Files:**
+- Create: `src/main/kotlin/com/team2/server/party/application/usecase/GetPartyParticipantsUseCase.kt`
+- Create: `src/test/kotlin/com/team2/server/party/application/usecase/GetPartyParticipantsUseCaseTest.kt`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+```kotlin
+package com.team2.server.party.application.usecase
+
+import com.team2.server.common.entity.Image
+import com.team2.server.common.entity.ImageTargetType
+import com.team2.server.common.exception.BusinessException
+import com.team2.server.common.exception.ErrorCode
+import com.team2.server.common.repository.ImageRepository
+import com.team2.server.party.entity.Character
+import com.team2.server.party.entity.Participant
+import com.team2.server.party.entity.RealtimeParticipantProfile
+import com.team2.server.party.entity.RealtimeParty
+import com.team2.server.party.service.ParticipantService
+import com.team2.server.party.service.PartyService
+import com.team2.server.user.entity.AuthProvider
+import com.team2.server.user.entity.User
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.springframework.test.util.ReflectionTestUtils
+import java.time.LocalDateTime
+
+class GetPartyParticipantsUseCaseTest {
+    private val partyService = mock(PartyService::class.java)
+    private val participantService = mock(ParticipantService::class.java)
+    private val imageRepository = mock(ImageRepository::class.java)
+    private val useCase = GetPartyParticipantsUseCase(partyService, participantService, imageRepository)
+
+    @Test
+    fun `주최자 호출 시 joinOrder는 참가자 id 오름차순으로 부여되고 isOwner 가 표시된다`() {
+        val party =
+            RealtimeParty(
+                ownerId = 10L,
+                celebrantNickname = "주최자",
+                startedAt = LocalDateTime.now().plusHours(1),
+            ).withId(100L)
+        val owner = newUser(10L)
+        val memberUser = newUser(20L)
+        val ownerParticipant = newParticipant(1L, party, owner, isCelebrant = true)
+        val memberParticipant = newParticipant(2L, party, memberUser, isCelebrant = false)
+        val character = newCharacter(7L)
+        val ownerProfile = newProfile(11L, ownerParticipant, "주최닉", character)
+        val memberProfile = newProfile(12L, memberParticipant, "참가닉", character)
+
+        `when`(partyService.requireRealtimeParty(100L)).thenReturn(party)
+        `when`(participantService.findOrderedProfiles(100L)).thenReturn(listOf(ownerProfile, memberProfile))
+        `when`(
+            imageRepository.findAllByTargetTypeAndTargetIdsOrderByTargetIdAndSortOrder(
+                ImageTargetType.CHARACTER,
+                listOf(7L),
+            ),
+        ).thenReturn(listOf(newImage(7L, "https://cdn/c7.png", 0)))
+
+        val result = useCase.invoke(partyId = 100L, userId = 10L)
+
+        assertThat(result.totalCount).isEqualTo(2)
+        assertThat(result.maxCount).isEqualTo(RealtimeParty.MAX_PARTICIPANTS)
+        assertThat(result.participants[0].joinOrder).isEqualTo(1)
+        assertThat(result.participants[0].isOwner).isTrue()
+        assertThat(result.participants[0].isCelebrant).isTrue()
+        assertThat(result.participants[0].isMe).isTrue()
+        assertThat(result.participants[0].characterImageUrl).isEqualTo("https://cdn/c7.png")
+        assertThat(result.participants[1].joinOrder).isEqualTo(2)
+        assertThat(result.participants[1].isOwner).isFalse()
+        assertThat(result.participants[1].isCelebrant).isFalse()
+        assertThat(result.participants[1].isMe).isFalse()
+    }
+
+    @Test
+    fun `참가자 본인이 호출하면 본인의 isMe 만 true`() {
+        val party = RealtimeParty(ownerId = 10L, celebrantNickname = "x", startedAt = LocalDateTime.now().plusHours(1)).withId(100L)
+        val ownerParticipant = newParticipant(1L, party, newUser(10L), isCelebrant = true)
+        val meParticipant = newParticipant(2L, party, newUser(20L), isCelebrant = false)
+        val character = newCharacter(7L)
+        `when`(partyService.requireRealtimeParty(100L)).thenReturn(party)
+        `when`(participantService.findOrderedProfiles(100L)).thenReturn(
+            listOf(
+                newProfile(11L, ownerParticipant, "주최", character),
+                newProfile(12L, meParticipant, "나", character),
+            ),
+        )
+        `when`(
+            imageRepository.findAllByTargetTypeAndTargetIdsOrderByTargetIdAndSortOrder(
+                ImageTargetType.CHARACTER,
+                listOf(7L),
+            ),
+        ).thenReturn(emptyList())
+
+        val result = useCase.invoke(partyId = 100L, userId = 20L)
+
+        assertThat(result.participants[0].isMe).isFalse()
+        assertThat(result.participants[1].isMe).isTrue()
+        assertThat(result.participants[1].characterImageUrl).isNull()
+    }
+
+    @Test
+    fun `비참가자 호출 시 ParticipantService 가 PARTY_FORBIDDEN 던지면 전파한다`() {
+        val party = RealtimeParty(ownerId = 10L, celebrantNickname = "x", startedAt = LocalDateTime.now().plusHours(1)).withId(100L)
+        `when`(partyService.requireRealtimeParty(100L)).thenReturn(party)
+        `when`(participantService.requireParticipant(100L, 99L))
+            .thenThrow(BusinessException(ErrorCode.PARTY_FORBIDDEN))
+
+        assertThatThrownBy { useCase.invoke(partyId = 100L, userId = 99L) }
+            .isInstanceOf(BusinessException::class.java)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PARTY_FORBIDDEN)
+    }
+
+    @Test
+    fun `PaperOnly 파티는 PartyService 에서 PARTY_NOT_REALTIME 을 던지고 전파한다`() {
+        `when`(partyService.requireRealtimeParty(100L))
+            .thenThrow(BusinessException(ErrorCode.PARTY_NOT_REALTIME))
+
+        assertThatThrownBy { useCase.invoke(partyId = 100L, userId = 10L) }
+            .isInstanceOf(BusinessException::class.java)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PARTY_NOT_REALTIME)
+    }
+
+    private fun newUser(id: Long) =
+        User(provider = AuthProvider.GOOGLE, providerId = "p$id", email = "e$id@e", name = "n$id").withId(id)
+
+    private fun newParticipant(
+        id: Long,
+        party: RealtimeParty,
+        user: User,
+        isCelebrant: Boolean,
+    ) = Participant(party = party, user = user, isCelebrant = isCelebrant).withId(id)
+
+    private fun newCharacter(id: Long) = Character(name = "c$id").withId(id)
+
+    private fun newProfile(
+        id: Long,
+        participant: Participant,
+        nickname: String,
+        character: Character,
+    ) = RealtimeParticipantProfile(participant = participant, nickname = nickname, character = character).withId(id)
+
+    private fun newImage(
+        targetId: Long,
+        url: String,
+        order: Int,
+    ) = Image(imageUrl = url, targetType = ImageTargetType.CHARACTER, targetId = targetId, sortOrder = order).withId(targetId)
+
+    private fun <T : Any> T.withId(id: Long): T = apply { ReflectionTestUtils.setField(this, "id", id) }
+}
+```
+
+- [ ] **Step 2: 테스트 실행으로 실패 확인**
+
+```bash
+./gradlew test --tests "com.team2.server.party.application.usecase.GetPartyParticipantsUseCaseTest"
+```
+
+Expected: 컴파일 실패 — `GetPartyParticipantsUseCase` 클래스 없음
+
+- [ ] **Step 3: UseCase 구현**
+
+`src/main/kotlin/com/team2/server/party/application/usecase/GetPartyParticipantsUseCase.kt`:
+
+```kotlin
+package com.team2.server.party.application.usecase
+
+import com.team2.server.common.entity.ImageTargetType
+import com.team2.server.common.repository.ImageRepository
+import com.team2.server.party.dto.PartyParticipantResult
+import com.team2.server.party.dto.PartyParticipantsResult
+import com.team2.server.party.entity.RealtimeParty
+import com.team2.server.party.service.ParticipantService
+import com.team2.server.party.service.PartyService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class GetPartyParticipantsUseCase(
+    private val partyService: PartyService,
+    private val participantService: ParticipantService,
+    private val imageRepository: ImageRepository,
+) {
+    @Transactional(readOnly = true)
+    fun invoke(
+        partyId: Long,
+        userId: Long,
+    ): PartyParticipantsResult {
+        val party = partyService.requireRealtimeParty(partyId)
+        participantService.requireParticipant(partyId, userId)
+
+        val profiles = participantService.findOrderedProfiles(partyId)
+        val characterIds = profiles.mapNotNull { it.character?.id }.distinct()
+        val imageUrlByCharacterId =
+            if (characterIds.isEmpty()) {
+                emptyMap()
+            } else {
+                imageRepository
+                    .findAllByTargetTypeAndTargetIdsOrderByTargetIdAndSortOrder(ImageTargetType.CHARACTER, characterIds)
+                    .filter { it.sortOrder == CHARACTER_IMAGE_SORT_ORDER }
+                    .associate { it.targetId to it.imageUrl }
+            }
+
+        val items =
+            profiles.mapIndexed { index, profile ->
+                val participant = profile.participant
+                PartyParticipantResult(
+                    participantId = participant.id,
+                    joinOrder = index + 1,
+                    nickname = profile.nickname,
+                    characterId = profile.character?.id,
+                    characterImageUrl = profile.character?.id?.let { imageUrlByCharacterId[it] },
+                    isOwner = participant.user?.id == party.ownerId,
+                    isCelebrant = participant.isCelebrant,
+                    isMe = participant.user?.id == userId,
+                )
+            }
+        return PartyParticipantsResult(
+            totalCount = items.size,
+            maxCount = RealtimeParty.MAX_PARTICIPANTS,
+            participants = items,
+        )
+    }
+
+    private companion object {
+        private const val CHARACTER_IMAGE_SORT_ORDER = 0
+    }
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+```bash
+./gradlew test --tests "com.team2.server.party.application.usecase.GetPartyParticipantsUseCaseTest"
+```
+
+Expected: BUILD SUCCESSFUL, 4 tests passed
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/main/kotlin/com/team2/server/party/application/usecase/GetPartyParticipantsUseCase.kt \
+        src/test/kotlin/com/team2/server/party/application/usecase/GetPartyParticipantsUseCaseTest.kt
+git commit -m "feat: 파티 참여자 목록 조회 UseCase 추가"
+```
+
+---
+
+## Task 8: API Response DTO
+
+**Files:**
+- Create: `src/main/kotlin/com/team2/server/party/api/dto/PartyParticipantResponse.kt`
+- Create: `src/main/kotlin/com/team2/server/party/api/dto/PartyParticipantsResponse.kt`
+
+- [ ] **Step 1: PartyParticipantResponse 생성**
+
+```kotlin
+package com.team2.server.party.api.dto
+
+import com.team2.server.party.dto.PartyParticipantResult
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "파티 참여자 항목")
+data class PartyParticipantResponse(
+    @Schema(description = "참여자 ID", example = "17")
+    val participantId: Long,
+    @Schema(description = "입장 순서 (1부터)", example = "1")
+    val joinOrder: Int,
+    @Schema(description = "닉네임", example = "주최자닉")
+    val nickname: String,
+    @Schema(description = "캐릭터 ID", example = "3", nullable = true)
+    val characterId: Long?,
+    @Schema(description = "캐릭터 메인 이미지 URL", nullable = true)
+    val characterImageUrl: String?,
+    @Schema(description = "파티 주최자 여부", example = "true")
+    val isOwner: Boolean,
+    @Schema(description = "파티 주인공 여부", example = "true")
+    val isCelebrant: Boolean,
+    @Schema(description = "조회자 본인 여부", example = "false")
+    val isMe: Boolean,
+) {
+    companion object {
+        fun from(result: PartyParticipantResult): PartyParticipantResponse =
+            PartyParticipantResponse(
+                participantId = result.participantId,
+                joinOrder = result.joinOrder,
+                nickname = result.nickname,
+                characterId = result.characterId,
+                characterImageUrl = result.characterImageUrl,
+                isOwner = result.isOwner,
+                isCelebrant = result.isCelebrant,
+                isMe = result.isMe,
+            )
+    }
+}
+```
+
+- [ ] **Step 2: PartyParticipantsResponse 생성**
+
+```kotlin
+package com.team2.server.party.api.dto
+
+import com.team2.server.party.dto.PartyParticipantsResult
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "파티 참여자 목록 응답")
+data class PartyParticipantsResponse(
+    @Schema(description = "현재 참여자 수", example = "4")
+    val totalCount: Int,
+    @Schema(description = "최대 참여자 수", example = "14")
+    val maxCount: Int,
+    @Schema(description = "입장 순서대로 정렬된 참여자 목록")
+    val participants: List<PartyParticipantResponse>,
+) {
+    companion object {
+        fun from(result: PartyParticipantsResult): PartyParticipantsResponse =
+            PartyParticipantsResponse(
+                totalCount = result.totalCount,
+                maxCount = result.maxCount,
+                participants = result.participants.map(PartyParticipantResponse::from),
+            )
+    }
+}
+```
+
+- [ ] **Step 3: 컴파일 확인**
+
+```bash
+./gradlew compileKotlin
+```
+
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add src/main/kotlin/com/team2/server/party/api/dto/PartyParticipantResponse.kt \
+        src/main/kotlin/com/team2/server/party/api/dto/PartyParticipantsResponse.kt
+git commit -m "feat: 파티 참여자 목록 API 응답 DTO 추가"
+```
+
+---
+
+## Task 9: ParticipantApi (Swagger interface)
+
+**Files:**
+- Create: `src/main/kotlin/com/team2/server/party/api/ParticipantApi.kt`
+
+- [ ] **Step 1: 인터페이스 생성**
+
+```kotlin
+package com.team2.server.party.api
+
+import com.team2.server.auth.principal.UserPrincipal
+import com.team2.server.common.response.ApiResponse
+import com.team2.server.common.swagger.AuthErrorResponses
+import com.team2.server.common.swagger.ForbiddenResponse
+import com.team2.server.common.swagger.InternalServerErrorResponse
+import com.team2.server.party.api.dto.PartyParticipantsResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
+
+@Tag(name = "Party", description = "파티 API")
+interface ParticipantApi {
+    @Operation(
+        summary = "파티 참여자 목록 조회",
+        description = "실시간 파티 진행 기본화면용. 입장 순서로 정렬된 참여자 목록을 반환한다. RealtimeParty 전용, 참여자만 조회 가능.",
+        security = [SecurityRequirement(name = "Bearer Authentication")],
+    )
+    @SwaggerApiResponse(responseCode = "200", description = "참여자 목록 조회 성공")
+    @AuthErrorResponses
+    @ForbiddenResponse
+    @InternalServerErrorResponse
+    fun getPartyParticipants(
+        @Parameter(hidden = true) principal: UserPrincipal,
+        @Parameter(description = "파티 ID", example = "1") partyId: Long,
+    ): ApiResponse<PartyParticipantsResponse>
+}
+```
+
+> `ForbiddenResponse` 가 단일 어노테이션이 아니라 메서드명이라면 생략하고 `AuthErrorResponses` 만 유지해도 무방. (Step 3 컴파일에서 확인되면 그대로, 컴파일 실패면 import 제거 + 해당 줄 삭제.)
+
+- [ ] **Step 2: 컴파일 확인**
+
+```bash
+./gradlew compileKotlin
+```
+
+Expected: BUILD SUCCESSFUL (또는 `ForbiddenResponse` 미존재 시 import 와 어노테이션 제거 후 재시도)
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/main/kotlin/com/team2/server/party/api/ParticipantApi.kt
+git commit -m "feat: ParticipantApi Swagger 인터페이스 추가"
+```
+
+---
+
+## Task 10: ParticipantController + 통합 테스트
+
+**Files:**
+- Create: `src/main/kotlin/com/team2/server/party/api/ParticipantController.kt`
+- Create: `src/test/kotlin/com/team2/server/party/api/ParticipantControllerTest.kt`
+
+- [ ] **Step 1: Controller 통합 테스트 작성**
+
+```kotlin
+package com.team2.server.party.api
+
+import com.team2.server.auth.config.JwtProperties
+import com.team2.server.auth.jwt.JwtTokenProvider
+import com.team2.server.common.entity.Image
+import com.team2.server.common.entity.ImageTargetType
+import com.team2.server.common.repository.ImageRepository
+import com.team2.server.config.TestcontainersConfiguration
+import com.team2.server.party.entity.Character
+import com.team2.server.party.entity.PaperOnlyParty
+import com.team2.server.party.entity.Participant
+import com.team2.server.party.entity.RealtimeParticipantProfile
+import com.team2.server.party.entity.RealtimeParty
+import com.team2.server.party.repository.CharacterRepository
+import com.team2.server.party.repository.ParticipantRepository
+import com.team2.server.party.repository.PartyRepository
+import com.team2.server.party.repository.RealtimeParticipantProfileRepository
+import com.team2.server.user.entity.AuthProvider
+import com.team2.server.user.entity.User
+import com.team2.server.user.repository.UserRepository
+import org.hamcrest.Matchers.hasSize
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.context.annotation.Import
+import org.springframework.http.HttpHeaders
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import java.time.LocalDateTime
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import(TestcontainersConfiguration::class)
+class ParticipantControllerTest
+    @Autowired
+    constructor(
+        private val mockMvc: MockMvc,
+        private val partyRepository: PartyRepository,
+        private val participantRepository: ParticipantRepository,
+        private val realtimeParticipantProfileRepository: RealtimeParticipantProfileRepository,
+        private val characterRepository: CharacterRepository,
+        private val imageRepository: ImageRepository,
+        private val userRepository: UserRepository,
+        private val jwtTokenProvider: JwtTokenProvider,
+        private val jwtProperties: JwtProperties,
+    ) {
+        private lateinit var owner: User
+        private lateinit var member: User
+        private lateinit var outsider: User
+        private lateinit var realtimeParty: RealtimeParty
+        private lateinit var paperOnlyParty: PaperOnlyParty
+
+        @BeforeEach
+        fun setUp() {
+            realtimeParticipantProfileRepository.deleteAll()
+            participantRepository.deleteAll()
+            partyRepository.deleteAll()
+            imageRepository.deleteAll()
+            characterRepository.deleteAll()
+            userRepository.deleteAll()
+
+            owner = userRepository.save(User(provider = AuthProvider.GOOGLE, providerId = "o", email = "o@e", name = "owner"))
+            member = userRepository.save(User(provider = AuthProvider.GOOGLE, providerId = "m", email = "m@e", name = "member"))
+            outsider = userRepository.save(User(provider = AuthProvider.GOOGLE, providerId = "x", email = "x@e", name = "outsider"))
+
+            realtimeParty =
+                partyRepository.save(
+                    RealtimeParty(
+                        ownerId = owner.id,
+                        celebrantNickname = "주최자",
+                        startedAt = LocalDateTime.now().plusHours(1),
+                    ),
+                )
+            paperOnlyParty =
+                partyRepository.save(
+                    PaperOnlyParty(
+                        ownerId = owner.id,
+                        celebrantNickname = "롤링",
+                        startedAt = LocalDateTime.now().plusDays(1),
+                    ),
+                )
+
+            val character = characterRepository.save(Character(name = "octopus"))
+            imageRepository.save(
+                Image(
+                    imageUrl = "https://cdn/char.png",
+                    targetType = ImageTargetType.CHARACTER,
+                    targetId = character.id,
+                    sortOrder = 0,
+                ),
+            )
+
+            val ownerParticipant =
+                participantRepository.save(Participant(party = realtimeParty, user = owner, isCelebrant = true))
+            realtimeParticipantProfileRepository.save(
+                RealtimeParticipantProfile(participant = ownerParticipant, nickname = "주최자", character = character),
+            )
+            val memberParticipant =
+                participantRepository.save(Participant(party = realtimeParty, user = member, isCelebrant = false))
+            realtimeParticipantProfileRepository.save(
+                RealtimeParticipantProfile(participant = memberParticipant, nickname = "참가자A", character = character),
+            )
+        }
+
+        @Test
+        fun `주최자 호출 시 200 과 입장 순서대로 정렬된 목록을 반환한다`() {
+            mockMvc.get("/api/v1/parties/${realtimeParty.id}/participants") {
+                header(HttpHeaders.AUTHORIZATION, bearer(owner.id))
+            }.andExpect {
+                status { isOk() }
+                jsonPath("$.data.totalCount") { value(2) }
+                jsonPath("$.data.maxCount") { value(14) }
+                jsonPath("$.data.participants", hasSize<Any>(2))
+                jsonPath("$.data.participants[0].joinOrder") { value(1) }
+                jsonPath("$.data.participants[0].isOwner") { value(true) }
+                jsonPath("$.data.participants[0].isCelebrant") { value(true) }
+                jsonPath("$.data.participants[0].isMe") { value(true) }
+                jsonPath("$.data.participants[0].characterImageUrl") { value("https://cdn/char.png") }
+                jsonPath("$.data.participants[1].joinOrder") { value(2) }
+                jsonPath("$.data.participants[1].isOwner") { value(false) }
+                jsonPath("$.data.participants[1].isMe") { value(false) }
+            }
+        }
+
+        @Test
+        fun `일반 참가자 호출 시 본인의 isMe 만 true`() {
+            mockMvc.get("/api/v1/parties/${realtimeParty.id}/participants") {
+                header(HttpHeaders.AUTHORIZATION, bearer(member.id))
+            }.andExpect {
+                status { isOk() }
+                jsonPath("$.data.participants[0].isMe") { value(false) }
+                jsonPath("$.data.participants[1].isMe") { value(true) }
+            }
+        }
+
+        @Test
+        fun `비참가자 호출 시 403 PARTY_FORBIDDEN`() {
+            mockMvc.get("/api/v1/parties/${realtimeParty.id}/participants") {
+                header(HttpHeaders.AUTHORIZATION, bearer(outsider.id))
+            }.andExpect {
+                status { isForbidden() }
+                jsonPath("$.error.code") { value("PARTY_FORBIDDEN") }
+            }
+        }
+
+        @Test
+        fun `PaperOnly 파티 호출 시 400 PARTY_NOT_REALTIME`() {
+            participantRepository.save(Participant(party = paperOnlyParty, user = owner, isCelebrant = true))
+
+            mockMvc.get("/api/v1/parties/${paperOnlyParty.id}/participants") {
+                header(HttpHeaders.AUTHORIZATION, bearer(owner.id))
+            }.andExpect {
+                status { isBadRequest() }
+                jsonPath("$.error.code") { value("PARTY_NOT_REALTIME") }
+            }
+        }
+
+        @Test
+        fun `존재하지 않는 파티 호출 시 404 PARTY_NOT_FOUND`() {
+            mockMvc.get("/api/v1/parties/99999/participants") {
+                header(HttpHeaders.AUTHORIZATION, bearer(owner.id))
+            }.andExpect {
+                status { isNotFound() }
+                jsonPath("$.error.code") { value("PARTY_NOT_FOUND") }
+            }
+        }
+
+        @Test
+        fun `Authorization 헤더 없으면 401`() {
+            mockMvc.get("/api/v1/parties/${realtimeParty.id}/participants")
+                .andExpect {
+                    status { isUnauthorized() }
+                }
+        }
+
+        private fun bearer(userId: Long): String = "Bearer ${jwtTokenProvider.createAccessToken(userId)}"
+    }
+```
+
+> Bearer 토큰 발급 헬퍼 시그니처는 develop 의 기존 테스트(예: `ArchiveControllerTest`) 의 패턴을 그대로 따라야 한다. `jwtTokenProvider.createAccessToken(userId)` 가 없는 시그니처라면 같은 파일 패턴 (`createAccessToken(userId.toString(), ...)` 등) 으로 맞춰서 수정한다.
+
+- [ ] **Step 2: 테스트 실행으로 실패 확인**
+
+```bash
+DOCKER_HOST=unix:///Users/choetaegyu/.colima/default/docker.sock \
+TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock \
+./gradlew test --tests "com.team2.server.party.api.ParticipantControllerTest"
+```
+
+Expected: 컴파일 실패 — `ParticipantController` 미존재
+
+- [ ] **Step 3: Controller 구현**
+
+```kotlin
+package com.team2.server.party.api
+
+import com.team2.server.auth.principal.UserPrincipal
+import com.team2.server.common.response.ApiResponse
+import com.team2.server.party.api.dto.PartyParticipantsResponse
+import com.team2.server.party.application.usecase.GetPartyParticipantsUseCase
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/parties")
+class ParticipantController(
+    private val getPartyParticipantsUseCase: GetPartyParticipantsUseCase,
+) : ParticipantApi {
+    @GetMapping("/{partyId}/participants")
+    override fun getPartyParticipants(
+        @AuthenticationPrincipal principal: UserPrincipal,
+        @PathVariable partyId: Long,
+    ): ApiResponse<PartyParticipantsResponse> {
+        val result = getPartyParticipantsUseCase.invoke(partyId = partyId, userId = principal.userId)
+        return ApiResponse.success(PartyParticipantsResponse.from(result))
+    }
+}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+```bash
+DOCKER_HOST=unix:///Users/choetaegyu/.colima/default/docker.sock \
+TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock \
+./gradlew test --tests "com.team2.server.party.api.ParticipantControllerTest"
+```
+
+Expected: BUILD SUCCESSFUL, 6 tests passed
+
+> 실패 시 가장 흔한 원인: (a) `bearer()` 토큰 시그니처 불일치 — `ArchiveControllerTest` 의 동일 패턴 확인 후 정렬, (b) `setUp` 의 deleteAll 순서로 FK 충돌 — 자식부터 부모 순(profile → participant → party → user/character) 으로 정렬.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/main/kotlin/com/team2/server/party/api/ParticipantController.kt \
+        src/test/kotlin/com/team2/server/party/api/ParticipantControllerTest.kt
+git commit -m "feat: 파티 참여자 목록 조회 Controller 추가"
+```
+
+---
+
+## Task 11: 전체 검증 + Push + PR 업데이트
+
+**Files:** 변경 없음
+
+- [ ] **Step 1: ktlint 검증**
+
+```bash
+./gradlew ktlintCheck
+```
+
+Expected: BUILD SUCCESSFUL. 실패하면 `./gradlew ktlintFormat` 실행 후 변경분 커밋 (`chore: ktlint 포맷 정렬`).
+
+- [ ] **Step 2: 전체 build + test**
+
+```bash
+DOCKER_HOST=unix:///Users/choetaegyu/.colima/default/docker.sock \
+TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock \
+./gradlew build
+```
+
+Expected: BUILD SUCCESSFUL, all tests passed (실패 0, 스킵 0).
+
+- [ ] **Step 3: 원격 push**
+
+```bash
+git push origin feature/party-participants-list
+```
+
+Expected: 정상 push. PR #149 가 자동으로 새 커밋들 반영.
+
+- [ ] **Step 4: PR 본문 갱신**
+
+PR #149 의 description 에 다음 추가 (또는 새 PR comment):
+
+```
+구현 완료 (TDD 11 task).
+- Repository, Service, UseCase 단위·통합 테스트 모두 통과.
+- 응답 스키마는 spec 문서 그대로.
+- 패키지 경로는 develop 의 옛 레이아웃 + Archive(#127) 패턴을 따름.
+```
+
+- [ ] **Step 5: 검증 완료**
+
+CI 그린 확인 후 리뷰 요청.

--- a/docs/superpowers/specs/2026-05-14-party-participants-list-design.md
+++ b/docs/superpowers/specs/2026-05-14-party-participants-list-design.md
@@ -1,0 +1,299 @@
+# 파티 참여자 목록 조회 API 설계
+
+- 작성일: 2026-05-14
+- 작성자: taegyu.choi
+- 관련 화면: 파티 진행 기본화면 (파티 시작 전, 참가자 1명 이상)
+- 대상 파티: `RealtimeParty` 전용
+
+## 1. 배경 / 목표
+
+실시간 파티 시작 전에 입장한 참가자를 모아 보여주는 "파티 진행 기본화면"을 그리기 위한 서버 API. 클라이언트는 응답을 받아 다음을 수행한다.
+
+- 입장 순서대로 1~13번 캐릭터 위치 고정 배치
+- 주최자 화면: 본인 외 가장 먼저 입장한 참가자를 상단 큰 캐릭터로 배치
+- 참가자 화면: 본인을 상단 큰 캐릭터로 배치
+- 주최자(모자쓴 캐릭터)는 하단 고정
+
+서버는 정렬된 참가자 목록과 식별 정보를 반환하고, UI 배치는 클라이언트가 결정한다.
+
+## 2. 비범위 (YAGNI)
+
+- 음악 버튼, 채팅 바텀시트, 입장 안내멘트 등 UI 위젯
+- WebSocket / 실시간 입장 알림 (별도 PR — 채팅 도메인)
+- 페이지네이션 (최대 14명)
+- 응답 캐싱 (필요시 측정 후 추가)
+- PaperOnly 파티의 참가자 화면 (요구사항 없음)
+
+## 3. API 사양
+
+### Endpoint
+
+```
+GET /api/v1/parties/{partyId}/participants
+Authorization: Bearer <jwt>      # 필수
+```
+
+### Path Variable
+
+| 이름 | 타입 | 설명 |
+|---|---|---|
+| partyId | Long | 파티 ID |
+
+### Response (200 OK)
+
+```json
+{
+  "status": 200,
+  "data": {
+    "totalCount": 4,
+    "maxCount": 14,
+    "participants": [
+      {
+        "participantId": 17,
+        "joinOrder": 1,
+        "nickname": "주최자닉",
+        "characterId": 3,
+        "characterImageUrl": "https://cdn.example.com/characters/char3.png",
+        "isOwner": true,
+        "isCelebrant": true,
+        "isMe": false
+      },
+      {
+        "participantId": 18,
+        "joinOrder": 2,
+        "nickname": "참가자A",
+        "characterId": 7,
+        "characterImageUrl": "https://cdn.example.com/characters/char7.png",
+        "isOwner": false,
+        "isCelebrant": false,
+        "isMe": true
+      }
+    ]
+  }
+}
+```
+
+### 응답 필드 정의
+
+| 필드 | 타입 | 비고 |
+|---|---|---|
+| totalCount | Int | 현재 참가자 수 |
+| maxCount | Int | 상수 14 (`RealtimeParty.MAX_PARTICIPANTS`) |
+| participants | List | `joinOrder` 오름차순 |
+| participants[].participantId | Long | 식별자 |
+| participants[].joinOrder | Int | 1..N, 서버가 `participant.id ASC` 기준으로 부여 |
+| participants[].nickname | String | `RealtimeParticipantProfile.nickname` |
+| participants[].characterId | Long | `Character.id` |
+| participants[].characterImageUrl | String? | sortOrder=0 이미지 (`ImageRepository` 배치 조회) |
+| participants[].isOwner | Boolean | `participant.user?.id == party.ownerId` |
+| participants[].isCelebrant | Boolean | `participant.isCelebrant` |
+| participants[].isMe | Boolean | `participant.user?.id == 호출자 userId` |
+
+> `isOwner` / `isCelebrant` 는 현재 항상 동일하지만 향후 "남이 대신 만든 파티" 시나리오에 대비해 분리. 클라이언트 측 UI 룰(모자 표시 vs 주인공 표시)을 독립적으로 매핑할 수 있음.
+
+### Error Response
+
+| 상황 | HTTP | code | message |
+|---|---|---|---|
+| 미인증 | 401 | AUTH_UNAUTHORIZED | 인증이 필요합니다 |
+| 존재하지 않는 partyId | 404 | PARTY_NOT_FOUND | 파티를 찾을 수 없습니다 |
+| PaperOnly 파티 | 400 | **PARTY_NOT_REALTIME** *(신규)* | 실시간 파티가 아닙니다 |
+| 참가자 아닌 사용자 | 403 | PARTY_FORBIDDEN | 파티에 대한 권한이 없습니다 |
+
+## 4. 레이어드 아키텍처 매핑
+
+```
+ParticipantController              (api)
+        │ invoke
+GetPartyParticipantsUseCase        (application/usecase, @Transactional(readOnly = true))
+        │
+        ├─ PartyService.requireRealtimeParty(partyId)        → RealtimeParty
+        ├─ ParticipantService.requireParticipant(partyId, userId)
+        ├─ ParticipantService.findOrderedProfiles(partyId)   → List<RealtimeParticipantProfile>
+        └─ ImageRepository.findAllByTargetTypeAndTargetIdsOrderByTargetIdAndSortOrder(CHARACTER, ids)
+```
+
+### 의존 방향 준수
+
+- Controller → UseCase 만 호출
+- UseCase → 같은 feature 의 Service 조합 (`PartyService`, `ParticipantService`)
+- Service → Service 호출 없음 (UseCase 가 조합)
+- UseCase 가 응답 DTO 변환 책임
+
+## 5. 신규 / 수정 파일
+
+### 신규
+
+| 경로 | 역할 |
+|---|---|
+| `party/api/ParticipantApi.kt` | Swagger interface |
+| `party/api/ParticipantController.kt` | `GET /api/v1/parties/{partyId}/participants` |
+| `party/api/dto/PartyParticipantsResponse.kt` | 응답 envelope (`totalCount`, `maxCount`, `participants`) |
+| `party/api/dto/PartyParticipantResponse.kt` | 개별 참가자 응답 항목 |
+| `party/application/dto/PartyParticipantsResult.kt` | 응답용 application DTO (envelope) |
+| `party/application/dto/PartyParticipantResult.kt` | 응답용 application DTO (item) |
+| `party/application/usecase/GetPartyParticipantsUseCase.kt` | 흐름 제어, @Transactional(readOnly) |
+
+### 수정
+
+| 경로 | 변경 |
+|---|---|
+| `common/exception/ErrorCode.kt` | `PARTY_NOT_REALTIME(BAD_REQUEST, "실시간 파티가 아닙니다")` 추가 |
+| `party/domain/entity/RealtimeParty.kt` | `const val MAX_PARTICIPANTS = 14` 추가 |
+| `party/application/service/PartyService.kt` | `requireRealtimeParty(partyId): RealtimeParty` 추가 (status 무관) |
+| `party/application/service/ParticipantService.kt` | `requireParticipant(partyId, userId)` 추가 / `findOrderedProfiles(partyId): List<RealtimeParticipantProfile>` 추가 |
+| `party/infrastructure/persistence/RealtimeParticipantProfileRepository.kt` | `findAllByPartyIdOrderByParticipantIdAsc(partyId)` JPQL JOIN FETCH 쿼리 추가 |
+
+### Repository 쿼리
+
+```kotlin
+@Query(
+    """
+    SELECT rpp
+    FROM RealtimeParticipantProfile rpp
+    JOIN FETCH rpp.participant participant
+    LEFT JOIN FETCH participant.user
+    LEFT JOIN FETCH rpp.character
+    WHERE participant.party.id = :partyId
+    ORDER BY participant.id ASC
+    """,
+)
+fun findAllByPartyIdOrderByParticipantIdAsc(partyId: Long): List<RealtimeParticipantProfile>
+```
+
+- 한 번의 쿼리로 N+1 회피
+- `character` LEFT JOIN — 익명 참가자 (현재 코드상 character null 가능)
+- `user` LEFT JOIN — 익명 참가자 처리
+
+> 캐릭터 이미지 URL 은 `ImageRepository.findAllByTargetTypeAndTargetIdsOrderByTargetIdAndSortOrder(CHARACTER, characterIds)` 로 별도 배치 조회 후 매핑 (기존 `GetCharactersUseCase` 패턴 동일).
+
+### Service 새 메서드
+
+**`PartyService.requireRealtimeParty`**
+
+```kotlin
+fun requireRealtimeParty(partyId: Long): RealtimeParty {
+    val party = findParty(partyId)
+    if (party.partyOption != PartyOption.REALTIME) {
+        throw BusinessException(ErrorCode.PARTY_NOT_REALTIME)
+    }
+    return Hibernate.unproxy(party) as RealtimeParty
+}
+```
+
+- 기존 `findActiveRealtimeParty` 와 다름: LIVE_OPEN 상태 강제하지 않음 (시작 전 화면용)
+- `findParty` private → 재사용
+
+**`ParticipantService.requireParticipant`**
+
+```kotlin
+fun requireParticipant(partyId: Long, userId: Long) {
+    if (!participantRepository.existsByPartyIdAndUserId(partyId, userId)) {
+        throw BusinessException(ErrorCode.PARTY_FORBIDDEN)
+    }
+}
+```
+
+**`ParticipantService.findOrderedProfiles`**
+
+```kotlin
+fun findOrderedProfiles(partyId: Long): List<RealtimeParticipantProfile> =
+    realtimeParticipantProfileRepository.findAllByPartyIdOrderByParticipantIdAsc(partyId)
+```
+
+> `ParticipantService` 는 현재 `RealtimeParticipantProfileRepository` 를 보유하지 않음 → 의존성 5개 이내 제약 확인 필요. 현재 의존성 1개라 여유 충분.
+
+## 6. UseCase 의사 코드
+
+```kotlin
+@Service
+class GetPartyParticipantsUseCase(
+    private val partyService: PartyService,
+    private val participantService: ParticipantService,
+    private val imageRepository: ImageRepository,
+) {
+    @Transactional(readOnly = true)
+    fun invoke(partyId: Long, userId: Long): PartyParticipantsResult {
+        val party = partyService.requireRealtimeParty(partyId)
+        participantService.requireParticipant(partyId, userId)
+
+        val profiles = participantService.findOrderedProfiles(partyId)
+        val characterIds = profiles.mapNotNull { it.character?.id }.distinct()
+        val imageUrlByCharacterId =
+            if (characterIds.isEmpty()) emptyMap()
+            else imageRepository
+                .findAllByTargetTypeAndTargetIdsOrderByTargetIdAndSortOrder(ImageTargetType.CHARACTER, characterIds)
+                .filter { it.sortOrder == CHARACTER_IMAGE_SORT_ORDER }
+                .associate { it.targetId to it.imageUrl }
+
+        val items = profiles.mapIndexed { index, profile ->
+            val participant = profile.participant
+            PartyParticipantResult(
+                participantId = participant.id,
+                joinOrder = index + 1,
+                nickname = profile.nickname,
+                characterId = profile.character?.id,
+                characterImageUrl = profile.character?.id?.let { imageUrlByCharacterId[it] },
+                isOwner = participant.user?.id == party.ownerId,
+                isCelebrant = participant.isCelebrant,
+                isMe = participant.user?.id == userId,
+            )
+        }
+        return PartyParticipantsResult(
+            totalCount = items.size,
+            maxCount = RealtimeParty.MAX_PARTICIPANTS,
+            participants = items,
+        )
+    }
+
+    private companion object {
+        private const val CHARACTER_IMAGE_SORT_ORDER = 0
+    }
+}
+```
+
+- 60줄 이내, 의존성 3개 — `layered-architecture.md` 제약 만족.
+
+## 7. 테스트 전략
+
+`docs/testing-rules.md` 준수: `@SpringBootTest` / `@DataJpaTest` 는 반드시 `TestcontainersConfiguration` 경유.
+
+### Controller 통합 테스트 (`@SpringBootTest`)
+
+| 케이스 | 기대 |
+|---|---|
+| 주최자 호출 (참가자 4명) | 200, `isOwner=true` 1건, 응답 순서 `joinOrder` 1..4 |
+| 일반 참가자 호출 | 200, 본인 `isMe=true` 1건만 |
+| 참가자 1명만 (주최자 단독) | 200, totalCount=1 |
+| 참가자 14명 (가득) | 200, totalCount=14, maxCount=14 |
+| 비참가자 호출 | 403, PARTY_FORBIDDEN |
+| PaperOnly 파티 | 400, PARTY_NOT_REALTIME |
+| 존재하지 않는 partyId | 404, PARTY_NOT_FOUND |
+| Authorization 헤더 없음 | 401, AUTH_UNAUTHORIZED |
+
+### Repository 테스트 (`@DataJpaTest` + Testcontainers)
+
+- `findAllByPartyIdOrderByParticipantIdAsc`: 순서 검증
+- N+1 확인: Hibernate Statistics 로 쿼리 수 ≤ 2 (메인 + 이미지 배치)
+
+### UseCase 단위 테스트
+
+- 권한 분기 (mock service): 비참가자 → PARTY_FORBIDDEN
+- 옵션 분기 (mock service): PaperOnly → PARTY_NOT_REALTIME
+- 캐릭터 없는 익명 참가자: `characterImageUrl=null`
+
+## 8. 마이그레이션 / 운영
+
+- DB 스키마 변경 없음
+- Flyway 마이그레이션 없음
+- 새 ErrorCode 만 enum 추가 → 백워드 호환
+
+## 9. 검토 체크리스트 (구현 전)
+
+- [ ] `ParticipantService` 의존성 5개 이내 (현재 1개 → 2개로 증가, 여유 충분)
+- [ ] `PartyService` 의존성 4개 이내? (`PartyService` 는 Service 라 의존성 4개 이내) — 현재 8개로 이미 초과 상태이므로 본 PR 에서는 메서드만 추가, 의존성 추가 없음
+- [ ] UseCase 60줄·의존성 5개 이내
+- [ ] 모든 통합 테스트 `TestcontainersConfiguration` 사용
+- [ ] N+1 없음
+
+> **주의**: `PartyService` 의존성이 이미 8개로 layered-architecture 규칙(4개 이내) 초과 상태. 본 PR 에서는 메서드 추가만 수행하고 의존성은 추가하지 않음. 의존성 정리는 별도 refactor PR 로 분리.

--- a/docs/superpowers/specs/2026-05-14-party-participants-list-design.md
+++ b/docs/superpowers/specs/2026-05-14-party-participants-list-design.md
@@ -30,8 +30,12 @@
 
 ```
 GET /api/v1/parties/{partyId}/participants
-Authorization: Bearer <jwt>      # 필수
+Authorization: Bearer <jwt>      # 로그인 사용자
+X-Participant-Token: <token>     # 비로그인 참가자
 ```
+
+- 로그인 사용자는 `Authorization: Bearer <jwt>` 헤더를, 비로그인 참가자는 `X-Participant-Token: <participantToken>` 헤더를 사용한다. 둘 중 하나는 반드시 포함해야 한다.
+- 두 헤더가 모두 있으면 `Authorization` 헤더 우선.
 
 ### Path Variable
 
@@ -83,11 +87,11 @@ Authorization: Bearer <jwt>      # 필수
 | participants[].participantId | Long | 식별자 |
 | participants[].joinOrder | Int | 1..N, 서버가 `participant.id ASC` 기준으로 부여 |
 | participants[].nickname | String | `RealtimeParticipantProfile.nickname` |
-| participants[].characterId | Long | `Character.id` |
+| participants[].characterId | Long? | `Character.id`. 익명 참가자는 character 없을 수 있음 → null |
 | participants[].characterImageUrl | String? | sortOrder=0 이미지 (`ImageRepository` 배치 조회) |
 | participants[].isOwner | Boolean | `participant.user?.id == party.ownerId` |
 | participants[].isCelebrant | Boolean | `participant.isCelebrant` |
-| participants[].isMe | Boolean | `participant.user?.id == 호출자 userId` |
+| participants[].isMe | Boolean | `participant.id == 호출자의 participantId` (JWT 호출자는 partyId+userId 조회, 토큰 호출자는 토큰으로 식별된 participant) |
 
 > `isOwner` / `isCelebrant` 는 현재 항상 동일하지만 향후 "남이 대신 만든 파티" 시나리오에 대비해 분리. 클라이언트 측 UI 룰(모자 표시 vs 주인공 표시)을 독립적으로 매핑할 수 있음.
 
@@ -95,10 +99,13 @@ Authorization: Bearer <jwt>      # 필수
 
 | 상황 | HTTP | code | message |
 |---|---|---|---|
-| 미인증 | 401 | AUTH_UNAUTHORIZED | 인증이 필요합니다 |
-| 존재하지 않는 partyId | 404 | PARTY_NOT_FOUND | 파티를 찾을 수 없습니다 |
-| PaperOnly 파티 | 400 | **PARTY_NOT_REALTIME** *(신규)* | 실시간 파티가 아닙니다 |
+| JWT/토큰 모두 없음 | 401 | UNAUTHORIZED | 로그인이 필요합니다 |
+| 잘못된 토큰 / 다른 파티의 토큰 | 403 | PARTY_FORBIDDEN | 파티에 대한 권한이 없습니다 |
 | 참가자 아닌 사용자 | 403 | PARTY_FORBIDDEN | 파티에 대한 권한이 없습니다 |
+| 존재하지 않는 partyId | 403 | PARTY_FORBIDDEN | 파티에 대한 권한이 없습니다 |
+| 참가자가 호출한 PaperOnly 파티 | 400 | **PARTY_NOT_REALTIME** *(신규)* | 실시간 파티가 아닙니다 |
+
+> 인가 → 파티 타입 검사 순서: 비참가자가 PaperOnly 파티 / 존재하지 않는 파티를 호출하면 파티 타입(400) / 존재 여부(404)가 아닌 인가 실패(403)로 응답한다. 비참가자에게 리소스 속성·존재 여부를 노출하지 않기 위함.
 
 ## 4. 레이어드 아키텍처 매핑
 
@@ -107,8 +114,8 @@ ParticipantController              (api)
         │ invoke
 GetPartyParticipantsUseCase        (application/usecase, @Transactional(readOnly = true))
         │
-        ├─ PartyService.requireRealtimeParty(partyId)        → RealtimeParty
-        ├─ ParticipantService.requireParticipant(partyId, userId)
+        ├─ ParticipantService.requireCallerParticipantId(partyId, userId?, participantToken?) → Long  (인가 먼저)
+        ├─ PartyService.requireRealtimeParty(partyId)        → RealtimeParty           (인가 후 파티 타입 검사)
         ├─ ParticipantService.findOrderedProfiles(partyId)   → List<RealtimeParticipantProfile>
         └─ ImageRepository.findAllByTargetTypeAndTargetIdsOrderByTargetIdAndSortOrder(CHARACTER, ids)
 ```
@@ -141,7 +148,8 @@ GetPartyParticipantsUseCase        (application/usecase, @Transactional(readOnly
 | `common/exception/ErrorCode.kt` | `PARTY_NOT_REALTIME(BAD_REQUEST, "실시간 파티가 아닙니다")` 추가 |
 | `party/domain/entity/RealtimeParty.kt` | `const val MAX_PARTICIPANTS = 14` 추가 |
 | `party/application/service/PartyService.kt` | `requireRealtimeParty(partyId): RealtimeParty` 추가 (status 무관) |
-| `party/application/service/ParticipantService.kt` | `requireParticipant(partyId, userId)` 추가 / `findOrderedProfiles(partyId): List<RealtimeParticipantProfile>` 추가 |
+| `party/application/service/ParticipantService.kt` | `requireCallerParticipantId(partyId, userId?, participantToken?): Long` 추가 / `findOrderedProfiles(partyId): List<RealtimeParticipantProfile>` 추가 |
+| `auth/config/SecurityConfig.kt` | `GET /api/v1/parties/*/participants` → `permitAll` (토큰 인증을 UseCase 내부에서 검증하므로 필터 우회) |
 | `party/infrastructure/persistence/RealtimeParticipantProfileRepository.kt` | `findAllByPartyIdOrderByParticipantIdAsc(partyId)` JPQL JOIN FETCH 쿼리 추가 |
 
 ### Repository 쿼리
@@ -184,15 +192,34 @@ fun requireRealtimeParty(partyId: Long): RealtimeParty {
 - 기존 `findActiveRealtimeParty` 와 다름: LIVE_OPEN 상태 강제하지 않음 (시작 전 화면용)
 - `findParty` private → 재사용
 
-**`ParticipantService.requireParticipant`**
+**`ParticipantService.requireCallerParticipantId`**
 
 ```kotlin
-fun requireParticipant(partyId: Long, userId: Long) {
-    if (!participantRepository.existsByPartyIdAndUserId(partyId, userId)) {
-        throw BusinessException(ErrorCode.PARTY_FORBIDDEN)
+fun requireCallerParticipantId(
+    partyId: Long,
+    userId: Long?,
+    participantToken: String?,
+): Long {
+    if (userId != null) {
+        val participant = participantRepository.findByPartyIdAndUserId(partyId, userId)
+            ?: throw BusinessException(ErrorCode.PARTY_FORBIDDEN)
+        return participant.id
     }
+    if (participantToken != null) {
+        val profile = realtimeParticipantProfileRepository.findByParticipantToken(participantToken)
+            ?: throw BusinessException(ErrorCode.PARTY_FORBIDDEN)
+        if (profile.participant.party.id != partyId) {
+            throw BusinessException(ErrorCode.PARTY_FORBIDDEN)
+        }
+        return profile.participant.id
+    }
+    throw BusinessException(ErrorCode.UNAUTHORIZED)
 }
 ```
+
+- JWT 호출자: `partyId + userId` 로 participant 조회 → 없으면 `403 PARTY_FORBIDDEN`
+- 토큰 호출자: 토큰으로 profile 조회 후 partyId 일치 검사 → 불일치/없음이면 `403 PARTY_FORBIDDEN`
+- 둘 다 없으면 `401 UNAUTHORIZED`
 
 **`ParticipantService.findOrderedProfiles`**
 
@@ -213,9 +240,14 @@ class GetPartyParticipantsUseCase(
     private val imageRepository: ImageRepository,
 ) {
     @Transactional(readOnly = true)
-    fun invoke(partyId: Long, userId: Long): PartyParticipantsResult {
+    fun invoke(
+        partyId: Long,
+        userId: Long?,
+        participantToken: String?,
+    ): PartyParticipantsResult {
+        // 인가 먼저 — 비참가자에게 파티 타입(400)을 노출하지 않기 위해
+        val callerParticipantId = participantService.requireCallerParticipantId(partyId, userId, participantToken)
         val party = partyService.requireRealtimeParty(partyId)
-        participantService.requireParticipant(partyId, userId)
 
         val profiles = participantService.findOrderedProfiles(partyId)
         val characterIds = profiles.mapNotNull { it.character?.id }.distinct()
@@ -236,7 +268,7 @@ class GetPartyParticipantsUseCase(
                 characterImageUrl = profile.character?.id?.let { imageUrlByCharacterId[it] },
                 isOwner = participant.user?.id == party.ownerId,
                 isCelebrant = participant.isCelebrant,
-                isMe = participant.user?.id == userId,
+                isMe = participant.id == callerParticipantId,
             )
         }
         return PartyParticipantsResult(
@@ -264,12 +296,15 @@ class GetPartyParticipantsUseCase(
 |---|---|
 | 주최자 호출 (참가자 4명) | 200, `isOwner=true` 1건, 응답 순서 `joinOrder` 1..4 |
 | 일반 참가자 호출 | 200, 본인 `isMe=true` 1건만 |
+| `X-Participant-Token` 호출 (비로그인 참가자) | 200, 토큰 owner의 `isMe=true` |
+| 다른 파티의 `X-Participant-Token` 호출 | 403, PARTY_FORBIDDEN |
 | 참가자 1명만 (주최자 단독) | 200, totalCount=1 |
 | 참가자 14명 (가득) | 200, totalCount=14, maxCount=14 |
-| 비참가자 호출 | 403, PARTY_FORBIDDEN |
-| PaperOnly 파티 | 400, PARTY_NOT_REALTIME |
-| 존재하지 않는 partyId | 404, PARTY_NOT_FOUND |
-| Authorization 헤더 없음 | 401, AUTH_UNAUTHORIZED |
+| 비참가자 호출 (JWT) | 403, PARTY_FORBIDDEN |
+| 비참가자가 PaperOnly 파티 호출 (JWT) | 403, PARTY_FORBIDDEN (인가 우선) |
+| 참가자가 PaperOnly 파티 호출 (JWT) | 400, PARTY_NOT_REALTIME |
+| 존재하지 않는 partyId | 403, PARTY_FORBIDDEN (존재 노출 방지) |
+| 헤더 둘 다 없음 | 401, UNAUTHORIZED |
 
 ### Repository 테스트 (`@DataJpaTest` + Testcontainers)
 

--- a/src/main/kotlin/com/team2/server/auth/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/team2/server/auth/config/SecurityConfig.kt
@@ -62,6 +62,7 @@ class SecurityConfig(
                         "/api/v1/party-invites/*/realtime-participants/stream",
                     ).permitAll()
                 auth.requestMatchers(HttpMethod.POST, "/api/v1/parties/*/chat-messages").permitAll()
+                auth.requestMatchers(HttpMethod.GET, "/api/v1/parties/*/participants").permitAll()
                 auth.anyRequest().authenticated()
             }.oauth2Login { oauth ->
                 oauth.userInfoEndpoint { it.userService(customOAuth2UserService) }

--- a/src/main/kotlin/com/team2/server/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/team2/server/common/exception/ErrorCode.kt
@@ -21,6 +21,7 @@ enum class ErrorCode(
     AUTH_USER_NOT_FOUND(HttpStatus.UNAUTHORIZED, "사용자를 찾을 수 없습니다"),
 
     PARTY_ENDED(HttpStatus.BAD_REQUEST, "이미 종료된 파티입니다"),
+    PARTY_NOT_REALTIME(HttpStatus.BAD_REQUEST, "실시간 파티가 아닙니다"),
     PARTY_ALREADY_STARTED(HttpStatus.CONFLICT, "이미 시작된 파티는 삭제할 수 없습니다"),
     ALREADY_JOINED(HttpStatus.CONFLICT, "이미 참여한 파티입니다"),
     CHARACTER_NOT_FOUND(HttpStatus.NOT_FOUND, "캐릭터를 찾을 수 없습니다"),

--- a/src/main/kotlin/com/team2/server/party/api/ParticipantApi.kt
+++ b/src/main/kotlin/com/team2/server/party/api/ParticipantApi.kt
@@ -1,0 +1,30 @@
+package com.team2.server.party.api
+
+import com.team2.server.auth.principal.UserPrincipal
+import com.team2.server.common.web.ApiResponse
+import com.team2.server.common.web.swagger.AuthErrorResponses
+import com.team2.server.common.web.swagger.ForbiddenResponse
+import com.team2.server.common.web.swagger.InternalServerErrorResponse
+import com.team2.server.party.api.dto.PartyParticipantsResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
+
+@Tag(name = "Party", description = "파티 API")
+interface ParticipantApi {
+    @Operation(
+        summary = "파티 참여자 목록 조회",
+        description = "실시간 파티 진행 기본화면용. 입장 순서로 정렬된 참여자 목록을 반환한다. RealtimeParty 전용, 참여자만 조회 가능.",
+        security = [SecurityRequirement(name = "Bearer Authentication")],
+    )
+    @SwaggerApiResponse(responseCode = "200", description = "참여자 목록 조회 성공")
+    @AuthErrorResponses
+    @ForbiddenResponse
+    @InternalServerErrorResponse
+    fun getPartyParticipants(
+        @Parameter(hidden = true) principal: UserPrincipal,
+        @Parameter(description = "파티 ID", example = "1") partyId: Long,
+    ): ApiResponse<PartyParticipantsResponse>
+}

--- a/src/main/kotlin/com/team2/server/party/api/ParticipantApi.kt
+++ b/src/main/kotlin/com/team2/server/party/api/ParticipantApi.kt
@@ -8,6 +8,7 @@ import com.team2.server.common.web.swagger.InternalServerErrorResponse
 import com.team2.server.party.api.dto.PartyParticipantsResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.enums.ParameterIn
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
@@ -16,7 +17,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
 interface ParticipantApi {
     @Operation(
         summary = "파티 참여자 목록 조회",
-        description = "실시간 파티 진행 기본화면용. 입장 순서로 정렬된 참여자 목록을 반환한다. RealtimeParty 전용, 참여자만 조회 가능.",
+        description = """
+실시간 파티 진행 기본화면용. 입장 순서로 정렬된 참여자 목록을 반환한다. RealtimeParty 전용, 참여자만 조회 가능.
+
+**인증**
+로그인 사용자는 `Authorization: Bearer {token}` 헤더를, 비로그인 참가자는 `X-Participant-Token: {participantToken}` 헤더를 사용한다. 둘 중 하나는 반드시 포함해야 한다.
+""",
         security = [SecurityRequirement(name = "Bearer Authentication")],
     )
     @SwaggerApiResponse(responseCode = "200", description = "참여자 목록 조회 성공")
@@ -24,7 +30,9 @@ interface ParticipantApi {
     @ForbiddenResponse
     @InternalServerErrorResponse
     fun getPartyParticipants(
-        @Parameter(hidden = true) principal: UserPrincipal,
+        @Parameter(hidden = true) principal: UserPrincipal?,
         @Parameter(description = "파티 ID", example = "1") partyId: Long,
+        @Parameter(description = "비로그인 참여자 토큰", `in` = ParameterIn.HEADER, name = "X-Participant-Token")
+        participantToken: String?,
     ): ApiResponse<PartyParticipantsResponse>
 }

--- a/src/main/kotlin/com/team2/server/party/api/ParticipantController.kt
+++ b/src/main/kotlin/com/team2/server/party/api/ParticipantController.kt
@@ -1,0 +1,27 @@
+package com.team2.server.party.api
+
+import com.team2.server.auth.principal.UserPrincipal
+import com.team2.server.common.web.ApiResponse
+import com.team2.server.party.api.dto.PartyParticipantsResponse
+import com.team2.server.party.application.usecase.GetPartyParticipantsUseCase
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/parties")
+class ParticipantController(
+    private val getPartyParticipantsUseCase: GetPartyParticipantsUseCase,
+) : ParticipantApi {
+    @GetMapping("/{partyId}/participants")
+    override fun getPartyParticipants(
+        @AuthenticationPrincipal principal: UserPrincipal,
+        @PathVariable partyId: Long,
+    ): ApiResponse<PartyParticipantsResponse> {
+        val result = getPartyParticipantsUseCase.invoke(partyId = partyId, userId = principal.userId)
+        return ApiResponse.success(HttpStatus.OK, PartyParticipantsResponse.from(result))
+    }
+}

--- a/src/main/kotlin/com/team2/server/party/api/ParticipantController.kt
+++ b/src/main/kotlin/com/team2/server/party/api/ParticipantController.kt
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -18,10 +19,16 @@ class ParticipantController(
 ) : ParticipantApi {
     @GetMapping("/{partyId}/participants")
     override fun getPartyParticipants(
-        @AuthenticationPrincipal principal: UserPrincipal,
+        @AuthenticationPrincipal principal: UserPrincipal?,
         @PathVariable partyId: Long,
+        @RequestHeader(value = "X-Participant-Token", required = false) participantToken: String?,
     ): ApiResponse<PartyParticipantsResponse> {
-        val result = getPartyParticipantsUseCase.invoke(partyId = partyId, userId = principal.userId)
+        val result =
+            getPartyParticipantsUseCase.invoke(
+                partyId = partyId,
+                userId = principal?.userId,
+                participantToken = participantToken,
+            )
         return ApiResponse.success(HttpStatus.OK, PartyParticipantsResponse.from(result))
     }
 }

--- a/src/main/kotlin/com/team2/server/party/api/dto/PartyParticipantResponse.kt
+++ b/src/main/kotlin/com/team2/server/party/api/dto/PartyParticipantResponse.kt
@@ -1,0 +1,38 @@
+package com.team2.server.party.api.dto
+
+import com.team2.server.party.application.dto.PartyParticipantResult
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "파티 참여자 항목")
+data class PartyParticipantResponse(
+    @Schema(description = "참여자 ID", example = "17")
+    val participantId: Long,
+    @Schema(description = "입장 순서 (1부터)", example = "1")
+    val joinOrder: Int,
+    @Schema(description = "닉네임", example = "주최자닉")
+    val nickname: String,
+    @Schema(description = "캐릭터 ID", example = "3", nullable = true)
+    val characterId: Long?,
+    @Schema(description = "캐릭터 메인 이미지 URL", nullable = true)
+    val characterImageUrl: String?,
+    @Schema(description = "파티 주최자 여부", example = "true")
+    val isOwner: Boolean,
+    @Schema(description = "파티 주인공 여부", example = "true")
+    val isCelebrant: Boolean,
+    @Schema(description = "조회자 본인 여부", example = "false")
+    val isMe: Boolean,
+) {
+    companion object {
+        fun from(result: PartyParticipantResult): PartyParticipantResponse =
+            PartyParticipantResponse(
+                participantId = result.participantId,
+                joinOrder = result.joinOrder,
+                nickname = result.nickname,
+                characterId = result.characterId,
+                characterImageUrl = result.characterImageUrl,
+                isOwner = result.isOwner,
+                isCelebrant = result.isCelebrant,
+                isMe = result.isMe,
+            )
+    }
+}

--- a/src/main/kotlin/com/team2/server/party/api/dto/PartyParticipantsResponse.kt
+++ b/src/main/kotlin/com/team2/server/party/api/dto/PartyParticipantsResponse.kt
@@ -1,0 +1,23 @@
+package com.team2.server.party.api.dto
+
+import com.team2.server.party.application.dto.PartyParticipantsResult
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "파티 참여자 목록 응답")
+data class PartyParticipantsResponse(
+    @Schema(description = "현재 참여자 수", example = "4")
+    val totalCount: Int,
+    @Schema(description = "최대 참여자 수", example = "14")
+    val maxCount: Int,
+    @Schema(description = "입장 순서대로 정렬된 참여자 목록")
+    val participants: List<PartyParticipantResponse>,
+) {
+    companion object {
+        fun from(result: PartyParticipantsResult): PartyParticipantsResponse =
+            PartyParticipantsResponse(
+                totalCount = result.totalCount,
+                maxCount = result.maxCount,
+                participants = result.participants.map(PartyParticipantResponse::from),
+            )
+    }
+}

--- a/src/main/kotlin/com/team2/server/party/application/dto/PartyParticipantResult.kt
+++ b/src/main/kotlin/com/team2/server/party/application/dto/PartyParticipantResult.kt
@@ -1,0 +1,12 @@
+package com.team2.server.party.application.dto
+
+data class PartyParticipantResult(
+    val participantId: Long,
+    val joinOrder: Int,
+    val nickname: String,
+    val characterId: Long?,
+    val characterImageUrl: String?,
+    val isOwner: Boolean,
+    val isCelebrant: Boolean,
+    val isMe: Boolean,
+)

--- a/src/main/kotlin/com/team2/server/party/application/dto/PartyParticipantsResult.kt
+++ b/src/main/kotlin/com/team2/server/party/application/dto/PartyParticipantsResult.kt
@@ -1,0 +1,7 @@
+package com.team2.server.party.application.dto
+
+data class PartyParticipantsResult(
+    val totalCount: Int,
+    val maxCount: Int,
+    val participants: List<PartyParticipantResult>,
+)

--- a/src/main/kotlin/com/team2/server/party/application/service/ParticipantService.kt
+++ b/src/main/kotlin/com/team2/server/party/application/service/ParticipantService.kt
@@ -34,13 +34,35 @@ class ParticipantService(
         participantRepository.findByPartyIdAndUserId(party.id, userId)
             ?: participantRepository.save(Participant(party = party, user = user))
 
-    fun requireParticipant(
+    fun requireCallerParticipantId(
+        partyId: Long,
+        userId: Long?,
+        participantToken: String?,
+    ): Long =
+        when {
+            userId != null -> resolveCallerByUser(partyId, userId)
+            participantToken != null -> resolveCallerByToken(partyId, participantToken)
+            else -> throw BusinessException(ErrorCode.UNAUTHORIZED)
+        }
+
+    private fun resolveCallerByUser(
         partyId: Long,
         userId: Long,
-    ) {
-        if (!participantRepository.existsByPartyIdAndUserId(partyId, userId)) {
+    ): Long =
+        participantRepository.findByPartyIdAndUserId(partyId, userId)?.id
+            ?: throw BusinessException(ErrorCode.PARTY_FORBIDDEN)
+
+    private fun resolveCallerByToken(
+        partyId: Long,
+        participantToken: String,
+    ): Long {
+        val profile =
+            realtimeParticipantProfileRepository.findByParticipantToken(participantToken)
+                ?: throw BusinessException(ErrorCode.PARTY_FORBIDDEN)
+        if (profile.participant.party.id != partyId) {
             throw BusinessException(ErrorCode.PARTY_FORBIDDEN)
         }
+        return profile.participant.id
     }
 
     fun findOrderedProfiles(partyId: Long): List<RealtimeParticipantProfile> =

--- a/src/main/kotlin/com/team2/server/party/application/service/ParticipantService.kt
+++ b/src/main/kotlin/com/team2/server/party/application/service/ParticipantService.kt
@@ -1,9 +1,13 @@
 package com.team2.server.party.application.service
 
+import com.team2.server.common.exception.BusinessException
+import com.team2.server.common.exception.ErrorCode
 import com.team2.server.common.exception.isConstraintViolation
 import com.team2.server.party.domain.entity.Participant
 import com.team2.server.party.domain.entity.Party
+import com.team2.server.party.domain.entity.RealtimeParticipantProfile
 import com.team2.server.party.infrastructure.persistence.ParticipantRepository
+import com.team2.server.party.infrastructure.persistence.RealtimeParticipantProfileRepository
 import com.team2.server.user.entity.User
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
@@ -11,6 +15,7 @@ import org.springframework.stereotype.Service
 @Service
 class ParticipantService(
     private val participantRepository: ParticipantRepository,
+    private val realtimeParticipantProfileRepository: RealtimeParticipantProfileRepository,
 ) {
     fun joinMember(
         party: Party,
@@ -28,6 +33,18 @@ class ParticipantService(
     ): Participant =
         participantRepository.findByPartyIdAndUserId(party.id, userId)
             ?: participantRepository.save(Participant(party = party, user = user))
+
+    fun requireParticipant(
+        partyId: Long,
+        userId: Long,
+    ) {
+        if (!participantRepository.existsByPartyIdAndUserId(partyId, userId)) {
+            throw BusinessException(ErrorCode.PARTY_FORBIDDEN)
+        }
+    }
+
+    fun findOrderedProfiles(partyId: Long): List<RealtimeParticipantProfile> =
+        realtimeParticipantProfileRepository.findAllByPartyIdOrderByParticipantIdAsc(partyId)
 
     private fun createMemberParticipant(
         party: Party,

--- a/src/main/kotlin/com/team2/server/party/application/service/PartyService.kt
+++ b/src/main/kotlin/com/team2/server/party/application/service/PartyService.kt
@@ -119,14 +119,22 @@ class PartyService(
         val party =
             partyRepository.findPartyById(partyId)
                 ?: throw BusinessException(ErrorCode.PARTY_NOT_FOUND)
-        val realtimeParty = requireRealtimeParty(party)
+        val realtimeParty = requireRealtimePartyForChat(party)
         if (realtimeParty.status() != RealtimePartyStatus.LIVE_OPEN) {
             throw BusinessException(ErrorCode.CHAT_NOT_ACTIVE)
         }
         return realtimeParty
     }
 
-    private fun requireRealtimeParty(party: Party): RealtimeParty {
+    fun requireRealtimeParty(partyId: Long): RealtimeParty {
+        val party = findParty(partyId)
+        if (party.partyOption != PartyOption.REALTIME) {
+            throw BusinessException(ErrorCode.PARTY_NOT_REALTIME)
+        }
+        return Hibernate.unproxy(party) as RealtimeParty
+    }
+
+    private fun requireRealtimePartyForChat(party: Party): RealtimeParty {
         if (party.partyOption != PartyOption.REALTIME) {
             throw BusinessException(ErrorCode.CHAT_NOT_SUPPORTED)
         }

--- a/src/main/kotlin/com/team2/server/party/application/usecase/GetPartyParticipantsUseCase.kt
+++ b/src/main/kotlin/com/team2/server/party/application/usecase/GetPartyParticipantsUseCase.kt
@@ -19,10 +19,11 @@ class GetPartyParticipantsUseCase(
     @Transactional(readOnly = true)
     fun invoke(
         partyId: Long,
-        userId: Long,
+        userId: Long?,
+        participantToken: String?,
     ): PartyParticipantsResult {
+        val callerParticipantId = participantService.requireCallerParticipantId(partyId, userId, participantToken)
         val party = partyService.requireRealtimeParty(partyId)
-        participantService.requireParticipant(partyId, userId)
 
         val profiles = participantService.findOrderedProfiles(partyId)
         val characterIds = profiles.mapNotNull { it.character?.id }.distinct()
@@ -47,7 +48,7 @@ class GetPartyParticipantsUseCase(
                     characterImageUrl = profile.character?.id?.let { imageUrlByCharacterId[it] },
                     isOwner = participant.user?.id == party.ownerId,
                     isCelebrant = participant.isCelebrant,
-                    isMe = participant.user?.id == userId,
+                    isMe = participant.id == callerParticipantId,
                 )
             }
         return PartyParticipantsResult(

--- a/src/main/kotlin/com/team2/server/party/application/usecase/GetPartyParticipantsUseCase.kt
+++ b/src/main/kotlin/com/team2/server/party/application/usecase/GetPartyParticipantsUseCase.kt
@@ -1,0 +1,63 @@
+package com.team2.server.party.application.usecase
+
+import com.team2.server.common.image.entity.ImageTargetType
+import com.team2.server.common.image.persistence.ImageRepository
+import com.team2.server.party.application.dto.PartyParticipantResult
+import com.team2.server.party.application.dto.PartyParticipantsResult
+import com.team2.server.party.application.service.ParticipantService
+import com.team2.server.party.application.service.PartyService
+import com.team2.server.party.domain.entity.RealtimeParty
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class GetPartyParticipantsUseCase(
+    private val partyService: PartyService,
+    private val participantService: ParticipantService,
+    private val imageRepository: ImageRepository,
+) {
+    @Transactional(readOnly = true)
+    fun invoke(
+        partyId: Long,
+        userId: Long,
+    ): PartyParticipantsResult {
+        val party = partyService.requireRealtimeParty(partyId)
+        participantService.requireParticipant(partyId, userId)
+
+        val profiles = participantService.findOrderedProfiles(partyId)
+        val characterIds = profiles.mapNotNull { it.character?.id }.distinct()
+        val imageUrlByCharacterId =
+            if (characterIds.isEmpty()) {
+                emptyMap()
+            } else {
+                imageRepository
+                    .findAllByTargetTypeAndTargetIdsOrderByTargetIdAndSortOrder(ImageTargetType.CHARACTER, characterIds)
+                    .filter { it.sortOrder == CHARACTER_IMAGE_SORT_ORDER }
+                    .associate { it.targetId to it.imageUrl }
+            }
+
+        val items =
+            profiles.mapIndexed { index, profile ->
+                val participant = profile.participant
+                PartyParticipantResult(
+                    participantId = participant.id,
+                    joinOrder = index + 1,
+                    nickname = profile.nickname,
+                    characterId = profile.character?.id,
+                    characterImageUrl = profile.character?.id?.let { imageUrlByCharacterId[it] },
+                    isOwner = participant.user?.id == party.ownerId,
+                    isCelebrant = participant.isCelebrant,
+                    isMe = participant.user?.id == userId,
+                )
+            }
+        return PartyParticipantsResult(
+            totalCount = items.size,
+            maxCount = RealtimeParty.MAX_PARTICIPANTS,
+            participants = items,
+        )
+    }
+
+    private companion object {
+        private const val CHARACTER_IMAGE_SORT_ORDER = 0
+    }
+}

--- a/src/main/kotlin/com/team2/server/party/domain/entity/RealtimeParty.kt
+++ b/src/main/kotlin/com/team2/server/party/domain/entity/RealtimeParty.kt
@@ -33,6 +33,7 @@ class RealtimeParty(
     companion object {
         const val LIVE_DURATION_MINUTES: Long = 10
         const val ENTERABLE_BEFORE_MINUTES: Long = 5
+        const val MAX_PARTICIPANTS: Int = 14
     }
 }
 

--- a/src/main/kotlin/com/team2/server/party/infrastructure/persistence/RealtimeParticipantProfileRepository.kt
+++ b/src/main/kotlin/com/team2/server/party/infrastructure/persistence/RealtimeParticipantProfileRepository.kt
@@ -4,6 +4,7 @@ import com.team2.server.party.domain.entity.Participant
 import com.team2.server.party.domain.entity.RealtimeParticipantProfile
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 
 interface RealtimeParticipantProfileRepository : JpaRepository<RealtimeParticipantProfile, Long> {
     fun findByParticipant(participant: Participant): RealtimeParticipantProfile?
@@ -12,4 +13,17 @@ interface RealtimeParticipantProfileRepository : JpaRepository<RealtimeParticipa
 
     @Modifying
     fun deleteAllByParticipantIdIn(participantIds: List<Long>)
+
+    @Query(
+        """
+        SELECT rpp
+        FROM RealtimeParticipantProfile rpp
+        JOIN FETCH rpp.participant participant
+        LEFT JOIN FETCH participant.user
+        LEFT JOIN FETCH rpp.character
+        WHERE participant.party.id = :partyId
+        ORDER BY participant.id ASC
+        """,
+    )
+    fun findAllByPartyIdOrderByParticipantIdAsc(partyId: Long): List<RealtimeParticipantProfile>
 }

--- a/src/test/kotlin/com/team2/server/party/api/ParticipantControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/party/api/ParticipantControllerTest.kt
@@ -19,6 +19,7 @@ import com.team2.server.user.entity.AuthProvider
 import com.team2.server.user.entity.User
 import com.team2.server.user.repository.UserRepository
 import org.hamcrest.Matchers.hasSize
+import org.hamcrest.Matchers.nullValue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -190,6 +191,77 @@ class ParticipantControllerTest
                 .get("/api/v1/parties/${realtimeParty.id}/participants")
                 .andExpect {
                     status { isUnauthorized() }
+                }
+        }
+
+        @Test
+        fun `참가자가 주최자 1명뿐이어도 totalCount는 1이고 maxCount는 14다`() {
+            val soloOwner = saveUser("participant-solo-owner", "solo-owner@e.com")
+            val soloParty =
+                partyRepository.save(
+                    RealtimeParty(
+                        ownerId = soloOwner.id,
+                        celebrantNickname = "혼자",
+                        startedAt = LocalDateTime.now().plusHours(2),
+                    ),
+                )
+            val character = characterRepository.save(Character(name = "solo-char"))
+            val participant =
+                participantRepository.save(Participant(party = soloParty, user = soloOwner, isCelebrant = true))
+            realtimeParticipantProfileRepository.save(
+                RealtimeParticipantProfile(participant = participant, nickname = "혼자", character = character),
+            )
+            val token = tokenProvider.issue(soloOwner)
+
+            mockMvc
+                .get("/api/v1/parties/${soloParty.id}/participants") {
+                    header("Authorization", "Bearer $token")
+                }.andExpect {
+                    status { isOk() }
+                    jsonPath("$.data.totalCount") { value(1) }
+                    jsonPath("$.data.maxCount") { value(14) }
+                    jsonPath("$.data.participants", hasSize<Any>(1))
+                    jsonPath("$.data.participants[0].joinOrder") { value(1) }
+                    jsonPath("$.data.participants[0].isOwner") { value(true) }
+                    jsonPath("$.data.participants[0].isMe") { value(true) }
+                }
+        }
+
+        @Test
+        fun `익명 참가자와 캐릭터 없는 프로필도 응답에 포함된다`() {
+            val anonymousProfileParty =
+                partyRepository.save(
+                    RealtimeParty(
+                        ownerId = owner.id,
+                        celebrantNickname = "익명포함",
+                        startedAt = LocalDateTime.now().plusHours(3),
+                    ),
+                )
+            val character = characterRepository.save(Character(name = "anon-char"))
+            val ownerP =
+                participantRepository.save(
+                    Participant(party = anonymousProfileParty, user = owner, isCelebrant = true),
+                )
+            realtimeParticipantProfileRepository.save(
+                RealtimeParticipantProfile(participant = ownerP, nickname = "주최자", character = character),
+            )
+            val anonymousP = participantRepository.save(Participant(party = anonymousProfileParty, user = null))
+            realtimeParticipantProfileRepository.save(
+                RealtimeParticipantProfile(participant = anonymousP, nickname = "익명", character = null),
+            )
+            val token = tokenProvider.issue(owner)
+
+            mockMvc
+                .get("/api/v1/parties/${anonymousProfileParty.id}/participants") {
+                    header("Authorization", "Bearer $token")
+                }.andExpect {
+                    status { isOk() }
+                    jsonPath("$.data.totalCount") { value(2) }
+                    jsonPath("$.data.participants[1].nickname") { value("익명") }
+                    jsonPath("$.data.participants[1].characterId") { value(nullValue()) }
+                    jsonPath("$.data.participants[1].characterImageUrl") { value(nullValue()) }
+                    jsonPath("$.data.participants[1].isOwner") { value(false) }
+                    jsonPath("$.data.participants[1].isMe") { value(false) }
                 }
         }
 

--- a/src/test/kotlin/com/team2/server/party/api/ParticipantControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/party/api/ParticipantControllerTest.kt
@@ -52,6 +52,7 @@ class ParticipantControllerTest
         private lateinit var outsider: User
         private lateinit var realtimeParty: RealtimeParty
         private lateinit var paperOnlyParty: PaperOnlyParty
+        private lateinit var memberProfile: RealtimeParticipantProfile
 
         @BeforeEach
         fun setUp() {
@@ -100,9 +101,14 @@ class ParticipantControllerTest
             )
             val memberParticipant =
                 participantRepository.save(Participant(party = realtimeParty, user = member, isCelebrant = false))
-            realtimeParticipantProfileRepository.save(
-                RealtimeParticipantProfile(participant = memberParticipant, nickname = "참가자A", character = character),
-            )
+            memberProfile =
+                realtimeParticipantProfileRepository.save(
+                    RealtimeParticipantProfile(
+                        participant = memberParticipant,
+                        nickname = "참가자A",
+                        character = character,
+                    ),
+                )
         }
 
         @Test
@@ -146,6 +152,49 @@ class ParticipantControllerTest
         }
 
         @Test
+        fun `X-Participant-Token 헤더로 비로그인 참가자가 조회 시 토큰 owner의 isMe만 true 다`() {
+            mockMvc
+                .get("/api/v1/parties/${realtimeParty.id}/participants") {
+                    header("X-Participant-Token", memberProfile.participantToken)
+                }.andExpect {
+                    status { isOk() }
+                    jsonPath("$.data.participants[0].isMe") { value(false) }
+                    jsonPath("$.data.participants[1].isMe") { value(true) }
+                }
+        }
+
+        @Test
+        fun `다른 파티의 X-Participant-Token으로 호출 시 403 PARTY_FORBIDDEN`() {
+            val otherParty =
+                partyRepository.save(
+                    RealtimeParty(
+                        ownerId = outsider.id,
+                        celebrantNickname = "다른파티",
+                        startedAt = LocalDateTime.now().plusDays(1),
+                    ),
+                )
+
+            mockMvc
+                .get("/api/v1/parties/${otherParty.id}/participants") {
+                    header("X-Participant-Token", memberProfile.participantToken)
+                }.andExpect {
+                    status { isForbidden() }
+                    jsonPath("$.error.code") { value("PARTY_FORBIDDEN") }
+                }
+        }
+
+        @Test
+        fun `존재하지 않는 X-Participant-Token으로 호출 시 403 PARTY_FORBIDDEN`() {
+            mockMvc
+                .get("/api/v1/parties/${realtimeParty.id}/participants") {
+                    header("X-Participant-Token", "deadbeef")
+                }.andExpect {
+                    status { isForbidden() }
+                    jsonPath("$.error.code") { value("PARTY_FORBIDDEN") }
+                }
+        }
+
+        @Test
         fun `비참가자 호출 시 403 PARTY_FORBIDDEN`() {
             val token = tokenProvider.issue(outsider)
 
@@ -159,7 +208,7 @@ class ParticipantControllerTest
         }
 
         @Test
-        fun `PaperOnly 파티 호출 시 400 PARTY_NOT_REALTIME`() {
+        fun `참가자가 PaperOnly 파티 호출 시 400 PARTY_NOT_REALTIME`() {
             participantRepository.save(Participant(party = paperOnlyParty, user = owner, isCelebrant = true))
             val token = tokenProvider.issue(owner)
 
@@ -173,6 +222,19 @@ class ParticipantControllerTest
         }
 
         @Test
+        fun `비참가자가 PaperOnly 파티 호출 시 인가 우선으로 403 PARTY_FORBIDDEN`() {
+            val token = tokenProvider.issue(outsider)
+
+            mockMvc
+                .get("/api/v1/parties/${paperOnlyParty.id}/participants") {
+                    header("Authorization", "Bearer $token")
+                }.andExpect {
+                    status { isForbidden() }
+                    jsonPath("$.error.code") { value("PARTY_FORBIDDEN") }
+                }
+        }
+
+        @Test
         fun `존재하지 않는 파티 호출 시 404 PARTY_NOT_FOUND`() {
             val token = tokenProvider.issue(owner)
 
@@ -180,17 +242,18 @@ class ParticipantControllerTest
                 .get("/api/v1/parties/99999/participants") {
                     header("Authorization", "Bearer $token")
                 }.andExpect {
-                    status { isNotFound() }
-                    jsonPath("$.error.code") { value("PARTY_NOT_FOUND") }
+                    status { isForbidden() }
+                    jsonPath("$.error.code") { value("PARTY_FORBIDDEN") }
                 }
         }
 
         @Test
-        fun `Authorization 헤더 없으면 401`() {
+        fun `Authorization과 X-Participant-Token 모두 없으면 401 UNAUTHORIZED`() {
             mockMvc
                 .get("/api/v1/parties/${realtimeParty.id}/participants")
                 .andExpect {
                     status { isUnauthorized() }
+                    jsonPath("$.error.code") { value("UNAUTHORIZED") }
                 }
         }
 

--- a/src/test/kotlin/com/team2/server/party/api/ParticipantControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/party/api/ParticipantControllerTest.kt
@@ -1,0 +1,209 @@
+package com.team2.server.party.api
+
+import com.team2.server.auth.config.JwtProperties
+import com.team2.server.auth.jwt.JwtTokenProvider
+import com.team2.server.common.image.entity.Image
+import com.team2.server.common.image.entity.ImageTargetType
+import com.team2.server.common.image.persistence.ImageRepository
+import com.team2.server.config.TestcontainersConfiguration
+import com.team2.server.party.domain.entity.Character
+import com.team2.server.party.domain.entity.PaperOnlyParty
+import com.team2.server.party.domain.entity.Participant
+import com.team2.server.party.domain.entity.RealtimeParticipantProfile
+import com.team2.server.party.domain.entity.RealtimeParty
+import com.team2.server.party.infrastructure.persistence.CharacterRepository
+import com.team2.server.party.infrastructure.persistence.ParticipantRepository
+import com.team2.server.party.infrastructure.persistence.PartyRepository
+import com.team2.server.party.infrastructure.persistence.RealtimeParticipantProfileRepository
+import com.team2.server.user.entity.AuthProvider
+import com.team2.server.user.entity.User
+import com.team2.server.user.repository.UserRepository
+import org.hamcrest.Matchers.hasSize
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.context.annotation.Import
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import java.time.LocalDateTime
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import(TestcontainersConfiguration::class)
+class ParticipantControllerTest
+    @Autowired
+    constructor(
+        private val mockMvc: MockMvc,
+        private val partyRepository: PartyRepository,
+        private val participantRepository: ParticipantRepository,
+        private val realtimeParticipantProfileRepository: RealtimeParticipantProfileRepository,
+        private val characterRepository: CharacterRepository,
+        private val imageRepository: ImageRepository,
+        private val userRepository: UserRepository,
+        private val jwtProperties: JwtProperties,
+    ) {
+        private val tokenProvider = JwtTokenProvider(jwtProperties)
+
+        private lateinit var owner: User
+        private lateinit var member: User
+        private lateinit var outsider: User
+        private lateinit var realtimeParty: RealtimeParty
+        private lateinit var paperOnlyParty: PaperOnlyParty
+
+        @BeforeEach
+        fun setUp() {
+            realtimeParticipantProfileRepository.deleteAll()
+            participantRepository.deleteAll()
+            partyRepository.deleteAll()
+            imageRepository.deleteAll()
+            characterRepository.deleteAll()
+            userRepository.deleteAll()
+
+            owner = saveUser("participant-owner", "owner@e.com")
+            member = saveUser("participant-member", "member@e.com")
+            outsider = saveUser("participant-outsider", "outsider@e.com")
+
+            realtimeParty =
+                partyRepository.save(
+                    RealtimeParty(
+                        ownerId = owner.id,
+                        celebrantNickname = "주최자",
+                        startedAt = LocalDateTime.now().plusHours(1),
+                    ),
+                )
+            paperOnlyParty =
+                partyRepository.save(
+                    PaperOnlyParty(
+                        ownerId = owner.id,
+                        celebrantNickname = "롤링",
+                        startedAt = LocalDateTime.now().plusDays(1),
+                    ),
+                )
+
+            val character = characterRepository.save(Character(name = "octopus"))
+            imageRepository.save(
+                Image(
+                    imageUrl = "https://cdn/char.png",
+                    targetType = ImageTargetType.CHARACTER,
+                    targetId = character.id,
+                    sortOrder = 0,
+                ),
+            )
+
+            val ownerParticipant =
+                participantRepository.save(Participant(party = realtimeParty, user = owner, isCelebrant = true))
+            realtimeParticipantProfileRepository.save(
+                RealtimeParticipantProfile(participant = ownerParticipant, nickname = "주최자", character = character),
+            )
+            val memberParticipant =
+                participantRepository.save(Participant(party = realtimeParty, user = member, isCelebrant = false))
+            realtimeParticipantProfileRepository.save(
+                RealtimeParticipantProfile(participant = memberParticipant, nickname = "참가자A", character = character),
+            )
+        }
+
+        @Test
+        fun `주최자 호출 시 200과 입장 순서대로 정렬된 목록을 반환한다`() {
+            val token = tokenProvider.issue(owner)
+
+            mockMvc
+                .get("/api/v1/parties/${realtimeParty.id}/participants") {
+                    header("Authorization", "Bearer $token")
+                }.andExpect {
+                    status { isOk() }
+                    jsonPath("$.data.totalCount") { value(2) }
+                    jsonPath("$.data.maxCount") { value(14) }
+                    jsonPath("$.data.participants", hasSize<Any>(2))
+                    jsonPath("$.data.participants[0].joinOrder") { value(1) }
+                    jsonPath("$.data.participants[0].nickname") { value("주최자") }
+                    jsonPath("$.data.participants[0].isOwner") { value(true) }
+                    jsonPath("$.data.participants[0].isCelebrant") { value(true) }
+                    jsonPath("$.data.participants[0].isMe") { value(true) }
+                    jsonPath("$.data.participants[0].characterImageUrl") { value("https://cdn/char.png") }
+                    jsonPath("$.data.participants[1].joinOrder") { value(2) }
+                    jsonPath("$.data.participants[1].nickname") { value("참가자A") }
+                    jsonPath("$.data.participants[1].isOwner") { value(false) }
+                    jsonPath("$.data.participants[1].isCelebrant") { value(false) }
+                    jsonPath("$.data.participants[1].isMe") { value(false) }
+                }
+        }
+
+        @Test
+        fun `일반 참가자 호출 시 본인의 isMe만 true 다`() {
+            val token = tokenProvider.issue(member)
+
+            mockMvc
+                .get("/api/v1/parties/${realtimeParty.id}/participants") {
+                    header("Authorization", "Bearer $token")
+                }.andExpect {
+                    status { isOk() }
+                    jsonPath("$.data.participants[0].isMe") { value(false) }
+                    jsonPath("$.data.participants[1].isMe") { value(true) }
+                }
+        }
+
+        @Test
+        fun `비참가자 호출 시 403 PARTY_FORBIDDEN`() {
+            val token = tokenProvider.issue(outsider)
+
+            mockMvc
+                .get("/api/v1/parties/${realtimeParty.id}/participants") {
+                    header("Authorization", "Bearer $token")
+                }.andExpect {
+                    status { isForbidden() }
+                    jsonPath("$.error.code") { value("PARTY_FORBIDDEN") }
+                }
+        }
+
+        @Test
+        fun `PaperOnly 파티 호출 시 400 PARTY_NOT_REALTIME`() {
+            participantRepository.save(Participant(party = paperOnlyParty, user = owner, isCelebrant = true))
+            val token = tokenProvider.issue(owner)
+
+            mockMvc
+                .get("/api/v1/parties/${paperOnlyParty.id}/participants") {
+                    header("Authorization", "Bearer $token")
+                }.andExpect {
+                    status { isBadRequest() }
+                    jsonPath("$.error.code") { value("PARTY_NOT_REALTIME") }
+                }
+        }
+
+        @Test
+        fun `존재하지 않는 파티 호출 시 404 PARTY_NOT_FOUND`() {
+            val token = tokenProvider.issue(owner)
+
+            mockMvc
+                .get("/api/v1/parties/99999/participants") {
+                    header("Authorization", "Bearer $token")
+                }.andExpect {
+                    status { isNotFound() }
+                    jsonPath("$.error.code") { value("PARTY_NOT_FOUND") }
+                }
+        }
+
+        @Test
+        fun `Authorization 헤더 없으면 401`() {
+            mockMvc
+                .get("/api/v1/parties/${realtimeParty.id}/participants")
+                .andExpect {
+                    status { isUnauthorized() }
+                }
+        }
+
+        private fun saveUser(
+            providerId: String,
+            email: String,
+        ): User =
+            userRepository.save(
+                User(
+                    name = "사용자",
+                    birthDay = "01-01",
+                    provider = AuthProvider.KAKAO,
+                    providerId = providerId,
+                    email = email,
+                ),
+            )
+    }

--- a/src/test/kotlin/com/team2/server/party/application/service/ParticipantServiceTest.kt
+++ b/src/test/kotlin/com/team2/server/party/application/service/ParticipantServiceTest.kt
@@ -1,7 +1,12 @@
 package com.team2.server.party.application.service
 
+import com.team2.server.common.exception.BusinessException
+import com.team2.server.common.exception.ErrorCode
 import com.team2.server.party.domain.entity.PaperOnlyParty
 import com.team2.server.party.domain.entity.Participant
+import com.team2.server.party.domain.entity.Party
+import com.team2.server.party.domain.entity.RealtimeParticipantProfile
+import com.team2.server.party.domain.entity.RealtimeParty
 import com.team2.server.party.infrastructure.persistence.ParticipantRepository
 import com.team2.server.party.infrastructure.persistence.RealtimeParticipantProfileRepository
 import com.team2.server.user.entity.AuthProvider
@@ -13,6 +18,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.time.LocalDateTime
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class ParticipantServiceTest {
     private val participantRepository: ParticipantRepository = mock()
@@ -33,6 +39,13 @@ class ParticipantServiceTest {
             ownerId = 1L,
             celebrantNickname = "홍길동",
             startedAt = LocalDateTime.now().plusDays(1),
+        )
+
+    private fun makeRealtimeParty(): RealtimeParty =
+        RealtimeParty(
+            ownerId = 1L,
+            celebrantNickname = "실시간",
+            startedAt = LocalDateTime.now().plusHours(1),
         )
 
     @Test
@@ -57,5 +70,81 @@ class ParticipantServiceTest {
         service.findOrCreate(party, userId = 42L, user = user)
 
         verify(participantRepository).save(any<Participant>())
+    }
+
+    @Test
+    fun `requireCallerParticipantId returns participant id when JWT user is a participant`() {
+        val party = makeRealtimeParty()
+        val user = makeUser()
+        val participant = Participant(party = party, user = user)
+        whenever(participantRepository.findByPartyIdAndUserId(party.id, 42L)).thenReturn(participant)
+
+        val result = service.requireCallerParticipantId(party.id, userId = 42L, participantToken = null)
+
+        assertEquals(participant.id, result)
+    }
+
+    @Test
+    fun `requireCallerParticipantId throws PARTY_FORBIDDEN when JWT user is not a participant`() {
+        val party = makeRealtimeParty()
+        whenever(participantRepository.findByPartyIdAndUserId(party.id, 42L)).thenReturn(null)
+
+        val ex =
+            assertFailsWith<BusinessException> {
+                service.requireCallerParticipantId(party.id, userId = 42L, participantToken = null)
+            }
+        assertEquals(ErrorCode.PARTY_FORBIDDEN, ex.errorCode)
+    }
+
+    @Test
+    fun `requireCallerParticipantId returns participant id when participant token matches the party`() {
+        val party = makeRealtimeParty()
+        val participant = Participant(party = party, user = null)
+        val profile = RealtimeParticipantProfile(participant = participant, nickname = "익명")
+        whenever(realtimeParticipantProfileRepository.findByParticipantToken("tok")).thenReturn(profile)
+
+        val result = service.requireCallerParticipantId(party.id, userId = null, participantToken = "tok")
+
+        assertEquals(participant.id, result)
+    }
+
+    @Test
+    fun `requireCallerParticipantId throws PARTY_FORBIDDEN when token belongs to a different party`() {
+        val otherParty: Party = mock()
+        whenever(otherParty.id).thenReturn(99L)
+        val participant: Participant = mock()
+        whenever(participant.party).thenReturn(otherParty)
+        val profile: RealtimeParticipantProfile = mock()
+        whenever(profile.participant).thenReturn(participant)
+        whenever(realtimeParticipantProfileRepository.findByParticipantToken("tok")).thenReturn(profile)
+
+        val ex =
+            assertFailsWith<BusinessException> {
+                service.requireCallerParticipantId(partyId = 1L, userId = null, participantToken = "tok")
+            }
+        assertEquals(ErrorCode.PARTY_FORBIDDEN, ex.errorCode)
+    }
+
+    @Test
+    fun `requireCallerParticipantId throws PARTY_FORBIDDEN when participant token does not exist`() {
+        val party = makeRealtimeParty()
+        whenever(realtimeParticipantProfileRepository.findByParticipantToken("tok")).thenReturn(null)
+
+        val ex =
+            assertFailsWith<BusinessException> {
+                service.requireCallerParticipantId(party.id, userId = null, participantToken = "tok")
+            }
+        assertEquals(ErrorCode.PARTY_FORBIDDEN, ex.errorCode)
+    }
+
+    @Test
+    fun `requireCallerParticipantId throws UNAUTHORIZED when both userId and token are null`() {
+        val party = makeRealtimeParty()
+
+        val ex =
+            assertFailsWith<BusinessException> {
+                service.requireCallerParticipantId(party.id, userId = null, participantToken = null)
+            }
+        assertEquals(ErrorCode.UNAUTHORIZED, ex.errorCode)
     }
 }

--- a/src/test/kotlin/com/team2/server/party/application/service/ParticipantServiceTest.kt
+++ b/src/test/kotlin/com/team2/server/party/application/service/ParticipantServiceTest.kt
@@ -3,6 +3,7 @@ package com.team2.server.party.application.service
 import com.team2.server.party.domain.entity.PaperOnlyParty
 import com.team2.server.party.domain.entity.Participant
 import com.team2.server.party.infrastructure.persistence.ParticipantRepository
+import com.team2.server.party.infrastructure.persistence.RealtimeParticipantProfileRepository
 import com.team2.server.user.entity.AuthProvider
 import com.team2.server.user.entity.User
 import org.junit.jupiter.api.Test
@@ -15,7 +16,8 @@ import kotlin.test.assertEquals
 
 class ParticipantServiceTest {
     private val participantRepository: ParticipantRepository = mock()
-    private val service = ParticipantService(participantRepository)
+    private val realtimeParticipantProfileRepository: RealtimeParticipantProfileRepository = mock()
+    private val service = ParticipantService(participantRepository, realtimeParticipantProfileRepository)
 
     private fun makeUser(): User =
         User(


### PR DESCRIPTION
## 🔗 Issue
- closes #145

## 💬 Context

실시간 파티 시작 전 진행 기본화면(참가자 1명 이상, 최대 14명)에 노출할 참여자 목록 API 의 사전 설계 문서를 추가합니다.

- 설계 문서를 먼저 머지하여 팀 내 합의 → 구현 PR 분리로 리뷰 부담 감소
- 구현에 앞서 응답 스키마, 에러 정책, 레이어 매핑, 테스트 전략을 명확히 합의하기 위함

## 🛠 Changes

- `docs/superpowers/specs/2026-05-14-party-participants-list-design.md` 신규 추가 (299 라인)
  - 엔드포인트: `GET /api/v1/parties/{partyId}/participants` (RealtimeParty 전용, Option A 단일 엔드포인트 채택)
  - 응답 스키마: `totalCount`, `maxCount(14)`, `participants[]` (joinOrder/nickname/character/isOwner/isCelebrant/isMe)
  - 에러: `PARTY_NOT_REALTIME(400)` 신규 / `PARTY_FORBIDDEN(403)` / `PARTY_NOT_FOUND(404)` / `AUTH_UNAUTHORIZED(401)`
  - 레이어 매핑: Controller → UseCase → (PartyService + ParticipantService) → Repository, layered-architecture 규칙 준수
  - Repository 쿼리: `findAllByPartyIdOrderByParticipantIdAsc` (JOIN FETCH, N+1 회피)
  - 테스트 전략: Controller 통합 / Repository / UseCase 단위 (Testcontainers 경유)

## 👀 Review Focus

- Option A (단일 엔드포인트) vs B/C (타입 분기) 채택 근거 — 다른 도메인 자원과의 일관성
- `isOwner` vs `isCelebrant` 분리 노출의 필요성 — 향후 "남이 대신 만든 파티" 시나리오 대비, 비용 ≈ 0
- `joinOrder` 를 서버에서 부여하는 결정 — 클라이언트 정렬 책임 제거
- `PartyService` 의존성 8개 이미 초과 상태 — 본 PR 범위에서는 메서드만 추가, 의존성 추가 없음 (별도 refactor 권장)

## ⚠️ Side Effects

- **DB 마이그레이션**: 없음 (구현 PR 에서도 스키마 변경 없음)
- **환경변수/설정**: 없음
- **의존성 변경**: 없음
- **API 변경(Breaking)**: 없음 (신규 엔드포인트)
- **외부 시스템 영향**: 없음 (문서 단계)
- **운영 작업**: 없음

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 파티 참여자 목록 조회 API 추가 (`GET /api/v1/parties/{partyId}/participants`)
  * 로그인/비로그인 인증 방식 지원 (Authorization 헤더 또는 X-Participant-Token)
  * 참여자 정보를 입장 순서대로 반환

* **Documentation**
  * API 설계 및 구현 플랜 문서 추가

* **Tests**
  * 통합 테스트 및 단위 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/18th-team2-server/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->