### PR TITLE
[Feat] 실시간 파티 종료 스키마 추가

### DIFF
--- a/src/main/resources/db/migration/V4__add_realtime_party_end_state.sql
+++ b/src/main/resources/db/migration/V4__add_realtime_party_end_state.sql
@@ -1,0 +1,2 @@
+ALTER TABLE realtime_party
+    ADD COLUMN live_ending_started_at DATETIME(6) NULL;

--- a/src/test/kotlin/com/team2/server/db/FlywayMigrationTest.kt
+++ b/src/test/kotlin/com/team2/server/db/FlywayMigrationTest.kt
@@ -69,7 +69,10 @@ class FlywayMigrationTest {
             statement.setString(1, table)
             statement.setString(2, column)
             statement.executeQuery().use { resultSet ->
-                resultSet.next()
+                if (!resultSet.next()) {
+                    throw NoSuchElementException("Column not found: $table.$column")
+                }
+
                 ColumnDefinition(
                     dataType = resultSet.getString("data_type"),
                     datetimePrecision = resultSet.getInt("datetime_precision"),

--- a/src/test/kotlin/com/team2/server/db/FlywayMigrationTest.kt
+++ b/src/test/kotlin/com/team2/server/db/FlywayMigrationTest.kt
@@ -23,6 +23,10 @@ class FlywayMigrationTest {
             assertEquals(5, connection.countRows("avatar"))
             assertEquals(3, connection.countRows("rolling_paper_wrapper"))
             assertEquals(13, connection.countRows("image"))
+            assertEquals(
+                ColumnDefinition(dataType = "datetime", datetimePrecision = 6, nullable = true),
+                connection.findColumn("realtime_party", "live_ending_started_at"),
+            )
         }
     }
 
@@ -38,6 +42,7 @@ class FlywayMigrationTest {
 
     private companion object {
         private val COUNTABLE_TABLES = setOf("avatar", "rolling_paper_wrapper", "image")
+        private val TABLES_WITH_COLUMNS_TO_ASSERT = setOf("realtime_party")
 
         @JvmStatic
         private val MYSQL: MySQLContainer<*> =
@@ -46,4 +51,37 @@ class FlywayMigrationTest {
                 .withReuse(true)
                 .also { it.start() }
     }
+
+    private fun java.sql.Connection.findColumn(
+        table: String,
+        column: String,
+    ): ColumnDefinition {
+        require(table in TABLES_WITH_COLUMNS_TO_ASSERT) { "Unsupported table name: $table" }
+        return prepareStatement(
+            """
+            select data_type, datetime_precision, is_nullable
+            from information_schema.columns
+            where table_schema = database()
+              and table_name = ?
+              and column_name = ?
+            """.trimIndent(),
+        ).use { statement ->
+            statement.setString(1, table)
+            statement.setString(2, column)
+            statement.executeQuery().use { resultSet ->
+                resultSet.next()
+                ColumnDefinition(
+                    dataType = resultSet.getString("data_type"),
+                    datetimePrecision = resultSet.getInt("datetime_precision"),
+                    nullable = resultSet.getString("is_nullable") == "YES",
+                )
+            }
+        }
+    }
+
+    private data class ColumnDefinition(
+        val dataType: String,
+        val datetimePrecision: Int,
+        val nullable: Boolean,
+    )
 }


### PR DESCRIPTION
## 🔗 Issue
- closes #157

## 💬 Context
실시간 파티 종료 구현에 앞서 카운트다운 시작 시각을 저장할 스키마를 먼저 추가합니다.

## 🛠 Changes
- `realtime_party.live_ending_started_at` 컬럼 추가
- Flyway clean DB 마이그레이션 테스트에서 컬럼 타입, precision, nullable 검증 추가

## 👀 Review Focus
- 컬럼 타입과 nullable 정책이 설계 문서와 맞는지
- 구현 PR 전 선행 schema PR 범위로 적절한지

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인