### PR TITLE
[Docs] 실시간 파티 종료 설계 문서 정리

### DIFF
--- a/docs/superpowers/plans/2026-05-19-realtime-party-end.md
+++ b/docs/superpowers/plans/2026-05-19-realtime-party-end.md
@@ -80,9 +80,11 @@ Run:
 - [ ] 자동 종료용 조건부 update를 추가한다: `live_ending_started_at = startedAt + 10분` only when null and `startedAt + 10분 <= now`.
 - [ ] polling 대상 조회를 추가한다: `liveEndingStartedAt != null`인 realtime party 목록.
 - [ ] 종료 가능 조회는 주최자 권한, `REALTIME` 타입, 4분 경과 또는 박터뜨리기 종료 여부를 검증한다.
+- [ ] 종료 가능 조회의 `canEnd`는 `liveEndingStartedAt == null && (now >= startedAt + 4분 || 박터뜨리기 종료)`일 때만 true다.
 - [ ] 박터뜨리기 완료 상태는 이벤트/상태 provider로 분리해 연결하고, 도메인이 없으면 false를 기본값으로 둔다.
-- [ ] 종료 요청은 주최자만 허용하고 `REALTIME_PARTY_END_NOT_AVAILABLE`, `REALTIME_PARTY_ALREADY_ENDED`를 구분한다.
-- [ ] 이미 `LIVE_ENDING`이면 기존 `endingStartedAt`, `endedAt`을 반환한다.
+- [ ] 종료 요청은 `LIVE_CLOSED`를 먼저 거부하고 `REALTIME_PARTY_ALREADY_ENDED`를 반환한다.
+- [ ] 이미 `LIVE_ENDING`이면 수동 종료 가능 조건을 다시 검사하지 않고 기존 `endingStartedAt`, `endedAt`을 반환한다.
+- [ ] `LIVE_OPEN`일 때만 수동 종료 가능 조건을 검사하고, 실패하면 `REALTIME_PARTY_END_NOT_AVAILABLE`을 반환한다.
 
 Run:
 
@@ -200,7 +202,9 @@ Run:
   - 소유자가 아니면 403
   - `PAPER_ONLY`이면 `CHAT_NOT_SUPPORTED`
   - 이미 `LIVE_ENDING`이면 기존 종료 시각 반환
+  - `LIVE_ENDING` 재요청은 4분/박터뜨리기 조건을 다시 검사하지 않음
   - 이미 `LIVE_CLOSED`이면 `REALTIME_PARTY_ALREADY_ENDED`
+  - `liveEndingStartedAt`이 있으면 `realtime-end` 조회의 `canEnd = false`
   - 동시 요청에서 하나만 update 성공
 
 - 복구/다음 행동 API

--- a/docs/superpowers/plans/2026-05-19-realtime-party-end.md
+++ b/docs/superpowers/plans/2026-05-19-realtime-party-end.md
@@ -4,7 +4,7 @@
 
 **Goal:** 실시간 파티의 주최자 수동 종료, 10분 자동 종료, 60초 종료 카운트다운, SSE 종료 이벤트, 종료 후 롤링페이퍼 이동 정보를 구현한다.
 
-**Architecture:** 파티 상태/권한/복구 API는 `party/application/usecase` 중심으로 구현하고, SSE 발송과 polling은 기존 `chat/infrastructure/sse` 흐름을 확장한다. 실시간 세션 종료는 `Party.endedAt()`과 분리해 `RealtimeParty.liveEndingStartedAt`으로 관리한다.
+**Architecture:** 파티 상태/권한/복구 API는 `party/application/usecase` 중심으로 구현하고, SSE 발송과 예약 실행은 기존 `chat/infrastructure/sse` 흐름을 확장한다. 실시간 세션 종료는 `Party.endedAt()`과 분리해 `RealtimeParty.liveEndingStartedAt`으로 관리한다.
 
 **Architecture Test Guardrails:** `*Controller`는 `..api..`, `*UseCase`는 `..application.usecase..`, `*Repository`는 `..infrastructure.persistence..`에 둔다. `@Transactional`은 UseCase에만 둔다. `chat` 인프라가 `party.infrastructure.persistence`를 직접 의존하지 않도록, DB 조회/조건부 update는 `party.application.usecase` 경유로 노출한다.
 
@@ -22,7 +22,7 @@
 - 자동 종료는 `startedAt + 10분`을 `liveEndingStartedAt`에 저장한다. 스케줄러 실행 시각 `now`를 저장하지 않는다.
 - 주최자 롤링페이퍼 열람 가능 시점은 `liveEndingStartedAt ?: startedAt + 10분`이다.
 - `party-ended`는 공통 payload만 보내고, 개인화 이동 정보는 `GET /api/v1/parties/{partyId}/realtime-next-action`에서 조회한다.
-- `PartyEndScheduler`는 per-party 예약을 잡지 않고 DB polling으로 `party-ending`, `party-ended`를 발송한다.
+- `PartyEndScheduler`는 1초 반복 polling을 사용하지 않고, startup recovery + after-commit event + `TaskScheduler` 예약으로 `party-ending`, `party-ended`를 발송한다.
 - 비회원 참가자의 `rollingPaperWritten`은 `participantToken -> RealtimeParticipantProfile -> Participant.hasWrittenPaper`로 계산한다.
 - 참가자용 `inviteToken`은 해당 party의 만료되지 않은 초대 토큰을 `PartyInviteRepository.findByPartyIdAndExpiresAtAfter(partyId, now)`로 조회한다.
 - 박터뜨리기 종료는 수동 종료 가능 상태만 열고 자동 종료는 시작하지 않는다.
@@ -37,12 +37,12 @@
 |---|---|
 | `src/main/resources/db/migration/V4__add_realtime_party_end_state.sql` | `realtime_party.live_ending_started_at` 추가 |
 | `src/main/kotlin/com/team2/server/party/domain/entity/RealtimeParty.kt` | 종료 상수, 상태 계산, `hostViewableAt()` 수정 |
-| `src/main/kotlin/com/team2/server/party/infrastructure/persistence/PartyRepository.kt` | 종료 polling/조건부 update 쿼리 |
+| `src/main/kotlin/com/team2/server/party/infrastructure/persistence/PartyRepository.kt` | 종료 복구 조회/조건부 update 쿼리 |
 | `src/main/kotlin/com/team2/server/party/api/PartyApi.kt` | 실시간 종료 API Swagger 계약 |
 | `src/main/kotlin/com/team2/server/party/api/PartyController.kt` | 주최자 종료 조회/요청, 상태/다음 행동 조회 |
 | `src/main/kotlin/com/team2/server/party/api/dto/*Realtime*` | 종료 상태/요청/다음 행동 응답 DTO |
 | `src/main/kotlin/com/team2/server/party/application/usecase/*Realtime*` | 종료 가능 조회, 종료 요청, 상태 복구, 다음 행동 조회 |
-| `src/main/kotlin/com/team2/server/chat/infrastructure/sse/PartyEndScheduler.kt` | usecase 경유 DB polling 기반 종료 이벤트 발송 |
+| `src/main/kotlin/com/team2/server/chat/infrastructure/sse/PartyEndScheduler.kt` | startup recovery + event 기반 종료 이벤트 발송 |
 | `src/main/kotlin/com/team2/server/chat/infrastructure/sse/SseEmitterRegistry.kt` | 주최자 단독 알림, grace cleanup 지원 |
 | `src/main/kotlin/com/team2/server/chat/usecase/EnterAndSubscribeChatUseCase.kt` | 연결 직후 `party-state` 발송, `LIVE_ENDING` 재연결 허용 |
 | `src/main/kotlin/com/team2/server/auth/config/SecurityConfig.kt` | participant token 기반 복구 API 공개 경로 조정 |
@@ -85,8 +85,8 @@ Run:
 
 - [ ] 수동 종료용 조건부 update를 추가한다: `live_ending_started_at = now` only when null.
 - [ ] 자동 종료용 조건부 update를 추가한다: `live_ending_started_at = startedAt + 10분` only when null and `startedAt + 10분 <= now`.
