### PR TITLE
[Feat] 촛불끄기 시작 지연 시간 41초 변경

### DIFF
--- a/docs/superpowers/plans/2026-05-24-realtime-candle-blow.md
+++ b/docs/superpowers/plans/2026-05-24-realtime-candle-blow.md
@@ -2,7 +2,7 @@
 
 > 단계별로 진행한다. 각 단계가 끝나면 커밋하지 않고 변경 내용과 검증 결과를 공유한다.
 
-**Goal:** 실시간 파티 시작 35초 뒤 공유 촛불 9개를 끄는 단계를 시작하고, 9개 모두 꺼짐 또는 45초 타임아웃으로 종료한 뒤 기존 박터뜨리기 start API를 열어준다.
+**Goal:** 실시간 파티 시작 41초 뒤 공유 촛불 9개를 끄는 단계를 시작하고, 9개 모두 꺼짐 또는 45초 타임아웃으로 종료한 뒤 기존 박터뜨리기 start API를 열어준다.
 
 **Architecture:** 기존 `burstgame` feature 안에 촛불 phase를 추가한다. HTTP 진입점은 `api`, 흐름/트랜잭션은 `application/usecase`, 공유 상태와 정책은 `domain`, in-memory store/scheduler/SSE adapter는 `infrastructure`에 둔다.
 
@@ -13,7 +13,7 @@
 ## Decisions
 
 - 촛불끄기는 `REALTIME` 파티에서만 동작한다.
-- 시작 시각은 `party.startedAt + 35초`다.
+- 시작 시각은 `party.startedAt + 41초`다.
 - 제한 시간은 45초다.
 - 촛불 수는 9개 고정이고 외부 입력으로 바꾸지 않는다.
 - 실시간 파티 참여자라면 누구나 촛불을 끌 수 있다.
@@ -60,7 +60,7 @@
 - Test: `src/test/kotlin/com/team2/server/burstgame/infrastructure/candle/InMemoryCandleBlowSessionStoreTest.kt`
 
 - [x] `CANDLE_COUNT = 9`
-- [x] `START_DELAY_SECONDS = 35`
+- [x] `START_DELAY_SECONDS = 41`
 - [x] `DURATION_SECONDS = 45`
 - [x] 1차 store는 단일 app instance 전제의 in-memory 구현으로 둔다.
 - [x] 추후 store 구현 교체 가능성을 고려해 `CandleBlowSessionStore` 포트 뒤에 구현을 숨긴다.
@@ -84,7 +84,7 @@
 - [x] `GET /api/v1/parties/{partyId}/candle-blow`
 - [x] `POST /api/v1/parties/{partyId}/candle-blow/candles/{candleId}`
 - [x] JWT 또는 `X-Participant-Token` 참여자 검증 재사용
-- [x] `party.startedAt + 35초` 전 `WAITING` 상태 blow 요청은 `CANDLE_BLOW_NOT_STARTED`
+- [x] `party.startedAt + 41초` 전 `WAITING` 상태 blow 요청은 `CANDLE_BLOW_NOT_STARTED`
 - [x] `FINISHED` 상태 blow 요청은 `200 OK` 멱등 응답
 - [x] `GetCandleBlowStateUseCase`, `BlowCandleUseCase`는 `CandleBlowService`에 상태 조회/전이 처리를 위임한다.
 

--- a/docs/superpowers/specs/2026-05-24-realtime-candle-blow-design.md
+++ b/docs/superpowers/specs/2026-05-24-realtime-candle-blow-design.md
@@ -10,7 +10,7 @@
 
 핵심 동작:
 
-- 실시간 파티가 시작된 뒤 35초가 지나면 촛불끄기 단계가 서버 기준으로 시작된다.
+- 실시간 파티가 시작된 뒤 41초가 지나면 촛불끄기 단계가 서버 기준으로 시작된다.
 - 촛불은 파티 전체가 공유하는 9개 고정 슬롯이다.
 - 실시간 파티 참여자라면 누구나 촛불을 끌 수 있다.
 - 이미 꺼진 촛불을 다시 누르면 실패가 아니라 `200 OK`로 현재 상태를 반환한다.
