### PR TITLE
[Fix] ResolveLiveOpenRealtimePartyUseCase Clock 미주입 버그 수정

### DIFF
--- a/src/main/kotlin/com/team2/server/party/application/usecase/ResolveLiveOpenRealtimePartyUseCase.kt
+++ b/src/main/kotlin/com/team2/server/party/application/usecase/ResolveLiveOpenRealtimePartyUseCase.kt
@@ -7,15 +7,18 @@ import com.team2.server.party.domain.entity.RealtimeParty
 import com.team2.server.party.domain.entity.RealtimePartyStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
+import java.time.LocalDateTime
 
 @Service
 class ResolveLiveOpenRealtimePartyUseCase(
     private val partyService: PartyService,
+    private val clock: Clock,
 ) {
     @Transactional(readOnly = true)
     fun invoke(partyId: Long): RealtimeParty {
         val party = partyService.requireRealtimeParty(partyId)
-        if (party.status() != RealtimePartyStatus.LIVE_OPEN) {
+        if (party.status(LocalDateTime.now(clock)) != RealtimePartyStatus.LIVE_OPEN) {
             throw BusinessException(ErrorCode.CHAT_NOT_ACTIVE)
         }
         return party


### PR DESCRIPTION
## 🔗 Issue
- closes #183

## 💬 Context
Docker 컨테이너 환경에서 JVM 타임존이 UTC로 동작할 때, `ResolveLiveOpenRealtimePartyUseCase`가 `Clock` 빈을 주입받지 않고 `LocalDateTime.now()`를 직접 호출하여 파티 상태 판단에 오류가 발생했습니다.
DB에 KST로 저장된 `startedAt`과 UTC 기반의 `now()`를 비교하면 9시간 차이로 파티가 아직 시작되지 않은 것처럼 인식되어 LIVE_OPEN 구간에서도 `CHAT_NOT_ACTIVE` 예외가 던져졌습니다.

## 🛠 Changes
- `ResolveLiveOpenRealtimePartyUseCase`에 `Clock` 빈 주입
- `party.status(LocalDateTime.now(clock))` 호출로 변경하여 다른 UseCase들과 일관된 방식으로 현재 시각 처리

## 👀 Review Focus
- 다른 UseCase들(`GetRealtimePartyStateUseCase`, `StartRealtimePartyEndUseCase` 등)은 이미 `Clock`을 주입받아 사용 중이며, 이번 수정으로 패턴이 통일됩니다
- `LocalDateTime.now()` 직접 호출이 남아있는 곳이 있는지 추가 검토 필요

## ⚠️ Side Effects
- **DB 마이그레이션**: 없음
- **환경변수/설정**: 없음
- **의존성 변경**: 없음
- **API 변경(Breaking)**: 없음
- **외부 시스템 영향**: 없음
- **운영 작업**: 없음

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **버그 수정**
  * 실시간 파티의 라이브 상태 판정 로직을 개선하여 정확도를 높였습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/18th-team2-server/pull/184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->