### PR TITLE
[Fix] SSE 에러 응답 Content-Type 수정 및 nginx 스트리밍 설정 추가

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -71,6 +71,37 @@ http {
             proxy_send_timeout 60s;
         }
 
+        location ~ "^/api/v1/party-invites/[^/]+/realtime-participants/stream$" {
+            limit_req zone=api_per_ip burst=10 nodelay;
+            limit_conn conn_per_ip 10;
+            set $selected_api_upstream "";
+            set $selected_api_upstream_available 0;
+            if ($host = api.hapalin.com) {
+                set $selected_api_upstream $prod_api_upstream;
+                set $selected_api_upstream_available $prod_api_upstream_available;
+            }
+            if ($host = dev-api.hapalin.com) {
+                set $selected_api_upstream $dev_api_upstream;
+                set $selected_api_upstream_available $dev_api_upstream_available;
+            }
+            if ($selected_api_upstream_available = 0) {
+                return 503;
+            }
+            proxy_pass $selected_api_upstream;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Port $server_port;
+            proxy_connect_timeout 60s;
+            proxy_read_timeout 1800s;
+            proxy_send_timeout 60s;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_http_version 1.1;
+            proxy_set_header Connection '';
+        }
+
         location / {
             limit_req zone=api_per_ip burst=60 nodelay;
             limit_conn conn_per_ip 30;
@@ -118,6 +149,27 @@ http {
             proxy_connect_timeout 60s;
             proxy_read_timeout 120s;
             proxy_send_timeout 60s;
+        }
+
+        location ~ "^/api/v1/party-invites/[^/]+/realtime-participants/stream$" {
+            limit_req zone=api_per_ip burst=10 nodelay;
+            limit_conn conn_per_ip 10;
+            if ($dev_http_upstream_available = 0) {
+                return 503;
+            }
+            proxy_pass $dev_http_upstream;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Port $server_port;
+            proxy_connect_timeout 60s;
+            proxy_read_timeout 1800s;
+            proxy_send_timeout 60s;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_http_version 1.1;
+            proxy_set_header Connection '';
         }
 
         location / {

--- a/src/main/kotlin/com/team2/server/chat/controller/ChatApi.kt
+++ b/src/main/kotlin/com/team2/server/chat/controller/ChatApi.kt
@@ -8,7 +8,6 @@ import com.team2.server.chat.dto.EnterRealtimePartyRequest
 import com.team2.server.chat.dto.SendChatMessageRequest
 import com.team2.server.common.web.ApiResponse
 import com.team2.server.common.web.ErrorResponse
-import com.team2.server.common.web.swagger.AuthErrorResponses
 import com.team2.server.common.web.swagger.InternalServerErrorResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -128,16 +127,22 @@ curl -N -X POST http://localhost:8080/api/v1/party-invites/{inviteToken}/realtim
                 examples = [
                     ExampleObject(
                         name = "초대 링크 만료",
-                        value = """{"status":400,"error":{"code":"INVITE_LINK_EXPIRED","message":"초대 링크가 만료되었습니다"}}""",
+                        value = """{"status":400,"error":{"code":"INVITE_LINK_EXPIRED","message":"만료된 초대링크입니다"}}""",
                     ),
                     ExampleObject(
-                        name = "입장 가능 시간 이전",
-                        value = """{"status":400,"error":{"code":"CHAT_NOT_ACTIVE","message":"아직 입장할 수 없습니다"}}""",
+                        name = "입장 불가 상태 (파티 미시작·종료)",
+                        value =
+                            """{"status":400,"error":{"code":"CHAT_NOT_ACTIVE","message":"현재 채팅이 활성화된 시간이 아닙니다"}}""",
                     ),
                     ExampleObject(
                         name = "실시간 파티가 아님",
                         value =
-                            """{"status":400,"error":{"code":"CHAT_NOT_SUPPORTED","message":"실시간 채팅을 지원하지 않는 파티입니다"}}""",
+                            """{"status":400,"error":{"code":"CHAT_NOT_SUPPORTED","message":"채팅을 지원하지 않는 파티입니다"}}""",
+                    ),
+                    ExampleObject(
+                        name = "주최자 닉네임 변경 불가 (재입장 시)",
+                        value =
+                            """{"status":400,"error":{"code":"PARTY_HOST_NICKNAME_NOT_EDITABLE","message":"주최자 닉네임은 변경할 수 없습니다"}}""",
                     ),
                 ],
             ),
@@ -158,6 +163,22 @@ curl -N -X POST http://localhost:8080/api/v1/party-invites/{inviteToken}/realtim
                     ExampleObject(
                         name = "존재하지 않는 캐릭터",
                         value = """{"status":404,"error":{"code":"CHARACTER_NOT_FOUND","message":"캐릭터를 찾을 수 없습니다"}}""",
+                    ),
+                ],
+            ),
+        ],
+    )
+    @SwaggerApiResponse(
+        responseCode = "409",
+        description = "닉네임 중복",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = ErrorResponse::class),
+                examples = [
+                    ExampleObject(
+                        value =
+                            """{"status":409,"error":{"code":"PARTY_NICKNAME_DUPLICATED","message":"이미 사용 중인 닉네임입니다"}}""",
                     ),
                 ],
             ),