@@ -20,7 +20,7 @@
 기본 정책:
 
 ```kotlin
-CANDLE_BLOW_START_DELAY_SECONDS = 35
+CANDLE_BLOW_START_DELAY_SECONDS = 41
 CANDLE_BLOW_DURATION_SECONDS = 45
 CANDLE_COUNT = 9
 ```
@@ -46,7 +46,7 @@ CANDLE_COUNT = 9
   │                                    │
   │ 실시간 파티 입장 + SSE 연결         │
   │                                    │
-  │ party.startedAt + 35초              │
+  │ party.startedAt + 41초              │
   │◄── event: candle-blow-started ─────│
   │                                    │
   │── POST /parties/{id}/              │
@@ -71,7 +71,7 @@ CANDLE_COUNT = 9
 
 | 영역 | 설명 |
 |---|---|
-| 시작 예약 | `party.startedAt + 35초`에 촛불끄기 시작 예약 및 SSE 발송 |
+| 시작 예약 | `party.startedAt + 41초`에 촛불끄기 시작 예약 및 SSE 발송 |
 | 복구 | 앱 재시작, SSE 유실, 늦은 입장 시 상태 조회 또는 입장 이벤트로 현재 단계 복구 |
 | 참여자 검증 | JWT 또는 `X-Participant-Token`으로 실시간 파티 참여자 확인 |
 | 공유 상태 관리 | 파티별 9개 촛불의 extinguished 상태를 단일 aggregate로 관리 |
@@ -122,7 +122,7 @@ X-Participant-Token: {participantToken}
 
 | 값 | 설명 |
 |---|---|
-| `WAITING` | `party.startedAt + 35초` 전 |
+| `WAITING` | `party.startedAt + 41초` 전 |
 | `ACTIVE` | 촛불끄기 입력 가능 |
 | `FINISHED` | `ALL_EXTINGUISHED` 또는 `TIMEOUT`으로 종료 |
 
@@ -134,7 +134,7 @@ X-Participant-Token: {participantToken}
 - 아직 시작 전이면 `WAITING` 상태를 반환한다.
 - 시작/종료 예약 이벤트가 유실됐더라도 조회 시점의 서버 시간으로 lazy transition을 수행할 수 있다.
 - 조회 lazy transition은 party 단위 lock 또는 compare-and-set 안에서 수행한다.
-  - `status == WAITING && now >= party.startedAt + 35초`이면 `transitionToActiveOnce()`와 `emitStartedEventOnce()`를 같은 critical section에서 예약한다.
+  - `status == WAITING && now >= party.startedAt + 41초`이면 `transitionToActiveOnce()`와 `emitStartedEventOnce()`를 같은 critical section에서 예약한다.
   - `status == ACTIVE && now >= endsAt`이면 `transitionToFinishedOnce()`와 `emitEndedEventOnce()`를 같은 critical section에서 예약한다.
   - persisted store로 교체할 때는 동등한 deduplication marker로 `candle-blow-started`, `candle-blow-ended`가 각각 정확히 1회만 발행되도록 보장한다.
 
@@ -193,8 +193,8 @@ X-Participant-Token: {participantToken}
 처리 정책:
 
 - `candleId`는 `1..9`만 허용한다. 범위를 벗어나면 `INVALID_INPUT`.
-- `WAITING` 상태이고 `now < party.startedAt + 35초`이면 `CANDLE_BLOW_NOT_STARTED`.
-- `WAITING` 상태지만 `now >= party.startedAt + 35초`이면 party 단위 lock 또는 compare-and-set 안에서 lazy `transitionToActiveOnce()`와 `emitStartedEventOnce()`를 예약한 뒤 촛불 끄기 요청을 처리한다.
+- `WAITING` 상태이고 `now < party.startedAt + 41초`이면 `CANDLE_BLOW_NOT_STARTED`.
+- `WAITING` 상태지만 `now >= party.startedAt + 41초`이면 party 단위 lock 또는 compare-and-set 안에서 lazy `transitionToActiveOnce()`와 `emitStartedEventOnce()`를 예약한 뒤 촛불 끄기 요청을 처리한다.
 - `FINISHED` 상태에서 호출하면 `200 OK`와 현재 종료 상태를 반환한다.
 - 이미 꺼진 촛불이면 `200 OK`와 현재 상태를 반환한다.
 - 새 촛불이 꺼지면 현재 9개 촛불 상태를 반환하고 progress SSE 발송 대상이 된다.
