### PR TITLE
[Feat] 개발 기간 촛불끄기 제한 시간을 5분으로 완화

### DIFF
--- a/docs/superpowers/plans/2026-05-24-realtime-candle-blow.md
+++ b/docs/superpowers/plans/2026-05-24-realtime-candle-blow.md
@@ -2,7 +2,7 @@
 
 > 단계별로 진행한다. 각 단계가 끝나면 커밋하지 않고 변경 내용과 검증 결과를 공유한다.
 
-**Goal:** 실시간 파티 시작 35초 뒤 공유 촛불 9개를 끄는 단계를 시작하고, 9개 모두 꺼짐 또는 45초 타임아웃으로 종료한 뒤 기존 박터뜨리기 start API를 열어준다.
+**Goal:** 실시간 파티 시작 35초 뒤 공유 촛불 9개를 끄는 단계를 시작하고, 9개 모두 꺼짐 또는 5분 타임아웃으로 종료한 뒤 기존 박터뜨리기 start API를 열어준다.
 
 **Architecture:** 기존 `burstgame` feature 안에 촛불 phase를 추가한다. HTTP 진입점은 `api`, 흐름/트랜잭션은 `application/usecase`, 공유 상태와 정책은 `domain`, in-memory store/scheduler/SSE adapter는 `infrastructure`에 둔다.
 
@@ -14,7 +14,7 @@
 
 - 촛불끄기는 `REALTIME` 파티에서만 동작한다.
 - 시작 시각은 `party.startedAt + 35초`다.
-- 제한 시간은 45초다.
+- 제한 시간은 개발 기간 동안 5분이다.
 - 촛불 수는 9개 고정이고 외부 입력으로 바꾸지 않는다.
 - 실시간 파티 참여자라면 누구나 촛불을 끌 수 있다.
 - 이미 꺼진 촛불 클릭은 `200 OK` 멱등 응답으로 처리한다.
@@ -61,7 +61,7 @@
 
 - [x] `CANDLE_COUNT = 9`
 - [x] `START_DELAY_SECONDS = 35`
-- [x] `DURATION_SECONDS = 45`
+- [x] `DURATION_SECONDS = 300`
 - [x] 1차 store는 단일 app instance 전제의 in-memory 구현으로 둔다.
 - [x] 추후 store 구현 교체 가능성을 고려해 `CandleBlowSessionStore` 포트 뒤에 구현을 숨긴다.
 - [x] `CandleBlowSession` aggregate 상태 전이와 store mutation은 `CandleBlowService`가 담당하고, UseCase는 참여자 검증과 응답 변환 흐름만 조합한다.

--- a/docs/superpowers/specs/2026-05-24-realtime-candle-blow-design.md
+++ b/docs/superpowers/specs/2026-05-24-realtime-candle-blow-design.md
@@ -14,14 +14,14 @@
 - 촛불은 파티 전체가 공유하는 9개 고정 슬롯이다.
 - 실시간 파티 참여자라면 누구나 촛불을 끌 수 있다.
 - 이미 꺼진 촛불을 다시 누르면 실패가 아니라 `200 OK`로 현재 상태를 반환한다.
-- 9개 촛불이 모두 꺼지거나 시작 후 45초가 지나면 촛불끄기 단계는 종료된다.
+- 9개 촛불이 모두 꺼지거나 시작 후 5분이 지나면 촛불끄기 단계는 종료된다.
 - 촛불끄기 종료는 박터뜨리기 자동 시작이 아니다. 참여자 중 누군가가 다음 버튼으로 기존 박터뜨리기 start API를 호출해야 한다.
 
 기본 정책:
 
 ```kotlin
 CANDLE_BLOW_START_DELAY_SECONDS = 35
-CANDLE_BLOW_DURATION_SECONDS = 45
+CANDLE_BLOW_DURATION_SECONDS = 300
 CANDLE_COUNT = 9
 ```
 
@@ -30,7 +30,7 @@ CANDLE_COUNT = 9
 | 값 | 설명 |
 |---|---|
 | `ALL_EXTINGUISHED` | 9개 촛불이 모두 꺼져 즉시 종료 |
-| `TIMEOUT` | 시작 후 45초가 지나 자동 종료 |
+| `TIMEOUT` | 시작 후 5분이 지나 자동 종료 |
 
 용어:
 
@@ -54,7 +54,7 @@ CANDLE_COUNT = 9
   │◄── 200 OK 현재 촛불 상태 ─────────│
   │◄── event: candle-blow-progress ───│
   │                                    │
-  │ 9개 모두 꺼짐 또는 45초 경과        │
+  │ 9개 모두 꺼짐 또는 5분 경과         │
   │◄── event: candle-blow-ended ──────│
   │                                    │
   │ 참여자 중 누군가 다음 버튼 클릭      │
@@ -76,7 +76,7 @@ CANDLE_COUNT = 9
 | 참여자 검증 | JWT 또는 `X-Participant-Token`으로 실시간 파티 참여자 확인 |
 | 공유 상태 관리 | 파티별 9개 촛불의 extinguished 상태를 단일 aggregate로 관리 |
 | 멱등 처리 | 이미 꺼진 촛불 클릭은 `200 OK`로 현재 촛불 상태를 그대로 반환 |
-| 종료 처리 | 9개 모두 꺼짐 또는 45초 타임아웃 시 finished 상태 전이 |
+| 종료 처리 | 9개 모두 꺼짐 또는 5분 타임아웃 시 finished 상태 전이 |
 | 박터뜨리기 연동 | `CandleBlowStatusReader` 계열 계약은 `finished` 여부를 반환하도록 정렬 |
 
 ---