@@ -195,13 +216,42 @@ curl -N -X POST http://localhost:8080/api/v1/party-invites/{inviteToken}/realtim
                 schema = Schema(implementation = ErrorResponse::class),
                 examples = [
                     ExampleObject(
-                        name = "파티가 활성 상태가 아님",
-                        value = """{"status":400,"error":{"code":"CHAT_NOT_ACTIVE","message":"현재 채팅을 사용할 수 없습니다"}}""",
+                        name = "파티가 LIVE_OPEN 상태가 아님",
+                        value =
+                            """{"status":400,"error":{"code":"CHAT_NOT_ACTIVE","message":"현재 채팅이 활성화된 시간이 아닙니다"}}""",
                     ),
                     ExampleObject(
                         name = "실시간 파티가 아님",
                         value =
-                            """{"status":400,"error":{"code":"CHAT_NOT_SUPPORTED","message":"실시간 채팅을 지원하지 않는 파티입니다"}}""",
+                            """{"status":400,"error":{"code":"CHAT_NOT_SUPPORTED","message":"채팅을 지원하지 않는 파티입니다"}}""",
+                    ),
+                ],
+            ),
+        ],
+    )
+    @SwaggerApiResponse(
+        responseCode = "401",
+        description = "인증 실패",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = ErrorResponse::class),
+                examples = [
+                    ExampleObject(
+                        name = "인증 필요",
+                        value = """{"status":401,"error":{"code":"AUTH_UNAUTHORIZED","message":"인증이 필요합니다"}}""",
+                    ),
+                    ExampleObject(
+                        name = "만료된 토큰",
+                        value = """{"status":401,"error":{"code":"AUTH_EXPIRED_TOKEN","message":"만료된 토큰입니다"}}""",
+                    ),
+                    ExampleObject(
+                        name = "유효하지 않은 토큰",
+                        value = """{"status":401,"error":{"code":"AUTH_INVALID_TOKEN","message":"유효하지 않은 토큰입니다"}}""",
+                    ),
+                    ExampleObject(
+                        name = "JWT·참여자 토큰 미제공",
+                        value = """{"status":401,"error":{"code":"UNAUTHORIZED","message":"로그인이 필요합니다"}}""",
                     ),
                 ],
             ),
@@ -216,7 +266,7 @@ curl -N -X POST http://localhost:8080/api/v1/party-invites/{inviteToken}/realtim
                 schema = Schema(implementation = ErrorResponse::class),
                 examples = [
                     ExampleObject(
-                        value = """{"status":403,"error":{"code":"PARTY_FORBIDDEN","message":"파티에 접근할 수 없습니다"}}""",
+                        value = """{"status":403,"error":{"code":"PARTY_FORBIDDEN","message":"파티에 대한 권한이 없습니다"}}""",
                     ),
                 ],
             ),