@@ -215,13 +215,13 @@ data: {"partyId":1,"status":"ACTIVE","candles":[{"candleId":1,"extinguished":fal
 
 발생 조건:
 
-- `party.startedAt + 35초` 도달
+- `party.startedAt + 41초` 도달
 - 서버 재시작 후 복구 시 이미 시작 시간이 지났지만 아직 종료 시간이 지나지 않은 경우
 - 상태 조회 또는 촛불 끄기 요청에서 `WAITING` lazy transition이 발생한 경우
 
 정확히 1회 발송 조건:
 
-- scheduler 시작, 서버 재시작 복구, 상태 조회 lazy transition, 촛불 끄기 요청이 동시에 시작을 시도해도 party 단위 lock 또는 compare-and-set에서 `status == WAITING && now >= party.startedAt + 35초`를 획득한 하나의 경로만 `transitionToActiveOnce()`를 수행한다.
+- scheduler 시작, 서버 재시작 복구, 상태 조회 lazy transition, 촛불 끄기 요청이 동시에 시작을 시도해도 party 단위 lock 또는 compare-and-set에서 `status == WAITING && now >= party.startedAt + 41초`를 획득한 하나의 경로만 `transitionToActiveOnce()`를 수행한다.
 - 같은 critical section 안에서 started snapshot과 `emitStartedEventOnce()` 예약 여부를 결정한다.
 - persisted store 구현으로 교체할 경우에는 status 전이와 event deduplication marker 저장을 하나의 원자적 연산으로 처리한다.
 
@@ -334,8 +334,8 @@ burstgame/infrastructure/scheduler
 
 ## 8. 테스트 포인트
 
-- `party.startedAt + 35초` 전 상태 조회는 `WAITING`.
-- `party.startedAt + 35초` 이후 상태 조회는 `ACTIVE`.
+- `party.startedAt + 41초` 전 상태 조회는 `WAITING`.
+- `party.startedAt + 41초` 이후 상태 조회는 `ACTIVE`.
 - 촛불 1개 끄기 성공 시 해당 `candleId`의 `extinguished`가 `true`로 바뀐다.
 - 이미 꺼진 촛불 재클릭은 `200 OK`와 현재 9개 촛불 상태를 반환한다.
 - 9개가 모두 꺼지면 `FINISHED`, `finishedReason=ALL_EXTINGUISHED`.

--- a/src/main/kotlin/com/team2/server/burstgame/domain/candle/CandleBlowPolicy.kt
+++ b/src/main/kotlin/com/team2/server/burstgame/domain/candle/CandleBlowPolicy.kt
@@ -6,7 +6,7 @@ import java.time.Duration
 
 object CandleBlowPolicy {
     const val CANDLE_COUNT = 9
-    const val START_DELAY_SECONDS = 35L
+    const val START_DELAY_SECONDS = 41L
     const val DURATION_SECONDS = 45L
     private const val SESSION_TTL_MINUTES = 10L
     val SESSION_TTL: Duration = Duration.ofMinutes(SESSION_TTL_MINUTES)

--- a/src/test/kotlin/com/team2/server/burstgame/api/BurstGameControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/burstgame/api/BurstGameControllerTest.kt
@@ -48,7 +48,7 @@ class BurstGameControllerTest
 
         @Test
         fun `participantToken으로 촛불끄기 상태 조회 성공`() {
-            val fixture = saveRealtimeParticipant(startedAt = LocalDateTime.now().minusSeconds(40))
+            val fixture = saveRealtimeParticipant(startedAt = activeCandleBlowStartedAt())
 
             mockMvc
                 .get("/api/v1/parties/${fixture.partyId}/candle-blow") {
@@ -68,7 +68,7 @@ class BurstGameControllerTest
 
         @Test
         fun `participantToken으로 촛불 끄기 성공`() {
-            val fixture = saveRealtimeParticipant(startedAt = LocalDateTime.now().minusSeconds(40))
+            val fixture = saveRealtimeParticipant(startedAt = activeCandleBlowStartedAt())
 
             mockMvc
                 .post("/api/v1/parties/${fixture.partyId}/candle-blow/candles/3") {
@@ -86,7 +86,7 @@ class BurstGameControllerTest
 
         @Test
         fun `허용 범위 밖 candleId 요청은 400을 반환한다`() {
-            val fixture = saveRealtimeParticipant(startedAt = LocalDateTime.now().minusSeconds(40))
+            val fixture = saveRealtimeParticipant(startedAt = activeCandleBlowStartedAt())
 
             mockMvc
                 .post("/api/v1/parties/${fixture.partyId}/candle-blow/candles/0") {
@@ -99,7 +99,7 @@ class BurstGameControllerTest
 
         @Test
         fun `이미 꺼진 촛불을 다시 꺼도 200 응답으로 현재 상태를 반환한다`() {
-            val fixture = saveRealtimeParticipant(startedAt = LocalDateTime.now().minusSeconds(40))
+            val fixture = saveRealtimeParticipant(startedAt = activeCandleBlowStartedAt())
 
             blowCandle(fixture, candleId = 3)
 
@@ -129,7 +129,7 @@ class BurstGameControllerTest
 
         @Test
         fun `모든 촛불이 꺼진 뒤 촛불 끄기 요청은 200 응답으로 종료 상태를 반환한다`() {
-            val fixture = saveRealtimeParticipant(startedAt = LocalDateTime.now().minusSeconds(40))
+            val fixture = saveRealtimeParticipant(startedAt = activeCandleBlowStartedAt())
 
             (1..CandleBlowPolicy.CANDLE_COUNT).forEach { candleId ->
                 blowCandle(fixture, candleId)
@@ -411,6 +411,9 @@ class BurstGameControllerTest
                 participantToken = profile.participantToken,
             )
         }
+
+        private fun activeCandleBlowStartedAt(): LocalDateTime =
+            LocalDateTime.now().minusSeconds(CandleBlowPolicy.START_DELAY_SECONDS + 1L)
 
         private fun saveRealtimeParticipants(): List<BurstGameFixture> {
             val party =

--- a/src/test/kotlin/com/team2/server/burstgame/infrastructure/candle/InMemoryCandleBlowSessionStoreTest.kt
+++ b/src/test/kotlin/com/team2/server/burstgame/infrastructure/candle/InMemoryCandleBlowSessionStoreTest.kt
@@ -113,7 +113,7 @@ class InMemoryCandleBlowSessionStoreTest {
                             session
                                 .blow(
                                     candleId = candleId,
-                                    now = partyStartedAt.plusSeconds(40),
+                                    now = partyStartedAt.plusSeconds(CandleBlowPolicy.START_DELAY_SECONDS),
                                 ).changed
                         } == true
                     }
@@ -125,7 +125,7 @@ class InMemoryCandleBlowSessionStoreTest {
             assertTrue(futures.all { it.get(1, TimeUnit.SECONDS) })
             val remainingCount =
                 store.withSessionLock(1L) {
-                    it.snapshot(partyStartedAt.plusSeconds(41)).remainingCount
+                    it.snapshot(partyStartedAt.plusSeconds(CandleBlowPolicy.START_DELAY_SECONDS)).remainingCount
                 }
             assertEquals(0, remainingCount)
         } finally {


### PR DESCRIPTION
## 🔗 Issue
- closes #189

## 💬 Context
촛불끄기 단계 시작 시점을 파티 시작 후 35초에서 41초로 조정합니다. 구현 정책과 문서 계약이 같은 값을 가리키도록 함께 정렬했습니다.

## 🛠 Changes
- `CandleBlowPolicy.START_DELAY_SECONDS`를 `41L`로 변경
- 촛불끄기 설계/계획 문서의 시작 지연 시간을 41초로 정렬-
- 동시성 테스트의 직접 시간값을 정책 상수 기준으로 변경

## 👀 Review Focus\n
- 촛불끄기 시작 지연 시간이 기획 의도대로 41초인지
- 문서와 구현의 정책값이 일치하는지

## ✅ Check List\n
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

 > **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견