### PR TITLE
[Docs] 닉네임 중복 에러 응답 스웨거 스펙 추가

### DIFF
--- a/src/main/kotlin/com/team2/server/party/api/ParticipantRealtimeProfileApi.kt
+++ b/src/main/kotlin/com/team2/server/party/api/ParticipantRealtimeProfileApi.kt
@@ -110,6 +110,30 @@ interface ParticipantRealtimeProfileApi {
             ),
         ],
     )
+    @SwaggerApiResponse(
+        responseCode = "409",
+        description = "같은 파티 내 닉네임 중복 (대소문자 무시)",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = ErrorResponse::class),
+                examples = [
+                    ExampleObject(
+                        name = "닉네임 중복",
+                        value = """
+                            {
+                              "status": 409,
+                              "error": {
+                                "code": "PARTY_NICKNAME_DUPLICATED",
+                                "message": "이미 사용 중인 닉네임입니다"
+                              }
+                            }
+                        """,
+                    ),
+                ],
+            ),
+        ],
+    )
     @InternalServerErrorResponse
     fun upsertMyRealtimeProfile(
         @Parameter(hidden = true) principal: UserPrincipal,


### PR DESCRIPTION
## 🔗 Issue
- closes #166

## 💬 Context
#167 에서 실시간 프로필 upsert(`PUT /api/v1/party-invites/{inviteToken}/participants/me/realtime-profile`)에 같은 파티 내 닉네임 중복 차단 정책을 추가하면서 `409 PARTY_NICKNAME_DUPLICATED` 응답이 새로 발생함. 그러나 Swagger 문서에는 이 응답이 정의되어 있지 않아 프론트엔드가 에러 케이스를 사전에 알 수 없었음. 프론트에서 닉네임 입력 화면 에러 처리를 구현할 수 있도록 스펙에 명시함.

## 🛠 Changes
- `ParticipantRealtimeProfileApi.upsertMyRealtimeProfile`에 `409` 응답 문서 추가
  - `ErrorResponse` 스키마 + 예시 JSON (`code: PARTY_NICKNAME_DUPLICATED`, `message: 이미 사용 중인 닉네임입니다`)
  - 기존 400(주최자 닉네임 변경)·404 문서화 패턴과 동일한 형식 유지

## 👀 Review Focus
- 예시 JSON의 `code`/`message`가 실제 `ErrorCode.PARTY_NICKNAME_DUPLICATED` 정의와 일치하는지
- 응답 설명 문구("같은 파티 내 닉네임 중복 (대소문자 무시)")가 실제 정책과 일치하는지

## ⚠️ Side Effects
- **DB 마이그레이션**: 없음
- **환경변수/설정**: 없음
- **의존성 변경**: 없음
- **API 변경(Breaking)**: 없음 (문서만 추가, 런타임 동작 변경 없음)
- **외부 시스템 영향**: 프론트엔드가 이 스펙을 참고해 `PARTY_NICKNAME_DUPLICATED` 에러 핸들링 구현 가능
- **운영 작업**: 없음

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **문서화**
  * 파티 내 닉네임 중복 시 발생하는 오류 응답에 대한 API 문서가 업데이트되었습니다. 같은 파티 내에서 중복된 닉네임(대소문자 무시)을 사용할 경우 409 상태 코드와 함께 적절한 오류 정보가 반환되는 방식이 명시되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/18th-team2-server/pull/170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->