@@ -237,7 +287,6 @@ curl -N -X POST http://localhost:8080/api/v1/party-invites/{inviteToken}/realtim
             ),
         ],
     )
-    @AuthErrorResponses
     @InternalServerErrorResponse
     fun sendMessage(
         @Parameter(description = "파티 ID") partyId: Long,
@@ -257,7 +306,80 @@ curl -N -X POST http://localhost:8080/api/v1/party-invites/{inviteToken}/realtim
 """,
     )
     @SwaggerApiResponse(responseCode = "204", description = "퇴장 성공")
-    @AuthErrorResponses
+    @SwaggerApiResponse(
+        responseCode = "400",
+        description = "실시간 파티가 아님",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = ErrorResponse::class),
+                examples = [
+                    ExampleObject(
+                        value =
+                            """{"status":400,"error":{"code":"CHAT_NOT_SUPPORTED","message":"채팅을 지원하지 않는 파티입니다"}}""",
+                    ),
+                ],
+            ),
+        ],
+    )
+    @SwaggerApiResponse(
+        responseCode = "401",
+        description = "인증 실패",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = ErrorResponse::class),
+                examples = [
+                    ExampleObject(
+                        name = "인증 필요",
+                        value = """{"status":401,"error":{"code":"AUTH_UNAUTHORIZED","message":"인증이 필요합니다"}}""",
+                    ),
+                    ExampleObject(
+                        name = "만료된 토큰",
+                        value = """{"status":401,"error":{"code":"AUTH_EXPIRED_TOKEN","message":"만료된 토큰입니다"}}""",
+                    ),
+                    ExampleObject(
+                        name = "유효하지 않은 토큰",
+                        value = """{"status":401,"error":{"code":"AUTH_INVALID_TOKEN","message":"유효하지 않은 토큰입니다"}}""",
+                    ),
+                    ExampleObject(
+                        name = "JWT·참여자 토큰 미제공",
+                        value = """{"status":401,"error":{"code":"UNAUTHORIZED","message":"로그인이 필요합니다"}}""",
+                    ),
+                ],
+            ),
+        ],
+    )
+    @SwaggerApiResponse(
+        responseCode = "403",
+        description = "해당 파티의 참여자가 아님",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = ErrorResponse::class),
+                examples = [
+                    ExampleObject(
+                        value = """{"status":403,"error":{"code":"PARTY_FORBIDDEN","message":"파티에 대한 권한이 없습니다"}}""",
+                    ),
+                ],
+            ),
+        ],
+    )
+    @SwaggerApiResponse(
+        responseCode = "404",
+        description = "파티 없음",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = ErrorResponse::class),
+                examples = [
+                    ExampleObject(
+                        value = """{"status":404,"error":{"code":"PARTY_NOT_FOUND","message":"파티를 찾을 수 없습니다"}}""",
+                    ),
+                ],
+            ),
+        ],
+    )
     @InternalServerErrorResponse
     fun leaveParty(
         @Parameter(description = "파티 ID") partyId: Long,

--- a/src/main/kotlin/com/team2/server/common/web/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/team2/server/common/web/GlobalExceptionHandler.kt
@@ -9,6 +9,7 @@ import org.springframework.http.MediaType
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.context.request.async.AsyncRequestNotUsableException
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import tools.jackson.databind.ObjectMapper
 
@@ -54,6 +55,11 @@ class GlobalExceptionHandler(
             HttpStatus.BAD_REQUEST.value(),
             ErrorResponse.of(HttpStatus.BAD_REQUEST, "INVALID_INPUT", "잘못된 요청 값입니다: ${e.value}"),
         )
+    }
+
+    @ExceptionHandler(AsyncRequestNotUsableException::class)
+    fun handleAsyncRequestNotUsableException(e: AsyncRequestNotUsableException) {
+        log.debug("Client disconnected during async request", e)
     }
 
     @ExceptionHandler(Exception::class)

--- a/src/main/kotlin/com/team2/server/common/web/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/team2/server/common/web/GlobalExceptionHandler.kt
@@ -2,45 +2,82 @@ package com.team2.server.common.web
 
 import com.team2.server.common.exception.BusinessException
 import com.team2.server.common.exception.ErrorCode
+import jakarta.servlet.http.HttpServletResponse
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
-import org.springframework.http.ResponseEntity
+import org.springframework.http.MediaType
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+import tools.jackson.databind.ObjectMapper
 
 @RestControllerAdvice
-class GlobalExceptionHandler {
+class GlobalExceptionHandler(
+    private val objectMapper: ObjectMapper,
+) {
     private val log = LoggerFactory.getLogger(javaClass)
 
     @ExceptionHandler(BusinessException::class)
-    fun handleBusinessException(e: BusinessException): ResponseEntity<ErrorResponse> {
+    fun handleBusinessException(
+        e: BusinessException,
+        response: HttpServletResponse,
+    ) {
         val errorCode = e.errorCode
-        val response = ErrorResponse.of(errorCode.httpStatus, errorCode.name, errorCode.message)
-        return ResponseEntity.status(errorCode.httpStatus).body(response)
+        writeErrorResponse(
+            response,
+            errorCode.httpStatus.value(),
+            ErrorResponse.of(errorCode.httpStatus, errorCode.name, errorCode.message),
+        )
     }
 
     @ExceptionHandler(MethodArgumentNotValidException::class)
-    fun handleValidationException(e: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> {
-        val message =
-            e.bindingResult.fieldErrors
-                .joinToString(", ") { "${it.field}: ${it.defaultMessage}" }
-        val response = ErrorResponse.of(e.statusCode, "VALIDATION_ERROR", message)
-        return ResponseEntity.status(e.statusCode).body(response)
+    fun handleValidationException(
+        e: MethodArgumentNotValidException,
+        response: HttpServletResponse,
+    ) {
+        val message = e.bindingResult.fieldErrors.joinToString(", ") { "${it.field}: ${it.defaultMessage}" }
+        writeErrorResponse(
+            response,
+            e.statusCode.value(),
+            ErrorResponse.of(e.statusCode, "VALIDATION_ERROR", message),
+        )
     }
 
     @ExceptionHandler(MethodArgumentTypeMismatchException::class)
-    fun handleTypeMismatchException(e: MethodArgumentTypeMismatchException): ResponseEntity<ErrorResponse> {
-        val response = ErrorResponse.of(HttpStatus.BAD_REQUEST, "INVALID_INPUT", "잘못된 요청 값입니다: ${e.value}")
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response)
+    fun handleTypeMismatchException(
+        e: MethodArgumentTypeMismatchException,
+        response: HttpServletResponse,
+    ) {
+        writeErrorResponse(
+            response,
+            HttpStatus.BAD_REQUEST.value(),
+            ErrorResponse.of(HttpStatus.BAD_REQUEST, "INVALID_INPUT", "잘못된 요청 값입니다: ${e.value}"),
+        )
     }
 
     @ExceptionHandler(Exception::class)
-    fun handleException(e: Exception): ResponseEntity<ErrorResponse> {
+    fun handleException(
+        e: Exception,
+        response: HttpServletResponse,
+    ) {
         log.error("Unexpected error", e)
         val errorCode = ErrorCode.INTERNAL_SERVER_ERROR
-        val response = ErrorResponse.of(errorCode.httpStatus, errorCode.name, errorCode.message)
-        return ResponseEntity.status(errorCode.httpStatus).body(response)
+        writeErrorResponse(
+            response,
+            errorCode.httpStatus.value(),
+            ErrorResponse.of(errorCode.httpStatus, errorCode.name, errorCode.message),
+        )
+    }
+
+    private fun writeErrorResponse(
+        response: HttpServletResponse,
+        status: Int,
+        body: ErrorResponse,
+    ) {
+        response.status = status
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
+        response.characterEncoding = Charsets.UTF_8.name()
+        objectMapper.writeValue(response.outputStream, body)
     }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -15,7 +15,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health
+        include: health,prometheus
   endpoint:
     health:
       show-details: never


### PR DESCRIPTION
## 🔗 Issue
- closes #177

## 💬 Context
SSE 스트림 요청(`Accept: text/event-stream`) 중 예외가 발생하면 Spring MVC의 content negotiation이 `ErrorResponse`를 `text/event-stream` 포맷으로 직렬화하려다 실패하거나 깨진 응답을 클라이언트에 내려보내는 문제가 있었습니다.

또한 nginx의 기본 `proxy_buffering on` 설정으로 인해 upstream의 SSE 이벤트가 버퍼에 적재됐다가 한꺼번에 플러시되어, `https://dev-api.hapalin.com`(nginx 경유)에서는 실시간 스트리밍이 동작하지 않고 `http://suker.iptime.org:8081`(직접 접근)에서만 정상 동작하는 원인이 되었습니다.

## 🛠 Changes
- **`GlobalExceptionHandler`**: `ResponseEntity` 반환 → `HttpServletResponse` 직접 쓰기 방식으로 교체. content negotiation을 우회하여 SSE 요청 포함 모든 상황에서 항상 `application/json`으로 에러 응답
- **`nginx/nginx.conf`**: SSE 엔드포인트 전용 location 추가 (`proxy_buffering off`, `proxy_http_version 1.1`, `proxy_read_timeout 1800s`, `Connection ''`). 443 서버 블록과 8081 서버 블록 모두 적용
- **`ChatApi.kt`**: Swagger 에러 코드 정밀화 — 누락 코드 추가(`PARTY_HOST_NICKNAME_NOT_EDITABLE`, `PARTY_NICKNAME_DUPLICATED`), `ErrorCode` 실제 메시지와 불일치하던 예시 수정, `leaveParty` 에러 응답 보강(400/401/403/404)
- **`application-prod.yml`**: prometheus 메트릭 엔드포인트 노출 추가

## 👀 Review Focus
- `GlobalExceptionHandler.writeErrorResponse`가 SSE 이외 일반 REST 요청에서도 기존과 동일하게 동작하는지 확인
- nginx SSE location의 `limit_conn 10` 설정이 실제 운영 동시 연결 수에 적합한지 검토
- `proxy_read_timeout 1800s` 값이 `EMITTER_TIMEOUT_MS`(파티 진행 시간 기반)와 충분한 여유를 두고 있는지 확인

## ⚠️ Side Effects
- **환경변수/설정**: `application-prod.yml`에 prometheus 메트릭 엔드포인트 추가 (`management.endpoints.web.exposure.include: health,prometheus`) — 배포 전 prometheus 스크레이프 설정 여부 확인 권장
- **운영 작업**: nginx 설정 변경으로 인해 배포 시 nginx reload 필요 (`nginx -s reload` 또는 nginx 컨테이너 재시작)
- **DB 마이그레이션**: 없음
- **의존성 변경**: 없음
- **API 변경(Breaking)**: 없음 (에러 응답 JSON 포맷 동일, content negotiation 동작만 수정)
- **외부 시스템 영향**: 없음

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 실시간 참여자 스트리밍 경로 최적화로 스트리밍 안정성 및 연결 처리 개선

* **Documentation**
  * API 응답 문서에 오류 코드/메시지 예시를 상세화하고 닉네임 중복 관련 409 예시 추가

* **Bug Fixes**
  * 예외 응답 처리 방식을 개선해 오류 응답 포맷과 비동기 연결 해제 로그 처리가 일관화됨

* **Chores**
  * 운영 설정에 Prometheus 노출을 추가해 모니터링 범위 확장

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/18th-team2-server/pull/178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->