-- [ ] polling 대상 조회를 추가한다: `liveEndingStartedAt != null`인 realtime party 목록.
-- [ ] `PartyEndScheduler`가 repository를 직접 주입받지 않도록 polling용 UseCase를 제공한다.
+- [ ] startup recovery용 조회를 추가한다: 자동 종료 예약 대상과 이미 종료 countdown이 시작된 realtime party 목록.
+- [ ] `PartyEndScheduler`가 repository를 직접 주입받지 않도록 복구/조건부 종료 UseCase를 제공한다.
 - [ ] 종료 가능 조회는 주최자 권한, `REALTIME` 타입, 4분 경과 또는 박터뜨리기 종료 여부를 검증한다.
 - [ ] 종료 가능 조회의 `canEnd`는 `status(now) == LIVE_OPEN && liveEndingStartedAt == null && (now >= startedAt + 4분 || 박터뜨리기 종료)`일 때만 true다.
 - [ ] 박터뜨리기 완료 상태는 이벤트/상태 provider로 분리해 연결하고, 도메인이 없으면 false를 기본값으로 둔다.
@@ -153,7 +153,7 @@ Run:
 ./gradlew test --tests '*Chat*'
 ```
 
-## Task 5: PartyEndScheduler를 DB polling으로 변경
+## Task 5: PartyEndScheduler를 startup recovery + event 기반으로 변경
 
 **Files:**
 - Modify: `src/main/kotlin/com/team2/server/chat/infrastructure/sse/PartyEndScheduler.kt`
@@ -162,14 +162,16 @@ Run:
 - Test: scheduler/usecase tests
 
 - [ ] 기존 `WARN_BEFORE_END_MINUTES`와 `startedAt + 9분` 알림 예약을 제거한다.
-- [ ] `scheduleIfNeeded(...)` 기반 per-party 예약을 제거하거나 no-op로 대체한다.
-- [ ] 1초 주기 polling으로 자동 종료 시작 조건을 처리한다.
-- [ ] polling은 `party.application.usecase`의 polling용 UseCase를 호출하고, `party.infrastructure.persistence`를 직접 참조하지 않는다.
+- [ ] 앱 시작 시 DB 상태를 1회 조회해 자동 종료 시작 예약과 `party-ended` 예약을 복구한다.
+- [ ] 신규 실시간 파티 생성 commit 이후 `RealtimePartyCreatedEvent`로 자동 종료 시작 예약을 잡는다.
+- [ ] 자동 종료 예약 task는 조건부 update로 `liveEndingStartedAt = startedAt + 10분`을 저장한다.
+- [ ] 수동/자동 종료 시작 commit 이후 `RealtimePartyEndingStartedEvent`로 `party-ending`을 전송하고 `party-ended`를 예약한다.
+- [ ] `PartyEndScheduler`는 `party.application.usecase`만 호출하고, `party.infrastructure.persistence`를 직접 참조하지 않는다.
 - [ ] 자동 종료 시작 시 `liveEndingStartedAt = startedAt + 10분`으로 저장한다.
 - [ ] `endingNotifiedPartyIds` 메모리 Set으로 `party-ending` 중복 발송을 막는다.
 - [ ] `endedNotifiedPartyIds` 메모리 Set으로 `party-ended` 중복 발송을 막는다.
 - [ ] `liveEndingStartedAt + 60초 <= now`이면 `party-ended`를 발송하고 grace cleanup을 예약한다.
-- [ ] 재시작 후 `party-ending` 누락은 재연결 `party-state`로 복구하고, polling은 현재 DB 상태 기준으로 계속 동작한다.
+- [ ] 재시작 후 `party-ending` 누락은 재연결 `party-state`로 복구하고, scheduler는 복구된 DB 상태 기준으로 예약을 다시 잡는다.
 
 Run:
 
@@ -230,7 +232,7 @@ Run:
   - 연결 직후 `party-state` 전송
   - 4분 도달 시 주최자에게 `host-end-available`
   - 자동 종료 시작 시 `party-ending`
-  - 자동 종료 저장값은 polling 실행 시각이 아니라 `startedAt + 10분`
+  - 자동 종료 저장값은 scheduler 실행 시각이 아니라 `startedAt + 10분`
   - 60초 경과 후 `party-ended`
   - `party-ended` 후 grace cleanup
   - `LIVE_ENDING`에서 기존 participantToken 재연결 허용

--- a/docs/superpowers/plans/2026-05-19-realtime-party-end.md
+++ b/docs/superpowers/plans/2026-05-19-realtime-party-end.md
@@ -1,0 +1,234 @@
+# Realtime Party End Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 실시간 파티의 주최자 수동 종료, 10분 자동 종료, 60초 종료 카운트다운, SSE 종료 이벤트, 종료 후 롤링페이퍼 이동 정보를 구현한다.
+
+**Architecture:** 파티 상태/권한/복구 API는 `party/application/usecase` 중심으로 구현하고, SSE 발송과 polling은 기존 `chat/infrastructure/sse` 흐름을 확장한다. 실시간 세션 종료는 `Party.endedAt()`과 분리해 `RealtimeParty.liveEndingStartedAt`으로 관리한다.
+
+**Spec Reference:** `docs/superpowers/specs/2026-05-19-realtime-party-end-design.md`
+
+---
+
+## Decisions
+
+- 단일 애플리케이션 인스턴스 운영을 전제로 한다.
+- 종료 시작 시각만 DB에 저장한다. 종료 완료 시각은 `liveEndingStartedAt + 60초`로 계산한다.
+- 종료 원인 컬럼은 추가하지 않는다.
+- 자동 종료는 `startedAt + 10분`을 `liveEndingStartedAt`에 저장한다. 스케줄러 실행 시각 `now`를 저장하지 않는다.
+- 주최자 롤링페이퍼 열람 가능 시점은 `liveEndingStartedAt ?: startedAt + 10분`이다.
+- `party-ended`는 공통 payload만 보내고, 개인화 이동 정보는 `GET /api/v1/parties/{partyId}/realtime-next-action`에서 조회한다.
+- `PartyEndScheduler`는 per-party 예약을 잡지 않고 DB polling으로 `party-ending`, `party-ended`를 발송한다.
+- 비회원 참가자의 `rollingPaperWritten`은 `participantToken -> RealtimeParticipantProfile -> Participant.hasWrittenPaper`로 계산한다.
+- 참가자용 `inviteToken`은 해당 party의 만료되지 않은 초대 토큰을 `PartyInviteRepository.findByPartyIdAndExpiresAtAfter(partyId, now)`로 조회한다.
+- 박터뜨리기 종료는 수동 종료 가능 상태만 열고 자동 종료는 시작하지 않는다.
+
+---
+
+## File Structure
+
+### 신규/수정 예정
+
+| 경로 | 책임 |
+|---|---|
+| `src/main/resources/db/migration/V4__add_realtime_party_end_state.sql` | `realtime_party.live_ending_started_at` 추가 |
+| `src/main/kotlin/com/team2/server/party/domain/entity/RealtimeParty.kt` | 종료 상수, 상태 계산, `hostViewableAt()` 수정 |
+| `src/main/kotlin/com/team2/server/party/infrastructure/persistence/PartyRepository.kt` | 종료 polling/조건부 update 쿼리 |
+| `src/main/kotlin/com/team2/server/party/api/PartyApi.kt` | 실시간 종료 API Swagger 계약 |
+| `src/main/kotlin/com/team2/server/party/api/PartyController.kt` | 주최자 종료 조회/요청, 상태/다음 행동 조회 |
+| `src/main/kotlin/com/team2/server/party/api/dto/*Realtime*` | 종료 상태/요청/다음 행동 응답 DTO |
+| `src/main/kotlin/com/team2/server/party/application/usecase/*Realtime*` | 종료 가능 조회, 종료 요청, 상태 복구, 다음 행동 조회 |
+| `src/main/kotlin/com/team2/server/chat/infrastructure/sse/PartyEndScheduler.kt` | DB polling 기반 종료 이벤트 발송 |
+| `src/main/kotlin/com/team2/server/chat/infrastructure/sse/SseEmitterRegistry.kt` | 주최자 단독 알림, grace cleanup 지원 |
+| `src/main/kotlin/com/team2/server/chat/usecase/EnterAndSubscribeChatUseCase.kt` | 연결 직후 `party-state` 발송, `LIVE_ENDING` 재연결 허용 |
+| `src/main/kotlin/com/team2/server/auth/config/SecurityConfig.kt` | participant token 기반 복구 API 공개 경로 조정 |
+| `src/main/kotlin/com/team2/server/common/exception/ErrorCode.kt` | 실시간 종료 전용 에러 추가 |
+
+---
+
+## Task Order
+
+## Task 1: 도메인 상태와 migration 추가
+
+**Files:**
+- Modify: `src/main/kotlin/com/team2/server/party/domain/entity/RealtimeParty.kt`
+- Create: `src/main/resources/db/migration/V4__add_realtime_party_end_state.sql`
+- Test: domain/entity or service test for realtime status
+
+- [ ] `realtime_party.live_ending_started_at DATETIME NULL` 컬럼을 추가한다.
+- [ ] `RealtimeParty.HOST_END_AVAILABLE_AFTER_MINUTES = 4`를 추가한다.
+- [ ] `RealtimeParty.LIVE_END_COUNTDOWN_SECONDS = 60`을 추가한다.
+- [ ] `RealtimePartyStatus.LIVE_ENDING`을 추가한다.
+- [ ] `effectiveEndingStartedAt()`은 `liveEndingStartedAt ?: startedAt.plusMinutes(LIVE_DURATION_MINUTES)`로 계산한다.
+- [ ] `effectiveLiveEndedAt()`은 `effectiveEndingStartedAt().plusSeconds(LIVE_END_COUNTDOWN_SECONDS)`로 계산한다.
+- [ ] `status(now)`는 `LIVE_OPEN`, `LIVE_ENDING`, `LIVE_CLOSED`, `ROLLING_PAPER_CLOSED` 순서를 정확히 반영한다.
+- [ ] `hostViewableAt()`은 `liveEndingStartedAt ?: startedAt.plusMinutes(LIVE_DURATION_MINUTES)`로 변경한다.
+
+Run:
+
+```bash
+./gradlew test --tests '*RealtimeParty*'
+```
+
+## Task 2: 종료 시작 조건부 update와 조회 기반 추가
+
+**Files:**
+- Modify: `src/main/kotlin/com/team2/server/party/infrastructure/persistence/PartyRepository.kt`
+- Create/Modify: realtime end usecase/service classes under `party/application/usecase`
+
+- [ ] 수동 종료용 조건부 update를 추가한다: `live_ending_started_at = now` only when null.
+- [ ] 자동 종료용 조건부 update를 추가한다: `live_ending_started_at = startedAt + 10분` only when null and `startedAt + 10분 <= now`.
+- [ ] polling 대상 조회를 추가한다: `liveEndingStartedAt != null`인 realtime party 목록.
+- [ ] 종료 가능 조회는 주최자 권한, `REALTIME` 타입, 4분 경과 또는 박터뜨리기 종료 여부를 검증한다.
+- [ ] 박터뜨리기 완료 상태는 이벤트/상태 provider로 분리해 연결하고, 도메인이 없으면 false를 기본값으로 둔다.
+- [ ] 종료 요청은 주최자만 허용하고 `REALTIME_PARTY_END_NOT_AVAILABLE`, `REALTIME_PARTY_ALREADY_ENDED`를 구분한다.
+- [ ] 이미 `LIVE_ENDING`이면 기존 `endingStartedAt`, `endedAt`을 반환한다.
+
+Run:
+
+```bash
+./gradlew test --tests '*RealtimePartyEnd*'
+```
+
+## Task 3: 종료/복구/다음 행동 API 추가
+
+**Files:**
+- Modify: `src/main/kotlin/com/team2/server/party/api/PartyApi.kt`
+- Modify: `src/main/kotlin/com/team2/server/party/api/PartyController.kt`
+- Create: DTOs under `src/main/kotlin/com/team2/server/party/api/dto/`
+- Modify: `src/main/kotlin/com/team2/server/auth/config/SecurityConfig.kt`
+- Modify: `src/main/kotlin/com/team2/server/common/exception/ErrorCode.kt`
+- Test: party controller tests
+
+- [ ] `GET /api/v1/parties/{partyId}/realtime-end`를 추가한다. 인증된 주최자만 호출한다.
+- [ ] `POST /api/v1/parties/{partyId}/realtime-end`를 추가한다. 인증된 주최자만 호출한다.
+- [ ] `GET /api/v1/parties/{partyId}/realtime-state`를 추가한다. `Authorization` 또는 `X-Participant-Token` 중 하나로 파티 소속을 확인한다.
+- [ ] `GET /api/v1/parties/{partyId}/realtime-next-action`을 추가한다. `LIVE_CLOSED`에서만 성공한다.
+- [ ] `realtime-state`, `realtime-next-action`은 participant token 사용을 위해 path-specific permitAll로 열고, invalid Bearer token은 기존 JWT 정책대로 401을 유지한다.
+- [ ] 주최자 next action은 `{ type: "HOST_ROLLING_PAPER_LIST", partyId }`로 응답한다.
+- [ ] 참가자 next action은 `{ type: "PARTICIPANT_ROLLING_PAPER_WRITE", inviteToken, rollingPaperWritten }`로 응답한다.
+- [ ] 회원 참가자는 `ParticipantRepository.findByPartyIdAndUserId(...)`로 participant를 찾는다.
+- [ ] 비회원 참가자는 `RealtimeParticipantProfileRepository.findByParticipantToken(...)`로 profile과 participant를 찾는다.
+- [ ] 참가자 `inviteToken`은 `PartyInviteRepository.findByPartyIdAndExpiresAtAfter(partyId, now)`로 조회한다.
+- [ ] 참가자 `rollingPaperWritten`은 resolved participant의 `hasWrittenPaper`로 응답한다.
+- [ ] `REALTIME_PARTY_END_NOT_AVAILABLE(400)`, `REALTIME_PARTY_ALREADY_ENDED(409)`를 추가한다.
+
+Run:
+
+```bash
+./gradlew test --tests '*PartyControllerTest'
+```
+
+## Task 4: SSE registry와 연결 초기 이벤트 확장
+
+**Files:**
+- Modify: `src/main/kotlin/com/team2/server/chat/infrastructure/sse/SseEmitterRegistry.kt`
+- Modify: `src/main/kotlin/com/team2/server/chat/infrastructure/sse/ChatSseGateway.kt`
+- Modify: `src/main/kotlin/com/team2/server/chat/usecase/EnterAndSubscribeChatUseCase.kt`
+- Modify: `src/main/kotlin/com/team2/server/chat/usecase/EnterRealtimePartyUseCase.kt`
+- Test: chat/realtime controller or usecase tests
+
+- [ ] SSE 연결 직후 `party-state`를 항상 전송한다.
+- [ ] `party-state` payload에 `partyId`, `status`, `liveStartAt`, `endingStartedAt`, `endedAt`을 포함한다.
+- [ ] 신규 입장은 `LIVE_OPEN`에서만 허용한다.
+- [ ] 기존 participantToken 기반 재연결은 `LIVE_ENDING`에서도 허용한다.
+- [ ] `LIVE_CLOSED`에서는 SSE 연결을 거부하고 REST 복구 API 사용을 유도한다.
+- [ ] 주최자 emitter를 식별하거나 owner participant를 통해 `host-end-available`을 주최자에게만 보낼 수 있게 한다.
+- [ ] `party-ended` 발송 후 즉시 complete하지 않고 grace time 후 남은 emitter를 정리한다.
+
+Run:
+
+```bash
+./gradlew test --tests '*Chat*'
+```
+
+## Task 5: PartyEndScheduler를 DB polling으로 변경
+
+**Files:**
+- Modify: `src/main/kotlin/com/team2/server/chat/infrastructure/sse/PartyEndScheduler.kt`
+- Modify: `src/main/kotlin/com/team2/server/chat/infrastructure/sse/ChatSchedulerConfig.kt` if needed
+- Modify: `src/main/kotlin/com/team2/server/chat/usecase/EnterAndSubscribeChatUseCase.kt`
+- Test: scheduler/usecase tests
+
+- [ ] 기존 `WARN_BEFORE_END_MINUTES`와 `startedAt + 9분` 알림 예약을 제거한다.
+- [ ] `scheduleIfNeeded(...)` 기반 per-party 예약을 제거하거나 no-op로 대체한다.
+- [ ] 1초 주기 polling으로 자동 종료 시작 조건을 처리한다.
+- [ ] 자동 종료 시작 시 `liveEndingStartedAt = startedAt + 10분`으로 저장한다.
+- [ ] `endingNotifiedPartyIds` 메모리 Set으로 `party-ending` 중복 발송을 막는다.
+- [ ] `endedNotifiedPartyIds` 메모리 Set으로 `party-ended` 중복 발송을 막는다.
+- [ ] `liveEndingStartedAt + 60초 <= now`이면 `party-ended`를 발송하고 grace cleanup을 예약한다.
+- [ ] 재시작 후 `party-ending` 누락은 재연결 `party-state`로 복구하고, polling은 현재 DB 상태 기준으로 계속 동작한다.
+
+Run:
+
+```bash
+./gradlew test --tests '*PartyEndScheduler*'
+```
+
+## Task 6: 박터뜨리기 종료 이벤트 연결
+
+**Files:**
+- Create/Modify burst game event type when the burst game module is available
+- Create listener/usecase in party or chat boundary
+
+- [ ] 박터뜨리기 종료 시 `BurstGameEndedEvent(partyId)`를 발행한다.
+- [ ] 이벤트 listener는 해당 party가 realtime이고 아직 `LIVE_OPEN`이면 주최자에게 `host-end-available`을 보낸다.
+- [ ] 이 이벤트는 `liveEndingStartedAt`을 저장하지 않는다.
+- [ ] 이벤트가 먼저 오고 4분도 경과하면 `realtime-end` 조회는 `canEnd = true`를 반환한다.
+
+Run:
+
+```bash
+./gradlew test --tests '*Burst*' --tests '*RealtimePartyEnd*'
+```
+
+## Test Plan
+
+- 도메인 상태
+  - 시작 전 `ROLLING_PAPER_OPEN`
+  - 시작 후 종료 시작 전 `LIVE_OPEN`
+  - 종료 시작 후 60초 전 `LIVE_ENDING`
+  - 종료 시작 후 60초 경과 `LIVE_CLOSED`
+  - `Party.isEnded(now)` 이후 `ROLLING_PAPER_CLOSED`
+  - 수동 종료 시 `hostViewableAt() == liveEndingStartedAt`
+  - 수동 종료 없으면 `hostViewableAt() == startedAt + 10분`
+
+- 주최자 종료 API
+  - 4분 전 수동 종료 요청 실패
+  - 4분 경과 후 수동 종료 성공
+  - 박터뜨리기 종료 후 4분 전에도 수동 종료 성공
+  - 소유자가 아니면 403
+  - `PAPER_ONLY`이면 `CHAT_NOT_SUPPORTED`
+  - 이미 `LIVE_ENDING`이면 기존 종료 시각 반환
+  - 이미 `LIVE_CLOSED`이면 `REALTIME_PARTY_ALREADY_ENDED`
+  - 동시 요청에서 하나만 update 성공
+
+- 복구/다음 행동 API
+  - 주최자 `realtime-end` 복구 조회 성공
+  - 회원 participant `realtime-state` 조회 성공
+  - 비회원 participant token으로 `realtime-state` 조회 성공
+  - `LIVE_OPEN`, `LIVE_ENDING`에서 `realtime-next-action` 실패
+  - `LIVE_CLOSED`에서 주최자 next action 응답
+  - `LIVE_CLOSED`에서 참가자 next action 응답
+  - participant token이 다른 파티 소속이면 403
+
+- SSE / scheduler
+  - 연결 직후 `party-state` 전송
+  - 4분 도달 시 주최자에게 `host-end-available`
+  - 자동 종료 시작 시 `party-ending`
+  - 자동 종료 저장값은 polling 실행 시각이 아니라 `startedAt + 10분`
+  - 60초 경과 후 `party-ended`
+  - `party-ended` 후 grace cleanup
+  - `LIVE_ENDING`에서 기존 participantToken 재연결 허용
+  - `LIVE_CLOSED`에서 SSE 재연결 거부
+
+## Verification
+
+```bash
+./gradlew test --tests '*RealtimeParty*'
+./gradlew test --tests '*RealtimePartyEnd*'
+./gradlew test --tests '*PartyEndScheduler*'
+./gradlew test --tests '*Chat*'
+./gradlew test
+./gradlew ktlintCheck
+```

--- a/docs/superpowers/plans/2026-05-19-realtime-party-end.md
+++ b/docs/superpowers/plans/2026-05-19-realtime-party-end.md
@@ -6,6 +6,10 @@
 
 **Architecture:** 파티 상태/권한/복구 API는 `party/application/usecase` 중심으로 구현하고, SSE 발송과 polling은 기존 `chat/infrastructure/sse` 흐름을 확장한다. 실시간 세션 종료는 `Party.endedAt()`과 분리해 `RealtimeParty.liveEndingStartedAt`으로 관리한다.
 
+**Architecture Test Guardrails:** `*Controller`는 `..api..`, `*UseCase`는 `..application.usecase..`, `*Repository`는 `..infrastructure.persistence..`에 둔다. `@Transactional`은 UseCase에만 둔다. `chat` 인프라가 `party.infrastructure.persistence`를 직접 의존하지 않도록, DB 조회/조건부 update는 `party.application.usecase` 경유로 노출한다.
+
+**Test Guardrails:** MockMvc 통합 테스트는 `@SpringBootTest + @AutoConfigureMockMvc + @Import(TestcontainersConfiguration::class)` 조합을 사용한다. 단순 통합 테스트는 `IntegrationTestSupport`, JPA slice는 `JpaSliceTestSupport`를 상속한다. 새 테스트에서 `@MockBean`, `@SpyBean`, `@TestPropertySource`, 임의 `@ActiveProfiles`를 추가해 Spring context fingerprint를 늘리지 않는다.
+
 **Spec Reference:** `docs/superpowers/specs/2026-05-19-realtime-party-end-design.md`
 
 ---
@@ -38,7 +42,7 @@
 | `src/main/kotlin/com/team2/server/party/api/PartyController.kt` | 주최자 종료 조회/요청, 상태/다음 행동 조회 |
 | `src/main/kotlin/com/team2/server/party/api/dto/*Realtime*` | 종료 상태/요청/다음 행동 응답 DTO |
 | `src/main/kotlin/com/team2/server/party/application/usecase/*Realtime*` | 종료 가능 조회, 종료 요청, 상태 복구, 다음 행동 조회 |
-| `src/main/kotlin/com/team2/server/chat/infrastructure/sse/PartyEndScheduler.kt` | DB polling 기반 종료 이벤트 발송 |
+| `src/main/kotlin/com/team2/server/chat/infrastructure/sse/PartyEndScheduler.kt` | usecase 경유 DB polling 기반 종료 이벤트 발송 |
 | `src/main/kotlin/com/team2/server/chat/infrastructure/sse/SseEmitterRegistry.kt` | 주최자 단독 알림, grace cleanup 지원 |
 | `src/main/kotlin/com/team2/server/chat/usecase/EnterAndSubscribeChatUseCase.kt` | 연결 직후 `party-state` 발송, `LIVE_ENDING` 재연결 허용 |
 | `src/main/kotlin/com/team2/server/auth/config/SecurityConfig.kt` | participant token 기반 복구 API 공개 경로 조정 |
@@ -53,7 +57,8 @@
 **Files:**
 - Modify: `src/main/kotlin/com/team2/server/party/domain/entity/RealtimeParty.kt`
 - Create: `src/main/resources/db/migration/V4__add_realtime_party_end_state.sql`
-- Test: domain/entity or service test for realtime status
+- Test: domain/entity test for realtime status
+- Test: `src/test/kotlin/com/team2/server/db/FlywayMigrationTest.kt`
 
 - [ ] `realtime_party.live_ending_started_at DATETIME NULL` 컬럼을 추가한다.
 - [ ] `RealtimeParty.HOST_END_AVAILABLE_AFTER_MINUTES = 4`를 추가한다.
@@ -63,11 +68,13 @@
 - [ ] `effectiveLiveEndedAt()`은 `effectiveEndingStartedAt().plusSeconds(LIVE_END_COUNTDOWN_SECONDS)`로 계산한다.
 - [ ] `status(now)`는 `LIVE_OPEN`, `LIVE_ENDING`, `LIVE_CLOSED`, `ROLLING_PAPER_CLOSED` 순서를 정확히 반영한다.
 - [ ] `hostViewableAt()`은 `liveEndingStartedAt ?: startedAt.plusMinutes(LIVE_DURATION_MINUTES)`로 변경한다.
+- [ ] `FlywayMigrationTest`로 V4 migration이 clean DB에 적용되는지 검증한다.
 
 Run:
 
 ```bash
 ./gradlew test --tests '*RealtimeParty*'
+./gradlew test --tests com.team2.server.db.FlywayMigrationTest
 ```
 
 ## Task 2: 종료 시작 조건부 update와 조회 기반 추가
@@ -79,6 +86,7 @@ Run:
 - [ ] 수동 종료용 조건부 update를 추가한다: `live_ending_started_at = now` only when null.
 - [ ] 자동 종료용 조건부 update를 추가한다: `live_ending_started_at = startedAt + 10분` only when null and `startedAt + 10분 <= now`.
 - [ ] polling 대상 조회를 추가한다: `liveEndingStartedAt != null`인 realtime party 목록.
+- [ ] `PartyEndScheduler`가 repository를 직접 주입받지 않도록 polling용 UseCase를 제공한다.
 - [ ] 종료 가능 조회는 주최자 권한, `REALTIME` 타입, 4분 경과 또는 박터뜨리기 종료 여부를 검증한다.
 - [ ] 종료 가능 조회의 `canEnd`는 `liveEndingStartedAt == null && (now >= startedAt + 4분 || 박터뜨리기 종료)`일 때만 true다.
 - [ ] 박터뜨리기 완료 상태는 이벤트/상태 provider로 분리해 연결하고, 도메인이 없으면 false를 기본값으로 둔다.
@@ -114,6 +122,7 @@ Run:
 - [ ] 참가자 `inviteToken`은 `PartyInviteRepository.findByPartyIdAndExpiresAtAfter(partyId, now)`로 조회한다.
 - [ ] 참가자 `rollingPaperWritten`은 resolved participant의 `hasWrittenPaper`로 응답한다.
 - [ ] `REALTIME_PARTY_END_NOT_AVAILABLE(400)`, `REALTIME_PARTY_ALREADY_ENDED(409)`를 추가한다.
+- [ ] 컨트롤러 테스트는 기존 MockMvc 통합 테스트 패턴을 따라 `@Import(TestcontainersConfiguration::class)`를 포함한다.
 
 Run:
 
@@ -155,6 +164,7 @@ Run:
 - [ ] 기존 `WARN_BEFORE_END_MINUTES`와 `startedAt + 9분` 알림 예약을 제거한다.
 - [ ] `scheduleIfNeeded(...)` 기반 per-party 예약을 제거하거나 no-op로 대체한다.
 - [ ] 1초 주기 polling으로 자동 종료 시작 조건을 처리한다.
+- [ ] polling은 `party.application.usecase`의 polling용 UseCase를 호출하고, `party.infrastructure.persistence`를 직접 참조하지 않는다.
 - [ ] 자동 종료 시작 시 `liveEndingStartedAt = startedAt + 10분`으로 저장한다.
 - [ ] `endingNotifiedPartyIds` 메모리 Set으로 `party-ending` 중복 발송을 막는다.
 - [ ] `endedNotifiedPartyIds` 메모리 Set으로 `party-ended` 중복 발송을 막는다.
@@ -229,6 +239,8 @@ Run:
 ## Verification
 
 ```bash
+./gradlew test --tests 'com.team2.server.architecture.*'
+./gradlew test --tests com.team2.server.db.FlywayMigrationTest
 ./gradlew test --tests '*RealtimeParty*'
 ./gradlew test --tests '*RealtimePartyEnd*'
 ./gradlew test --tests '*PartyEndScheduler*'

--- a/docs/superpowers/plans/2026-05-19-realtime-party-end.md
+++ b/docs/superpowers/plans/2026-05-19-realtime-party-end.md
@@ -66,7 +66,7 @@
 - [ ] `RealtimePartyStatus.LIVE_ENDING`을 추가한다.
 - [ ] `effectiveEndingStartedAt()`은 `liveEndingStartedAt ?: startedAt.plusMinutes(LIVE_DURATION_MINUTES)`로 계산한다.
 - [ ] `effectiveLiveEndedAt()`은 `effectiveEndingStartedAt().plusSeconds(LIVE_END_COUNTDOWN_SECONDS)`로 계산한다.
-- [ ] `status(now)`는 `LIVE_OPEN`, `LIVE_ENDING`, `LIVE_CLOSED`, `ROLLING_PAPER_CLOSED` 순서를 정확히 반영한다.
+- [ ] `status(now)`는 `ROLLING_PAPER_CLOSED`, `ROLLING_PAPER_OPEN`, `LIVE_OPEN`, `LIVE_ENDING`, `LIVE_CLOSED` 우선순서로 평가한다.
 - [ ] `hostViewableAt()`은 `liveEndingStartedAt ?: startedAt.plusMinutes(LIVE_DURATION_MINUTES)`로 변경한다.
 - [ ] `FlywayMigrationTest`로 V4 migration이 clean DB에 적용되는지 검증한다.
 
@@ -88,7 +88,7 @@ Run:
 - [ ] polling 대상 조회를 추가한다: `liveEndingStartedAt != null`인 realtime party 목록.
 - [ ] `PartyEndScheduler`가 repository를 직접 주입받지 않도록 polling용 UseCase를 제공한다.
 - [ ] 종료 가능 조회는 주최자 권한, `REALTIME` 타입, 4분 경과 또는 박터뜨리기 종료 여부를 검증한다.
-- [ ] 종료 가능 조회의 `canEnd`는 `liveEndingStartedAt == null && (now >= startedAt + 4분 || 박터뜨리기 종료)`일 때만 true다.
+- [ ] 종료 가능 조회의 `canEnd`는 `status(now) == LIVE_OPEN && liveEndingStartedAt == null && (now >= startedAt + 4분 || 박터뜨리기 종료)`일 때만 true다.
 - [ ] 박터뜨리기 완료 상태는 이벤트/상태 provider로 분리해 연결하고, 도메인이 없으면 false를 기본값으로 둔다.
 - [ ] 종료 요청은 `LIVE_CLOSED`를 먼저 거부하고 `REALTIME_PARTY_ALREADY_ENDED`를 반환한다.
 - [ ] 이미 `LIVE_ENDING`이면 수동 종료 가능 조건을 다시 검사하지 않고 기존 `endingStartedAt`, `endedAt`을 반환한다.

--- a/docs/superpowers/plans/2026-05-19-realtime-party-end.md
+++ b/docs/superpowers/plans/2026-05-19-realtime-party-end.md
@@ -24,7 +24,7 @@
 - `party-ended`는 공통 payload만 보내고, 개인화 이동 정보는 `GET /api/v1/parties/{partyId}/realtime-next-action`에서 조회한다.
 - `PartyEndScheduler`는 1초 반복 polling을 사용하지 않고, startup recovery + after-commit event + `TaskScheduler` 예약으로 `party-ending`, `party-ended`를 발송한다.
 - 비회원 참가자의 `rollingPaperWritten`은 `participantToken -> RealtimeParticipantProfile -> Participant.hasWrittenPaper`로 계산한다.
-- 참가자용 `inviteToken`은 해당 party의 만료되지 않은 초대 토큰을 `PartyInviteRepository.findByPartyIdAndExpiresAtAfter(partyId, now)`로 조회한다.
+- 참가자용 `inviteToken`은 `PartyInviteService`를 통해 조회한다. 요청 초대 토큰이 없으면 해당 party의 만료되지 않은 초대 토큰 중 최신 1개를 선택한다.
 - 박터뜨리기 종료는 수동 종료 가능 상태만 열고 자동 종료는 시작하지 않는다.
 
 ---
@@ -117,9 +117,9 @@ Run:
 - [ ] `realtime-state`, `realtime-next-action`은 participant token 사용을 위해 path-specific permitAll로 열고, invalid Bearer token은 기존 JWT 정책대로 401을 유지한다.
 - [ ] 주최자 next action은 `{ type: "HOST_ROLLING_PAPER_LIST", partyId }`로 응답한다.
 - [ ] 참가자 next action은 `{ type: "PARTICIPANT_ROLLING_PAPER_WRITE", inviteToken, rollingPaperWritten }`로 응답한다.
-- [ ] 회원 참가자는 `ParticipantRepository.findByPartyIdAndUserId(...)`로 participant를 찾는다.
-- [ ] 비회원 참가자는 `RealtimeParticipantProfileRepository.findByParticipantToken(...)`로 profile과 participant를 찾는다.
-- [ ] 참가자 `inviteToken`은 `PartyInviteRepository.findByPartyIdAndExpiresAtAfter(partyId, now)`로 조회한다.
+- [ ] 회원 참가자는 `ParticipantService`를 통해 party 소속 participant를 찾는다.
+- [ ] 비회원 참가자는 `ParticipantService` 또는 `RealtimeParticipantProfileService`를 통해 participant token에 연결된 profile과 participant를 찾는다.
+- [ ] 참가자 `inviteToken`은 `PartyInviteService`를 통해 조회한다. 요청 초대 토큰이 있으면 그 값을 우선 사용하고, 없으면 해당 party의 유효 초대 토큰 중 최신 1개를 선택한다.
 - [ ] 참가자 `rollingPaperWritten`은 resolved participant의 `hasWrittenPaper`로 응답한다.
 - [ ] `REALTIME_PARTY_END_NOT_AVAILABLE(400)`, `REALTIME_PARTY_ALREADY_ENDED(409)`를 추가한다.
 - [ ] 컨트롤러 테스트는 기존 MockMvc 통합 테스트 패턴을 따라 `@Import(TestcontainersConfiguration::class)`를 포함한다.

--- a/docs/superpowers/specs/2026-05-19-realtime-party-end-design.md
+++ b/docs/superpowers/specs/2026-05-19-realtime-party-end-design.md
@@ -1,0 +1,312 @@
+# 실시간 파티 종료 설계
+
+- 작성일: 2026-05-19
+- 기준 브랜치: `develop`
+- 운영 전제: 단일 애플리케이션 인스턴스
+
+## 1. 정책
+
+실시간 파티 종료는 `Party.endedAt()`과 별개의 실시간 세션 종료이다.
+
+- 주최자만 수동 종료 가능
+- 수동 종료 가능 조건: `startedAt + 4분` 도달 또는 박터뜨리기 종료
+- 박터뜨리기 종료는 수동 종료 가능 상태만 열고 자동 종료를 시작하지 않음
+- 자동 종료 트리거: `startedAt + 10분`
+- 종료 트리거 후 즉시 종료하지 않고 60초 카운트다운 진행
+- `party-ending` 전송 후 60초 뒤 `party-ended` 전송
+- `party-ended` 전송 후 짧은 grace time 뒤 남은 SSE emitter 정리
+- 실시간 세션 종료 후 재오픈, 신규 입장, 채팅 전송 불가
+- 주최자 롤링페이퍼 열람 가능 시점은 `liveEndingStartedAt ?: startedAt + 10분`
+
+상수:
+
+```kotlin
+RealtimeParty.LIVE_DURATION_MINUTES = 10
+RealtimeParty.HOST_END_AVAILABLE_AFTER_MINUTES = 4
+RealtimeParty.LIVE_END_COUNTDOWN_SECONDS = 60
+```
+
+기존 `PartyEndScheduler.WARN_BEFORE_END_MINUTES`와 `startedAt + 9분` 알림 예약은 제거한다.
+
+## 2. 상태 모델
+
+`realtime_party`에 컬럼을 추가한다.
+
+| 컬럼 | 타입 | nullable | 설명 |
+|---|---|---:|---|
+| `live_ending_started_at` | DATETIME | O | 60초 종료 카운트다운 시작 시각 |
+
+종료 완료 시각은 `live_ending_started_at + 60초`로 계산하고, 종료 원인 컬럼은 두지 않는다.
+
+도메인 계산:
+
+```kotlin
+val automaticEndingStartedAt = startedAt.plusMinutes(RealtimeParty.LIVE_DURATION_MINUTES)
+val effectiveEndingStartedAt = liveEndingStartedAt ?: automaticEndingStartedAt
+val effectiveLiveEndedAt = effectiveEndingStartedAt.plusSeconds(RealtimeParty.LIVE_END_COUNTDOWN_SECONDS)
+
+fun liveEndedAt(): LocalDateTime? =
+    liveEndingStartedAt?.plusSeconds(RealtimeParty.LIVE_END_COUNTDOWN_SECONDS)
+
+override fun hostViewableAt(): LocalDateTime =
+    liveEndingStartedAt ?: startedAt.plusMinutes(RealtimeParty.LIVE_DURATION_MINUTES)
+```
+
+상태:
+
+| 상태 | 조건 |
+|---|---|
+| `ROLLING_PAPER_OPEN` | `now < startedAt` |
+| `LIVE_OPEN` | `startedAt <= now < effectiveEndingStartedAt` |
+| `LIVE_ENDING` | `effectiveEndingStartedAt <= now < effectiveLiveEndedAt` |
+| `LIVE_CLOSED` | `effectiveLiveEndedAt <= now` |
+| `ROLLING_PAPER_CLOSED` | `Party.isEnded(now)` |
+
+## 3. API
+
+### 3-1. 주최자 종료 상태 복구 조회
+
+```http
+GET /api/v1/parties/{partyId}/realtime-end
+Authorization: Bearer {accessToken}
+```
+
+SSE 유실, 새로고침, 화면 재진입 시 주최자 화면 상태를 복구한다.
+주최자 클라이언트는 SSE 연결 직후 이 API를 호출해 종료 가능 상태를 맞춘다.
+
+```json
+{
+  "canEnd": true,
+  "availableAt": "2026-05-19T20:04:00",
+  "endingStartedAt": null,
+  "endedAt": null
+}
+```
+
+### 3-2. 주최자 종료 요청
+
+```http
+POST /api/v1/parties/{partyId}/realtime-end
+Authorization: Bearer {accessToken}
+```
+
+```json
+{
+  "partyId": 1,
+  "endingStartedAt": "2026-05-19T20:06:30",
+  "endedAt": "2026-05-19T20:07:30"
+}
+```
+
+검증:
+
+1. 파티 존재
+2. `partyOption == REALTIME`
+3. 요청자가 주최자
+4. `LIVE_CLOSED`가 아님
+5. 수동 종료 가능 조건 충족
+
+동시성:
+
+```sql
+UPDATE realtime_party
+SET live_ending_started_at = :now
+WHERE id = :partyId
+  AND live_ending_started_at IS NULL
+```
+
+- affected row `1`: 이번 요청이 카운트다운 시작
+- affected row `0`: 이미 시작된 카운트다운 조회 후 반환
+- 자동 종료 트리거도 조건부 update를 사용하되 저장값은 현재 시각이 아니라 `startedAt + 10분`
+
+### 3-3. 실시간 상태 복구 조회
+
+```http
+GET /api/v1/parties/{partyId}/realtime-state
+Authorization: Bearer {accessToken} 또는 X-Participant-Token: {participantToken}
+```
+
+주최자와 기존 참가자 모두 사용한다.
+
+```json
+{
+  "partyId": 1,
+  "status": "LIVE_ENDING",
+  "liveStartAt": "2026-05-19T20:00:00",
+  "endingStartedAt": "2026-05-19T20:10:00",
+  "endedAt": "2026-05-19T20:11:00"
+}
+```
+
+### 3-4. 종료 후 다음 행동 조회
+
+```http
+GET /api/v1/parties/{partyId}/realtime-next-action
+Authorization: Bearer {accessToken} 또는 X-Participant-Token: {participantToken}
+```
+
+`LIVE_CLOSED` 진입 후 호출한다. `party-ended`를 못 받은 클라이언트도 `realtime-state`로 `LIVE_CLOSED`를 확인한 뒤 호출할 수 있다.
+
+권한:
+
+- 주최자: `Authorization` 필요
+- 회원 참가자: `Authorization` 또는 `X-Participant-Token`
+- 비회원 참가자: `X-Participant-Token` 필요
+- 파티 소속이 아니면 `PARTY_FORBIDDEN`
+- `LIVE_OPEN`, `LIVE_ENDING`에서 호출하면 `REALTIME_PARTY_END_NOT_AVAILABLE`
+
+주최자:
+
+```json
+{
+  "type": "HOST_ROLLING_PAPER_LIST",
+  "partyId": 1
+}
+```
+
+참가자:
+
+```json
+{
+  "type": "PARTICIPANT_ROLLING_PAPER_WRITE",
+  "inviteToken": "exampletoken0000",
+  "rollingPaperWritten": false
+}
+```
+
+## 4. SSE 이벤트
+
+### party-state
+
+SSE 연결 직후 항상 현재 상태를 1회 전송한다.
+
+```text
+event: party-state
+data: {"partyId":1,"status":"LIVE_ENDING","liveStartAt":"2026-05-19T20:00:00","endingStartedAt":"2026-05-19T20:10:00","endedAt":"2026-05-19T20:11:00"}
+```
+
+### host-end-available
+
+주최자에게만 전송한다.
+
+```text
+event: host-end-available
+data: {"partyId":1,"availableAt":"2026-05-19T20:04:00"}
+```
+
+발생 조건:
+
+- `startedAt + 4분`
+- `BurstGameEndedEvent` 수신
+
+### party-ending
+
+```text
+event: party-ending
+data: {"partyId":1,"endingStartedAt":"2026-05-19T20:10:00","endedAt":"2026-05-19T20:11:00"}
+```
+
+### party-ended
+
+공통 payload만 전송한다. 개인화 이동 정보는 `realtime-next-action`에서 조회한다.
+
+```text
+event: party-ended
+data: {"partyId":1,"endedAt":"2026-05-19T20:11:00"}
+```
+
+## 5. 스케줄링
+
+`PartyEndScheduler`는 개별 파티별 `party-ended` 예약을 잡지 않고, DB 상태를 기준으로 짧은 주기(예: 1초)로 polling한다. SSE 발송은 트랜잭션 안에서 직접 수행하지 않는다.
+
+자동 종료 시작:
+
+```text
+live_ending_started_at IS NULL
+AND started_at + 10분 <= now
+  -> 조건부 update로 live_ending_started_at = started_at + 10분 저장
+```
+
+수동 종료 시작:
+
+```text
+POST /parties/{partyId}/realtime-end
+  -> 조건부 update로 live_ending_started_at = now 저장
+```
+
+SSE polling:
+
+```text
+live_ending_started_at != null
+AND live_ending_started_at + 60초 > now
+AND partyId not in endingNotifiedPartyIds
+  -> party-ending 전송
+
+live_ending_started_at + 60초 <= now
+AND partyId not in endedNotifiedPartyIds
+  -> party-ended 전송
+  -> grace time 이후 남은 SSE emitter 정리
+```
+
+자동 종료 조건부 update는 현재 시각이 아니라 `startedAt + 10분`을 저장한다.
+`endingNotifiedPartyIds`, `endedNotifiedPartyIds`는 단일 인스턴스 메모리 Set으로 중복 발송을 막는다.
+
+재시작 복구:
+
+- `live_ending_started_at != null && live_ending_started_at + 60초 > now`: polling으로 `party-ending`, `party-ended` 복구
+- `live_ending_started_at + 60초 <= now`: `LIVE_CLOSED`로 계산
+- 누락된 `party-ending`은 별도 보장하지 않고, 클라이언트는 재연결 시 `party-state`로 카운트다운 상태를 복구한다.
+
+## 6. 입장/채팅 검증
+
+신규 입장과 채팅 전송은 `LIVE_OPEN`에서만 허용한다.
+
+```kotlin
+fun isLiveOpen(now: LocalDateTime): Boolean =
+    now >= startedAt && now < effectiveEndingStartedAt
+```
+
+기존 참가자 SSE 재연결:
+
+- `participantToken`으로 기존 profile 확인 가능하면 `LIVE_ENDING`에서도 허용
+- 연결 직후 `party-state` 전송
+- `LIVE_CLOSED`에서는 SSE 재연결하지 않고 `realtime-state` 또는 `realtime-next-action`으로 복구
+
+## 7. 오류 코드
+
+| 상황 | 오류 코드 |
+|---|---|
+| 파티 없음 | `PARTY_NOT_FOUND` |
+| 실시간 파티가 아님 | `CHAT_NOT_SUPPORTED` |
+| 주최자가 아님 | `PARTY_FORBIDDEN` |
+| 아직 종료 가능 시점이 아님 | `REALTIME_PARTY_END_NOT_AVAILABLE` |
+| 이미 종료됨 | `REALTIME_PARTY_ALREADY_ENDED` |
+
+```kotlin
+REALTIME_PARTY_END_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "아직 실시간 파티를 종료할 수 없습니다")
+REALTIME_PARTY_ALREADY_ENDED(HttpStatus.CONFLICT, "이미 종료된 실시간 파티입니다")
+```
+
+## 8. 구현 체크리스트
+
+1. `RealtimeParty.liveEndingStartedAt` 추가
+2. Flyway migration 추가
+3. `RealtimePartyStatus.LIVE_ENDING` 추가
+4. `RealtimeParty.hostViewableAt()` 수정
+5. 종료 가능 상태 복구 조회 API 추가
+6. 주최자 종료 요청 API 추가
+7. 실시간 상태 복구 API 추가
+8. 종료 후 다음 행동 조회 API 추가
+9. `host-end-available`, `party-state`, `party-ending`, `party-ended` SSE 처리
+10. `PartyEndScheduler`를 DB polling 기반 `party-ending`, `party-ended` 발송 구조로 변경
+11. 기존 `WARN_BEFORE_END_MINUTES`와 9분 트리거 제거
+12. 종료 시작 조건부 update 구현
+13. `party-ended` 후 grace cleanup 적용
+14. 신규 입장/채팅 검증에서 `LIVE_ENDING`, `LIVE_CLOSED` 차단
+15. 기존 참가자 `LIVE_ENDING` SSE 재연결 허용
+16. 박터뜨리기 종료 시 `BurstGameEndedEvent` 발행/구독 연결
+17. 테스트 추가
+
+## 9. 확인 필요
+
+- 비회원 참가자의 `rollingPaperWritten` 계산 기준: 현재 롤링페이퍼 작성은 `inviteToken`, 실시간 채팅은 `participantToken` 기반이다.

--- a/docs/superpowers/specs/2026-05-19-realtime-party-end-design.md
+++ b/docs/superpowers/specs/2026-05-19-realtime-party-end-design.md
@@ -340,4 +340,7 @@ REALTIME_PARTY_ALREADY_ENDED(HttpStatus.CONFLICT, "이미 종료된 실시간 �
 ## 9. 참가자 next action 계산 기준
 
 - 비회원 참가자의 `rollingPaperWritten`은 `participantToken -> RealtimeParticipantProfile -> Participant.hasWrittenPaper`로 계산한다.
-- 참가자용 `inviteToken`은 해당 party의 만료되지 않은 초대 토큰을 `PartyInviteRepository.findByPartyIdAndExpiresAtAfter(partyId, now)`로 조회한다.
+- 참가자용 `inviteToken`은 참가자가 현재 요청에서 사용한 초대 토큰이 있으면 그 값을 우선 사용한다.
+- 요청 초대 토큰이 없으면 해당 party의 만료되지 않은 초대 토큰 중 가장 최근 생성된 토큰을 사용한다.
+  - 구현 시 `PartyInviteService`가 유효 초대 토큰 조회와 선택 기준을 캡슐화한다.
+  - 유효 초대 토큰이 여러 개면 `createdAt DESC`, `id DESC` 기준으로 1개를 선택한다.

--- a/docs/superpowers/specs/2026-05-19-realtime-party-end-design.md
+++ b/docs/superpowers/specs/2026-05-19-realtime-party-end-design.md
@@ -83,6 +83,12 @@ SSE 유실, 새로고침, 화면 재진입 시 주최자 화면 상태를 복구
 }
 ```
 
+`canEnd` 계산:
+
+- `liveEndingStartedAt != null`이면 이미 종료 절차가 시작된 상태이므로 `canEnd = false`
+- 그 외에는 `now >= startedAt + 4분` 또는 박터뜨리기 종료 상태이면 `canEnd = true`
+- 위 조건을 만족하지 않으면 `canEnd = false`
+
 ### 3-2. 주최자 종료 요청
 
 ```http
@@ -98,13 +104,16 @@ Authorization: Bearer {accessToken}
 }
 ```
 
-검증:
+처리 순서:
 
 1. 파티 존재
 2. `partyOption == REALTIME`
 3. 요청자가 주최자
-4. `LIVE_CLOSED`가 아님
-5. 수동 종료 가능 조건 충족
+4. `LIVE_CLOSED`이면 `REALTIME_PARTY_ALREADY_ENDED`
+5. `LIVE_ENDING`이면 수동 종료 가능 조건을 다시 검사하지 않고 기존 `endingStartedAt`, `endedAt` 반환
+6. `LIVE_OPEN`이면 수동 종료 가능 조건 검사
+7. 수동 종료 가능 조건을 만족하지 않으면 `REALTIME_PARTY_END_NOT_AVAILABLE`
+8. 조건부 update 실행 후 affected row 기준으로 신규 시작 또는 기존 카운트다운 반환
 
 동시성:
 

--- a/docs/superpowers/specs/2026-05-19-realtime-party-end-design.md
+++ b/docs/superpowers/specs/2026-05-19-realtime-party-end-design.md
@@ -228,14 +228,31 @@ data: {"partyId":1,"endedAt":"2026-05-19T20:11:00"}
 
 ## 5. 스케줄링
 
-`PartyEndScheduler`는 개별 파티별 `party-ended` 예약을 잡지 않고, DB 상태를 기준으로 짧은 주기(예: 1초)로 polling한다. SSE 발송은 트랜잭션 안에서 직접 수행하지 않는다.
+`PartyEndScheduler`는 1초 반복 polling을 사용하지 않는다. DB는 source of truth로 두고, 평상시에는 `TaskScheduler` 예약과 트랜잭션 commit 이후 이벤트로 동작한다. SSE 발송은 트랜잭션 안에서 직접 수행하지 않는다.
 
-자동 종료 시작:
+앱 시작 시 1회 복구:
 
 ```text
 live_ending_started_at IS NULL
 AND started_at + 10분 <= now
   -> 조건부 update로 live_ending_started_at = started_at + 10분 저장
+
+live_ending_started_at IS NULL
+AND started_at + 10분 > now
+  -> started_at + 10분에 자동 종료 시작 예약
+
+live_ending_started_at != null
+  -> live_ending_started_at + 60초에 party-ended 예약
+```
+
+이미 `live_ending_started_at + 60초 <= now`인 경우에는 즉시 `party-ended` 처리 대상으로 본다.
+
+자동 종료 시작:
+
+```text
+TaskScheduler 예약 시각 도달
+  -> 조건부 update로 live_ending_started_at = started_at + 10분 저장
+  -> commit 이후 RealtimePartyEndingStartedEvent 발행
 ```
 
 수동 종료 시작:
@@ -243,30 +260,32 @@ AND started_at + 10분 <= now
 ```text
 POST /api/v1/parties/{partyId}/realtime-end
   -> 조건부 update로 live_ending_started_at = now 저장
+  -> commit 이후 RealtimePartyEndingStartedEvent 발행
 ```
 
-SSE polling:
+신규 실시간 파티 생성:
 
 ```text
-live_ending_started_at != null
-AND live_ending_started_at + 60초 > now
-AND partyId not in endingNotifiedPartyIds
-  -> party-ending 전송
-
-live_ending_started_at + 60초 <= now
-AND partyId not in endedNotifiedPartyIds
-  -> party-ended 전송
-  -> grace time 이후 남은 SSE emitter 정리
+CreateRealtimePartyUseCase
+  -> commit 이후 RealtimePartyCreatedEvent 발행
+  -> started_at + 10분에 자동 종료 시작 예약
 ```
 
-자동 종료 조건부 update는 현재 시각이 아니라 `startedAt + 10분`을 저장한다.
-`endingNotifiedPartyIds`, `endedNotifiedPartyIds`는 단일 인스턴스 메모리 Set으로 중복 발송을 막는다.
+종료 시작 이벤트 처리:
+
+```text
+RealtimePartyEndingStartedEvent
+  -> party-ending 전송
+  -> live_ending_started_at + 60초에 party-ended 예약
+  -> party-ended 이후 grace time 뒤 남은 SSE emitter 정리
+```
 
 재시작 복구:
 
-- `live_ending_started_at != null && live_ending_started_at + 60초 > now`: polling으로 `party-ending`, `party-ended` 복구
-- `live_ending_started_at + 60초 <= now`: `LIVE_CLOSED`로 계산
-- 누락된 `party-ending`은 별도 보장하지 않고, 클라이언트는 재연결 시 `party-state`로 카운트다운 상태를 복구한다.
+- `live_ending_started_at == null && started_at + 10분 > now`: 자동 종료 시작 예약 복구
+- `live_ending_started_at == null && started_at + 10분 <= now`: 조건부 update 후 종료 시작 이벤트 처리
+- `live_ending_started_at != null`: `party-ended` 예약 복구
+- 누락된 `party-ending`은 클라이언트가 재연결 시 `party-state`로 카운트다운 상태를 복구한다.
 
 ## 6. 입장/채팅 검증
 
@@ -309,7 +328,7 @@ REALTIME_PARTY_ALREADY_ENDED(HttpStatus.CONFLICT, "이미 종료된 실시간 �
 7. 실시간 상태 복구 API 추가
 8. 종료 후 다음 행동 조회 API 추가
 9. `host-end-available`, `party-state`, `party-ending`, `party-ended` SSE 처리
-10. `PartyEndScheduler`를 DB polling 기반 `party-ending`, `party-ended` 발송 구조로 변경
+10. `PartyEndScheduler`를 startup recovery + event 기반 예약 구조로 변경
 11. 기존 `WARN_BEFORE_END_MINUTES`와 9분 트리거 제거
 12. 종료 시작 조건부 update 구현
 13. `party-ended` 후 grace cleanup 적용

--- a/docs/superpowers/specs/2026-05-19-realtime-party-end-design.md
+++ b/docs/superpowers/specs/2026-05-19-realtime-party-end-design.md
@@ -54,13 +54,15 @@ override fun hostViewableAt(): LocalDateTime =
 
 상태:
 
+아래 순서로 평가한다. `Party.isEnded(now)`가 우선되어야 `LIVE_CLOSED`가 롤링페이퍼 종료 상태를 가리지 않는다.
+
 | 상태 | 조건 |
 |---|---|
+| `ROLLING_PAPER_CLOSED` | `Party.isEnded(now)` |
 | `ROLLING_PAPER_OPEN` | `now < startedAt` |
 | `LIVE_OPEN` | `startedAt <= now < effectiveEndingStartedAt` |
 | `LIVE_ENDING` | `effectiveEndingStartedAt <= now < effectiveLiveEndedAt` |
 | `LIVE_CLOSED` | `effectiveLiveEndedAt <= now` |
-| `ROLLING_PAPER_CLOSED` | `Party.isEnded(now)` |
 
 ## 3. API
 
@@ -86,7 +88,7 @@ SSE 유실, 새로고침, 화면 재진입 시 주최자 화면 상태를 복구
 `canEnd` 계산:
 
 - `liveEndingStartedAt != null`이면 이미 종료 절차가 시작된 상태이므로 `canEnd = false`
-- 그 외에는 `now >= startedAt + 4분` 또는 박터뜨리기 종료 상태이면 `canEnd = true`
+- 그 외에는 `status(now) == RealtimePartyStatus.LIVE_OPEN`이고, `now >= startedAt + 4분` 또는 박터뜨리기 종료 상태이면 `canEnd = true`
 - 위 조건을 만족하지 않으면 `canEnd = false`
 
 ### 3-2. 주최자 종료 요청
@@ -239,7 +241,7 @@ AND started_at + 10분 <= now
 수동 종료 시작:
 
 ```text
-POST /parties/{partyId}/realtime-end
+POST /api/v1/parties/{partyId}/realtime-end
   -> 조건부 update로 live_ending_started_at = now 저장
 ```
 

--- a/docs/superpowers/specs/2026-05-19-realtime-party-end-design.md
+++ b/docs/superpowers/specs/2026-05-19-realtime-party-end-design.md
@@ -318,6 +318,7 @@ REALTIME_PARTY_ALREADY_ENDED(HttpStatus.CONFLICT, "이미 종료된 실시간 �
 16. 박터뜨리기 종료 시 `BurstGameEndedEvent` 발행/구독 연결
 17. 테스트 추가
 
-## 9. 확인 필요
+## 9. 참가자 next action 계산 기준
 
-- 비회원 참가자의 `rollingPaperWritten` 계산 기준: 현재 롤링페이퍼 작성은 `inviteToken`, 실시간 채팅은 `participantToken` 기반이다.
+- 비회원 참가자의 `rollingPaperWritten`은 `participantToken -> RealtimeParticipantProfile -> Participant.hasWrittenPaper`로 계산한다.
+- 참가자용 `inviteToken`은 해당 party의 만료되지 않은 초대 토큰을 `PartyInviteRepository.findByPartyIdAndExpiresAtAfter(partyId, now)`로 조회한다.


### PR DESCRIPTION
## 🔗 Issue
- closes #155

## 💬 Context
실시간 파티 종료 기능 구현 전 정책, API/SSE 계약, 구현 순서를 문서로 정리합니다.

## 🛠 Changes
- 실시간 파티 종료 설계 spec 추가
- 실시간 파티 종료 구현 plan 추가
- CodeRabbit/ArchUnit/CLAUDE 규칙 피드백 반영

## 👀 Review Focus
- 종료 상태와 SSE 이벤트 계약이 구현 가능한 수준으로 충분한지

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서**
  * 실시간 파티 종료 기획·설계 문서 추가: 주최자 수동 종료·자동 종료, 60초 카운트다운, 종료 전/후 SSE 이벤트 흐름(party-state/host-end-available/party-ending/party-ended), 종료 상태 및 노출 시점 규칙, 종료 후 입장·채팅 제한, 복구·스케줄링 정책(시작 시 복구·예약·이벤트 기반 처리), API 응답·오류 코드·검증 시나리오·구현 체크리스트 정리.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/18th-team2-server/pull/156?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->