### PR TITLE
[Feat] 실시간 프로필 닉네임 중복 검사 정책 추가

### DIFF
--- a/src/main/kotlin/com/team2/server/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/team2/server/common/exception/ErrorCode.kt
@@ -33,6 +33,7 @@ enum class ErrorCode(
     ROLLING_PAPER_NOT_VIEWABLE(HttpStatus.FORBIDDEN, "아직 롤링페이퍼를 확인할 수 없습니다"),
     ROLLING_PAPER_NOT_FOUND(HttpStatus.NOT_FOUND, "롤링페이퍼를 찾을 수 없습니다"),
     PARTY_HOST_NICKNAME_NOT_EDITABLE(HttpStatus.BAD_REQUEST, "주최자 닉네임은 변경할 수 없습니다"),
+    PARTY_NICKNAME_DUPLICATED(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다"),
     CHAT_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "채팅을 지원하지 않는 파티입니다"),
     CHAT_NOT_ACTIVE(HttpStatus.BAD_REQUEST, "현재 채팅이 활성화된 시간이 아닙니다"),
     BURST_GAME_NOT_FOUND(HttpStatus.NOT_FOUND, "박터뜨리기 라운드를 찾을 수 없습니다"),

--- a/src/main/kotlin/com/team2/server/party/application/service/RealtimeParticipantProfileService.kt
+++ b/src/main/kotlin/com/team2/server/party/application/service/RealtimeParticipantProfileService.kt
@@ -25,6 +25,7 @@ class RealtimeParticipantProfileService(
     ): RealtimeParticipantProfile {
         val existing = profileRepository.findByParticipant(participant)
         if (existing == null) {
+            validateNicknameUnique(participant, nickname)
             return profileRepository.save(
                 RealtimeParticipantProfile(
                     participant = participant,
@@ -33,12 +34,30 @@ class RealtimeParticipantProfileService(
                 ),
             )
         }
-        if (isHostNicknameLocked && existing.nickname != nickname) {
-            throw BusinessException(ErrorCode.PARTY_HOST_NICKNAME_NOT_EDITABLE)
+        if (existing.nickname != nickname) {
+            if (isHostNicknameLocked) {
+                throw BusinessException(ErrorCode.PARTY_HOST_NICKNAME_NOT_EDITABLE)
+            }
+            validateNicknameUnique(participant, nickname)
         }
         existing.nickname = nickname
         existing.character = character
         return existing
+    }
+
+    private fun validateNicknameUnique(
+        participant: Participant,
+        nickname: String,
+    ) {
+        val duplicated =
+            profileRepository.existsByPartyIdAndNicknameIgnoreCaseExcludingParticipant(
+                partyId = participant.party.id,
+                nickname = nickname,
+                excludingParticipantId = participant.id,
+            )
+        if (duplicated) {
+            throw BusinessException(ErrorCode.PARTY_NICKNAME_DUPLICATED)
+        }
     }
 
     fun resolveProfile(

--- a/src/main/kotlin/com/team2/server/party/infrastructure/persistence/RealtimeParticipantProfileRepository.kt
+++ b/src/main/kotlin/com/team2/server/party/infrastructure/persistence/RealtimeParticipantProfileRepository.kt
@@ -26,6 +26,21 @@ interface RealtimeParticipantProfileRepository : JpaRepository<RealtimeParticipa
 
     fun findAllByParticipantIdIn(participantIds: Collection<Long>): List<RealtimeParticipantProfile>
 
+    @Query(
+        """
+        SELECT (COUNT(profile) > 0)
+        FROM RealtimeParticipantProfile profile
+        WHERE profile.participant.party.id = :partyId
+          AND LOWER(profile.nickname) = LOWER(:nickname)
+          AND profile.participant.id <> :excludingParticipantId
+        """,
+    )
+    fun existsByPartyIdAndNicknameIgnoreCaseExcludingParticipant(
+        partyId: Long,
+        nickname: String,
+        excludingParticipantId: Long,
+    ): Boolean
+
     @Modifying
     fun deleteAllByParticipantIdIn(participantIds: List<Long>)
 

--- a/src/test/kotlin/com/team2/server/party/application/service/RealtimeParticipantProfileServiceTest.kt
+++ b/src/test/kotlin/com/team2/server/party/application/service/RealtimeParticipantProfileServiceTest.kt
@@ -16,6 +16,7 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -49,6 +50,13 @@ class RealtimeParticipantProfileServiceTest {
     fun `기존 프로필이 없으면 새로 생성한다`() {
         val participant = newParticipant(isCelebrant = false)
         whenever(profileRepository.findByParticipant(participant)).thenReturn(null)
+        whenever(
+            profileRepository.existsByPartyIdAndNicknameIgnoreCaseExcludingParticipant(
+                partyId = eq(party.id),
+                nickname = eq("안녕"),
+                excludingParticipantId = eq(participant.id),
+            ),
+        ).thenReturn(false)
         whenever(profileRepository.save(any<RealtimeParticipantProfile>())).thenAnswer { it.arguments[0] }
 
         val result = service.upsert(participant, "안녕", character, isHostNicknameLocked = false)
@@ -68,6 +76,13 @@ class RealtimeParticipantProfileServiceTest {
         val existing =
             RealtimeParticipantProfile(participant = participant, nickname = "old", character = character)
         whenever(profileRepository.findByParticipant(participant)).thenReturn(existing)
+        whenever(
+            profileRepository.existsByPartyIdAndNicknameIgnoreCaseExcludingParticipant(
+                partyId = eq(party.id),
+                nickname = eq("new"),
+                excludingParticipantId = eq(participant.id),
+            ),
+        ).thenReturn(false)
 
         val result = service.upsert(participant, "new", anotherCharacter, isHostNicknameLocked = false)
 
@@ -106,5 +121,65 @@ class RealtimeParticipantProfileServiceTest {
         assertEquals(ErrorCode.PARTY_HOST_NICKNAME_NOT_EDITABLE, e.errorCode)
         assertEquals("host", existing.nickname)
         assertSame(character, existing.character)
+    }
+
+    @Test
+    fun `새 프로필 생성 시 같은 파티에 동일 nickname이 있으면 PARTY_NICKNAME_DUPLICATED`() {
+        val participant = newParticipant(isCelebrant = false)
+        whenever(profileRepository.findByParticipant(participant)).thenReturn(null)
+        whenever(
+            profileRepository.existsByPartyIdAndNicknameIgnoreCaseExcludingParticipant(
+                partyId = eq(party.id),
+                nickname = eq("dupe"),
+                excludingParticipantId = eq(participant.id),
+            ),
+        ).thenReturn(true)
+
+        val e =
+            assertThrows<BusinessException> {
+                service.upsert(participant, "dupe", character, isHostNicknameLocked = false)
+            }
+        assertEquals(ErrorCode.PARTY_NICKNAME_DUPLICATED, e.errorCode)
+        verify(profileRepository, never()).save(any<RealtimeParticipantProfile>())
+    }
+
+    @Test
+    fun `기존 프로필 갱신 시 nickname이 변경되고 중복이면 PARTY_NICKNAME_DUPLICATED`() {
+        val participant = newParticipant(isCelebrant = false)
+        val existing =
+            RealtimeParticipantProfile(participant = participant, nickname = "old", character = character)
+        whenever(profileRepository.findByParticipant(participant)).thenReturn(existing)
+        whenever(
+            profileRepository.existsByPartyIdAndNicknameIgnoreCaseExcludingParticipant(
+                partyId = eq(party.id),
+                nickname = eq("new"),
+                excludingParticipantId = eq(participant.id),
+            ),
+        ).thenReturn(true)
+
+        val e =
+            assertThrows<BusinessException> {
+                service.upsert(participant, "new", anotherCharacter, isHostNicknameLocked = false)
+            }
+        assertEquals(ErrorCode.PARTY_NICKNAME_DUPLICATED, e.errorCode)
+        assertEquals("old", existing.nickname)
+        assertSame(character, existing.character)
+    }
+
+    @Test
+    fun `nickname이 변경되지 않으면 중복 검사를 수행하지 않는다`() {
+        val participant = newParticipant(isCelebrant = false)
+        val existing =
+            RealtimeParticipantProfile(participant = participant, nickname = "same", character = character)
+        whenever(profileRepository.findByParticipant(participant)).thenReturn(existing)
+
+        service.upsert(participant, "same", anotherCharacter, isHostNicknameLocked = false)
+
+        verify(profileRepository, never()).existsByPartyIdAndNicknameIgnoreCaseExcludingParticipant(
+            any(),
+            any(),
+            any(),
+        )
+        assertSame(anotherCharacter, existing.character)
     }
 }

--- a/src/test/kotlin/com/team2/server/party/infrastructure/persistence/RealtimeParticipantProfileRepositoryTest.kt
+++ b/src/test/kotlin/com/team2/server/party/infrastructure/persistence/RealtimeParticipantProfileRepositoryTest.kt
@@ -14,6 +14,7 @@ import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest
 import org.springframework.context.annotation.Import
 import java.time.LocalDateTime
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @DataJpaTest
@@ -142,5 +143,118 @@ class RealtimeParticipantProfileRepositoryTest
         fun `findAllByParticipantIdIn - 빈 컬렉션이면 빈 리스트`() {
             val result = profileRepository.findAllByParticipantIdIn(emptyList())
             assertTrue(result.isEmpty())
+        }
+
+        @Test
+        fun `existsByPartyIdAndNicknameIgnoreCaseExcludingParticipant - 대소문자 무시하고 같은 파티 내 중복을 감지`() {
+            val party =
+                partyRepository.save(
+                    RealtimeParty(ownerId = 1L, name = "p", celebrantNickname = "홍", startedAt = LocalDateTime.now()),
+                )
+            val userA =
+                userRepository.save(
+                    User(
+                        name = "A",
+                        birthDay = "01-01",
+                        email = "a@x",
+                        provider = AuthProvider.KAKAO,
+                        providerId = "a",
+                    ),
+                )
+            val userB =
+                userRepository.save(
+                    User(
+                        name = "B",
+                        birthDay = "02-02",
+                        email = "b@x",
+                        provider = AuthProvider.KAKAO,
+                        providerId = "b",
+                    ),
+                )
+            val pA = participantRepository.save(Participant(party = party, user = userA))
+            val pB = participantRepository.save(Participant(party = party, user = userB))
+            profileRepository.save(RealtimeParticipantProfile(participant = pA, nickname = "Alpha"))
+
+            val duplicated =
+                profileRepository.existsByPartyIdAndNicknameIgnoreCaseExcludingParticipant(
+                    partyId = party.id,
+                    nickname = "alpha",
+                    excludingParticipantId = pB.id,
+                )
+
+            assertTrue(duplicated)
+        }
+
+        @Test
+        fun `existsByPartyIdAndNicknameIgnoreCaseExcludingParticipant - 자기 자신의 nickname은 중복으로 보지 않는다`() {
+            val party =
+                partyRepository.save(
+                    RealtimeParty(ownerId = 1L, name = "p", celebrantNickname = "홍", startedAt = LocalDateTime.now()),
+                )
+            val user =
+                userRepository.save(
+                    User(
+                        name = "U",
+                        birthDay = "01-01",
+                        email = "u@x",
+                        provider = AuthProvider.KAKAO,
+                        providerId = "u",
+                    ),
+                )
+            val participant = participantRepository.save(Participant(party = party, user = user))
+            profileRepository.save(RealtimeParticipantProfile(participant = participant, nickname = "Same"))
+
+            val duplicated =
+                profileRepository.existsByPartyIdAndNicknameIgnoreCaseExcludingParticipant(
+                    partyId = party.id,
+                    nickname = "same",
+                    excludingParticipantId = participant.id,
+                )
+
+            assertFalse(duplicated)
+        }
+
+        @Test
+        fun `existsByPartyIdAndNicknameIgnoreCaseExcludingParticipant - 다른 파티의 동일 nickname은 무시`() {
+            val party1 =
+                partyRepository.save(
+                    RealtimeParty(ownerId = 1L, name = "p1", celebrantNickname = "홍", startedAt = LocalDateTime.now()),
+                )
+            val party2 =
+                partyRepository.save(
+                    RealtimeParty(ownerId = 1L, name = "p2", celebrantNickname = "홍", startedAt = LocalDateTime.now()),
+                )
+            val userA =
+                userRepository.save(
+                    User(
+                        name = "A",
+                        birthDay = "01-01",
+                        email = "aa@x",
+                        provider = AuthProvider.KAKAO,
+                        providerId = "aa",
+                    ),
+                )
+            val userB =
+                userRepository.save(
+                    User(
+                        name = "B",
+                        birthDay = "02-02",
+                        email = "bb@x",
+                        provider = AuthProvider.KAKAO,
+                        providerId = "bb",
+                    ),
+                )
+            val pInParty1 = participantRepository.save(Participant(party = party1, user = userA))
+            val pInParty2 = participantRepository.save(Participant(party = party2, user = userB))
+            profileRepository.save(RealtimeParticipantProfile(participant = pInParty1, nickname = "Same"))
+
+            val duplicated =
+                profileRepository.existsByPartyIdAndNicknameIgnoreCaseExcludingParticipant(
+                    partyId = party2.id,
+                    nickname = "same",
+                    excludingParticipantId = pInParty2.id,
+                )
+
+            assertFalse(duplicated)
         }
     }


### PR DESCRIPTION
## 🔗 Issue
- closes #166

## 💬 Context
실시간 프로필 upsert 엔드포인트(`PUT /api/v1/party-invites/{inviteToken}/participants/me/realtime-profile`)는 지금까지 같은 파티 안에서 동일 닉네임을 허용했음. 같은 파티에 동일 닉네임 참가자가 다수 존재하면 롤링페이퍼 작성·채팅 발신자 식별 등 닉네임을 기준으로 동작하는 다른 기능에서 혼란이 발생함. 이를 사전에 차단하기 위해 파티 단위 닉네임 유일성 정책을 추가함.

## 🛠 Changes
- `ErrorCode.PARTY_NICKNAME_DUPLICATED` 추가 (HTTP 409, "이미 사용 중인 닉네임입니다") — 기존 `ROLLING_PAPER_NICKNAME_DUPLICATED`와 동일한 패턴
- `RealtimeParticipantProfileRepository.existsByPartyIdAndNicknameIgnoreCaseExcludingParticipant` 추가 — 같은 `partyId` 내에서 `LOWER(nickname)`으로 동일 닉네임 존재 여부 확인, 자기 자신의 `participantId`는 제외
- `RealtimeParticipantProfileService.upsert`에 중복 검사 로직 추가
  - 신규 프로필 생성 시 항상 검사
  - 기존 프로필 갱신 시 `nickname`이 실제로 변경된 경우에만 검사
  - 호스트 닉네임 잠금(`PARTY_HOST_NICKNAME_NOT_EDITABLE`)이 중복 검사보다 우선
- 단위 테스트 3건 + 통합 테스트 3건 추가

## 👀 Review Focus
- **정책 디테일**: 대소문자 무시(`LOWER(nickname)`) + trim 후 비교 / 자기 자신 제외 / 미변경 시 검사 스킵 — 이 조합이 의도와 일치하는지
- **검사 순서**: `RealtimeParticipantProfileService.upsert` 에서 호스트 잠금 검사를 중복 검사보다 먼저 두었음 (주최자가 닉네임 변경을 시도하면 `PARTY_HOST_NICKNAME_NOT_EDITABLE`이 먼저 던져짐)
- **레이스 컨디션**: 현재는 `SELECT → INSERT/UPDATE` 흐름으로 동시 요청 시 같은 닉네임 통과 가능성이 이론상 존재. 트래픽 규모상 허용 가능하다고 판단해 DB 유니크 제약은 추가하지 않았음 — 다른 의견 환영

## ⚠️ Side Effects
- **DB 마이그레이션**: 없음
- **환경변수/설정**: 없음
- **의존성 변경**: 없음
- **API 변경(Breaking)**: 엔드포인트 시그니처/응답 포맷 변경 없음. 단, 같은 파티 내 중복 닉네임 입력 시 **신규 에러 응답** 발생 — `409 PARTY_NICKNAME_DUPLICATED` ("이미 사용 중인 닉네임입니다"). 기존엔 200으로 통과되던 케이스
- **외부 시스템 영향**: 프론트엔드에서 새 에러 코드(`PARTY_NICKNAME_DUPLICATED`) 노출 처리 필요 — 닉네임 입력 화면에서 사용자 안내 문구 표시
- **운영 작업**: 없음

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 파티 내 닉네임 중복 검사 기능 추가. 새 프로필 생성 또는 기존 프로필 수정 시 동일 파티 내에서 이미 사용 중인 닉네임으로 설정할 수 없습니다.

* **Tests**
  * 닉네임 중복 검사 및 검증 로직 관련 테스트 추가.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/18th-team2-server/pull/167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->