@@ -247,7 +247,7 @@ data: {"partyId":1,"status":"FINISHED","candles":[{"candleId":1,"extinguished":t
 발생 조건:
 
 - 9개 촛불이 모두 꺼짐
-- 시작 후 45초 경과
+- 시작 후 5분 경과
 
 정확히 1회 발송 조건:
 
@@ -339,7 +339,7 @@ burstgame/infrastructure/scheduler
 - 촛불 1개 끄기 성공 시 해당 `candleId`의 `extinguished`가 `true`로 바뀐다.
 - 이미 꺼진 촛불 재클릭은 `200 OK`와 현재 9개 촛불 상태를 반환한다.
 - 9개가 모두 꺼지면 `FINISHED`, `finishedReason=ALL_EXTINGUISHED`.
-- 45초가 지나면 `FINISHED`, `finishedReason=TIMEOUT`.
+- 5분이 지나면 `FINISHED`, `finishedReason=TIMEOUT`.
 - 종료 후 클릭은 `200 OK`와 현재 종료 상태를 반환한다.
 - `FINISHED` 상태에서는 박터뜨리기 start가 가능하다.
 - `WAITING`/`ACTIVE` 상태에서는 박터뜨리기 start가 `BURST_GAME_NOT_READY`.

--- a/src/main/kotlin/com/team2/server/burstgame/domain/candle/CandleBlowPolicy.kt
+++ b/src/main/kotlin/com/team2/server/burstgame/domain/candle/CandleBlowPolicy.kt
@@ -7,7 +7,7 @@ import java.time.Duration
 object CandleBlowPolicy {
     const val CANDLE_COUNT = 9
     const val START_DELAY_SECONDS = 35L
-    const val DURATION_SECONDS = 45L
+    const val DURATION_SECONDS = 300L
     private const val SESSION_TTL_MINUTES = 10L
     val SESSION_TTL: Duration = Duration.ofMinutes(SESSION_TTL_MINUTES)
 

--- a/src/test/kotlin/com/team2/server/burstgame/api/BurstGameControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/burstgame/api/BurstGameControllerTest.kt
@@ -148,7 +148,7 @@ class BurstGameControllerTest
 
         @Test
         fun `종료 시각이 지난 촛불끄기 조회는 TIMEOUT 종료 상태를 반환한다`() {
-            val fixture = saveRealtimeParticipant(startedAt = LocalDateTime.now().minusSeconds(90))
+            val fixture = saveRealtimeParticipant(startedAt = LocalDateTime.now().minusSeconds(340))
 
             mockMvc
                 .get("/api/v1/parties/${fixture.partyId}/candle-blow") {
@@ -195,7 +195,7 @@ class BurstGameControllerTest
 
         @Test
         fun `촛불 세션이 없어도 촛불 종료 시각이 지난 파티는 박터뜨리기 시작 성공`() {
-            val fixture = saveRealtimeParticipant(startedAt = LocalDateTime.now().minusSeconds(90))
+            val fixture = saveRealtimeParticipant(startedAt = LocalDateTime.now().minusSeconds(340))
 
             mockMvc
                 .post("/api/v1/parties/${fixture.partyId}/burst-game/start") {

--- a/src/test/kotlin/com/team2/server/burstgame/application/usecase/GetCandleBlowStateUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/burstgame/application/usecase/GetCandleBlowStateUseCaseTest.kt
@@ -6,6 +6,7 @@ import com.team2.server.burstgame.application.support.BurstGameParticipantResolv
 import com.team2.server.burstgame.application.support.CandleBlowEndEventPublisher
 import com.team2.server.burstgame.domain.BurstGameParticipantInfo
 import com.team2.server.burstgame.domain.candle.CandleBlowFinishedReason
+import com.team2.server.burstgame.domain.candle.CandleBlowPolicy
 import com.team2.server.burstgame.infrastructure.candle.InMemoryCandleBlowSessionStore
 import com.team2.server.party.domain.entity.RealtimeParty
 import org.junit.jupiter.api.extension.ExtendWith
@@ -40,7 +41,14 @@ class GetCandleBlowStateUseCaseTest {
     @Test
     fun `조회로 촛불끄기 timeout 종료가 발생하면 ended 이벤트를 커밋 이후 발행한다`() {
         whenever(participantResolver.resolveWithParty(1L, null, "tok"))
-            .thenReturn(resolved(partyStartedAt = LocalDateTime.of(2026, 5, 21, 20, 0)))
+            .thenReturn(
+                resolved(
+                    partyStartedAt =
+                        LocalDateTime
+                            .now(clock)
+                            .minusSeconds(CandleBlowPolicy.START_DELAY_SECONDS + CandleBlowPolicy.DURATION_SECONDS),
+                ),
+            )
 
         TransactionSynchronizationManager.initSynchronization()
         try {


### PR DESCRIPTION
## Summary

- 촛불끄기 제한 시간을 45초에서 5분(300초)으로 변경했습니다.
- timeout 전제 테스트를 5분 기준으로 보정했습니다.
- 촛불끄기 설계/계획 문서의 정책값을 함께 업데이트했습니다.

## Test

- ./gradlew test --tests '*CandleBlow*' --tests '*BurstGameControllerTest*'

Closes #193

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기능 개선**
  * 실시간 파티의 촛불끄기 단계 제한 시간을 45초에서 5분으로 연장했습니다.

* **문서**
  * 촛불끄기 제한 시간 정책 및 설계 사양을 업데이트했습니다.

* **테스트**
  * 새로운 제한 시간 정책에 맞춰 관련 테스트 케이스를 개선했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/18th-team2-server/pull/194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->