### PR TITLE
[Docs] 레이어드 아키텍처 Response DTO 룰 모순 해소

### DIFF
--- a/.claude/rules/layered-architecture.md
+++ b/.claude/rules/layered-architecture.md
@@ -4,10 +4,11 @@
 
 ```
 feature/
-├── api/              Controller, Request/Response DTO
+├── api/              Controller, Request DTO, (선택) Response DTO
 ├── application/
 │   ├── usecase/      흐름 제어, @Transactional 경계
-│   └── service/      Aggregate 단위 행위
+│   ├── service/      Aggregate 단위 행위
+│   └── dto/          UseCase 입출력 모델 (Command / Result)
 ├── domain/
 │   ├── entity/       행동 있는 JPA 엔티티
 │   ├── policy/       여러 엔티티 걸친 도메인 규칙
@@ -24,7 +25,7 @@ api → usecase → service → infrastructure
          └── domain ◀┘
 ```
 
-- Controller → UseCase만 허용
+- Controller → UseCase 호출만 허용 (UseCase 입출력용 `application/dto` 타입 참조는 허용)
 - UseCase → Service 조합, 다른 feature UseCase 허용
 - Service → 자기 Aggregate Repository/Domain만 허용
 - Service → Service 호출 금지 (어디든)

--- a/.claude/rules/layered-architecture.md
+++ b/.claude/rules/layered-architecture.md
@@ -36,7 +36,9 @@ api → usecase → service → infrastructure
 - `@Transactional`은 UseCase에만 선언
 - 60줄 이내, 생성자 의존성 5개 이내
 - Repository 쓰기(save/delete) 직접 호출 금지 → Service 위임
-- Response DTO 변환은 UseCase 책임
+- UseCase 는 `application/dto` 의 출력 모델을 반환 (도메인 객체 노출 금지)
+- `api/dto` 의 Response DTO 는 외부 노출 형태가 application 출력과 달라야 할 때만 분리 (versioning, 필드 가공, 다중 채널 직렬화 등)
+- 1:1 매핑이면 `application/dto` 하나만 두고 Controller 는 `ApiResponse` wrapper 만 씌운다
 
 ## Service 규칙
 


### PR DESCRIPTION
## 🔗 Issue
- 관련 없음 (룰 문서 정리)

## 💬 Context
PR #151 리뷰 중 \`.claude/rules/layered-architecture.md\` 안에서 세 룰이 동시에 만족 불가능한 모순이 드러났다.

| 룰 | 내용 |
|----|------|
| L7 패키지 구조 | \`Response DTO\` 는 \`api/\` 패키지 소속 |
| L22 의존 방향 | \`api → usecase → service → infrastructure\` (역방향 금지) |
| L39 UseCase 규칙 | Response DTO 변환은 UseCase 책임 |

UseCase 가 Response DTO 를 반환하려면 \`application → api\` 역방향 import 가 필요해 L7·L22 와 충돌. 또 1:1 매핑인데도 \`application/dto/*Result\` 와 \`api/dto/*Response\` 를 둘 다 만드는 패턴이 강제돼 보일러플레이트가 발생.

## 🛠 Changes
- \`.claude/rules/layered-architecture.md\` UseCase 규칙 L39 1줄 → 3줄로 분리·명확화
  - \`UseCase 는 application/dto 의 출력 모델 반환\` (도메인 객체 노출 금지)
  - \`api/dto Response DTO 는 application 출력과 달라야 할 때만 분리\` (versioning / 필드 가공 / 다중 채널 직렬화)
  - \`1:1 매핑이면 application/dto 하나만 두고 Controller 는 ApiResponse wrapper 만 씌운다\`

## 👀 Review Focus
- **모순 해소가 의도대로 됐는지** — L7(Response DTO 위치) / L22(의존 방향) / L39(UseCase 변환 책임) 셋이 더 이상 충돌하지 않는가
- **Result/Response 분리 기준** — \`외부 노출 형태가 application 출력과 달라야 할 때만\` 이라는 표현이 충분히 명확한지, 더 좋은 예시·기준이 있는지
- **기존 PR 들에 미치는 영향** — \`application/dto/*Result\` 와 \`api/dto/*Response\` 를 둘 다 둔 기존 코드를 강제 마이그레이션할지, 신규 코드부터 적용할지 정책 결정 필요
- **후속 작업** — PR #151 (\`feature/my-page-account-api\`) 은 본 룰 변경 머지 후 \`MeAccountResponse\` 제거 + \`MeAccountResult\` 단일화로 별도 정리 예정

## ⚠️ Side Effects
- **DB 마이그레이션**: 없음
- **환경변수/설정**: 없음
- **의존성 변경**: 없음
- **API 변경(Breaking)**: 없음
- **외부 시스템 영향**: 없음
- **운영 작업**: 없음 — 문서 변경만

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 레이어드 아키텍처 가이드를 업데이트하여 패키지 구조를 더욱 명확히 했습니다.
  * 계층 간 의존성 규칙을 개선하고 데이터 전송 객체(DTO) 사용 기준을 정리했습니다.
  * API 계층 구성 및 응답 DTO 분리 조건을 구체화했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/18th-team2-server/pull/159?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->