### PR TITLE
[Fix] Swagger boolean 스키마 응답 불일치 수정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     implementation("io.micrometer:micrometer-registry-prometheus")
     implementation("com.github.loki4j:loki-logback-appender:1.5.2")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     runtimeOnly("org.flywaydb:flyway-mysql")
     runtimeOnly("com.mysql:mysql-connector-j")

--- a/src/main/kotlin/com/team2/server/common/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/team2/server/common/config/SwaggerConfig.kt
@@ -1,6 +1,9 @@
 package com.team2.server.common.config
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.team2.server.common.web.swagger.OptionalAuth
+import io.swagger.v3.core.jackson.ModelResolver
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType
 import io.swagger.v3.oas.annotations.security.SecurityScheme
 import io.swagger.v3.oas.models.OpenAPI
@@ -21,6 +24,12 @@ import java.lang.reflect.Method
     bearerFormat = "JWT",
 )
 class SwaggerConfig {
+    @Bean
+    fun kotlinModelResolver(): ModelResolver {
+        val mapper = ObjectMapper().registerModule(KotlinModule.Builder().build())
+        return ModelResolver(mapper)
+    }
+
     @Bean
     fun openAPI(): OpenAPI =
         OpenAPI().info(


### PR DESCRIPTION
## 🔗 Issue
- closes #191

## 💬 Context
`isX` 접두사를 가진 boolean 필드(`isOwner`, `isCelebrant`, `isHost` 등)에서 OpenAPI 스키마(`/v3/api-docs`)와 실제 응답 JSON의 필드명이 서로 달랐습니다.

- **런타임 응답**: Spring의 Jackson 3(`tools.jackson` + kotlin module)이 생성자 파라미터명 `isOwner`를 그대로 직렬화 → `"isOwner"`
- **스키마 생성**: springdoc 내부의 swagger-core는 Jackson 2 기반이며 kotlin module이 없어, Java Bean 규칙으로 getter `isOwner()`의 `is`를 제거 → `"owner"`

그 결과 `isX` 필드만 스키마(`owner`/`celebrant`/`me`)와 응답(`isOwner`/`isCelebrant`/`isMe`)이 불일치했습니다. (접두사 없는 `partyEnded`·`hasNext` 등은 떼어낼 `is`가 없어 영향 없음)

## 🛠 Changes
- swagger-core 스키마 생성용으로 Jackson 2 kotlin module(`com.fasterxml.jackson.module:jackson-module-kotlin`) 의존성 추가
- `SwaggerConfig`에 Kotlin module을 등록한 `ModelResolver` bean 추가 → 스키마 생성기도 런타임과 동일하게 `is` 접두사를 유지
- 응답 계약(`isOwner` 등)은 변경 없이, 스키마만 실제 응답에 일치하도록 전역 수정 (DTO 개별 `@JsonProperty` 불필요)

## 👀 Review Focus
- `ModelResolver` bean이 springdoc 기본 ModelResolver를 대체하여 전역 적용되는지 (현재 `SwaggerConfigTest` 및 스키마 실측으로 확인됨)
- 추가한 의존성이 Jackson 2(swagger-core 전용)이고 런타임 Jackson 3와 분리되어 충돌이 없는지

## ⚠️ Side Effects
- **DB 마이그레이션**: 없음
- **환경변수/설정**: 없음
- **의존성 변경**: `com.fasterxml.jackson.module:jackson-module-kotlin`(Jackson 2, 버전은 Spring Boot BOM 관리) 추가
- **API 변경(Breaking)**: 실제 응답 포맷 변경 없음 (`isOwner` 등 그대로 유지)
- **외부 시스템 영향**: OpenAPI 스키마의 `isX` boolean 필드명이 `owner`→`isOwner` 등으로 정정됨. 기존에 잘못된 스키마(`owner`)로 코드 생성한 프론트가 있다면, 정정된 스키마(`isOwner`, 실제 응답과 일치)로 재생성 필요
- **운영 작업**: 없음

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견