### PR TITLE
[Refactor] 박터뜨리기 세션 테스트 격리 개선 및 컨텍스트 캐싱 복구

### DIFF
--- a/src/main/kotlin/com/team2/server/burstgame/application/port/BurstGameSessionStore.kt
+++ b/src/main/kotlin/com/team2/server/burstgame/application/port/BurstGameSessionStore.kt
@@ -19,6 +19,8 @@ interface BurstGameSessionStore {
 
     fun removeByPartyId(partyId: Long): Boolean
 
+    fun clear()
+
     sealed interface StartResult {
         data class Created(
             val session: BurstGameSession,

--- a/src/main/kotlin/com/team2/server/burstgame/infrastructure/memory/InMemoryBurstGameSessionStore.kt
+++ b/src/main/kotlin/com/team2/server/burstgame/infrastructure/memory/InMemoryBurstGameSessionStore.kt
@@ -61,6 +61,10 @@ class InMemoryBurstGameSessionStore : BurstGameSessionStore {
         }
     }
 
+    override fun clear() {
+        sessionsByPartyId.clear()
+    }
+
     private fun pruneExpiredLocked(
         partyId: Long,
         now: LocalDateTime,

--- a/src/test/kotlin/com/team2/server/burstgame/api/BurstGameControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/burstgame/api/BurstGameControllerTest.kt
@@ -1,5 +1,6 @@
 package com.team2.server.burstgame.api
 
+import com.team2.server.burstgame.application.port.BurstGameSessionStore
 import com.team2.server.burstgame.application.service.BurstGameSessionService
 import com.team2.server.common.DatabaseCleanup
 import com.team2.server.config.TestcontainersConfiguration
@@ -16,7 +17,6 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
-import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
@@ -25,7 +25,6 @@ import java.time.LocalDateTime
 @SpringBootTest
 @AutoConfigureMockMvc
 @Import(TestcontainersConfiguration::class)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 class BurstGameControllerTest
     @Autowired
     constructor(
@@ -34,11 +33,13 @@ class BurstGameControllerTest
         private val participantRepository: ParticipantRepository,
         private val profileRepository: RealtimeParticipantProfileRepository,
         private val sessionService: BurstGameSessionService,
+        private val sessionStore: BurstGameSessionStore,
         private val databaseCleanup: DatabaseCleanup,
     ) {
         @BeforeEach
         fun setUp() {
             databaseCleanup.execute()
+            sessionStore.clear()
         }
 
         @Test


### PR DESCRIPTION
## 🔗 Issue
- closes #168

## 💬 Context
전체 테스트 시간이 비정상적으로 길어(약 232초) 원인을 분석한 결과, `BurstGameControllerTest`에 걸린 `@DirtiesContext(AFTER_EACH_TEST_METHOD)`가 매 테스트 메서드마다 Spring 컨텍스트를 재생성하고 있었습니다. 이 한 클래스에서만 부팅 오버헤드로 약 72초를 소모했고, 동시에 컨텍스트 캐시 fingerprint를 분리시켜 다른 컨트롤러 테스트와의 캐시 공유까지 막고 있었습니다 (`docs/testing-rules.md`의 컨텍스트 캐싱 보호 규칙 위반).

`@DirtiesContext`가 필요했던 실제 이유는 `InMemoryBurstGameSessionStore`가 컨텍스트 수명 동안 인메모리 세션을 유지하는데, `DatabaseCleanup`은 DB만 비우고 인메모리 상태는 정리하지 못해 테스트 간 세션이 누수(409 Conflict)되기 때문이었습니다. 인메모리 상태를 명시적으로 정리하도록 바꿔 `@DirtiesContext` 없이도 테스트 격리를 보장합니다.

## 🛠 Changes
- `BurstGameSessionStore` 인터페이스에 `clear()` 추가
- `InMemoryBurstGameSessionStore`에 `clear()` 구현 (`sessionsByPartyId.clear()`)
- `BurstGameControllerTest`에서 `@DirtiesContext` 제거, `@BeforeEach`에서 `databaseCleanup.execute()` 직후 `sessionStore.clear()` 호출
- 결과: 전체 테스트 누적 시간 232s → 96s (약 59% 단축), 해당 suite 81.5s → 2.4s

## 👀 Review Focus
- `sessionStore.clear()` 호출 위치가 `databaseCleanup.execute()` 직후로 적절한지 (테스트 시작 시점 격리)
- `clear()`를 인터페이스에 노출한 설계 — 테스트 격리 목적의 메서드를 포트에 두는 것이 적절한지에 대한 의견

## ⚠️ Side Effects
- **DB 마이그레이션**: 없음
- **환경변수/설정**: 없음
- **의존성 변경**: 없음
- **API 변경(Breaking)**: 없음 (HTTP 엔드포인트/DTO 변경 없음, `BurstGameSessionStore.clear()`는 내부 포트 인터페이스 추가)
- **외부 시스템 영향**: 없음
- **운영 작업**: 없음

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견