### PR TITLE
[Feat] 주최자 입장 기준 촛불끄기 타이밍 조정

### DIFF
--- a/docs/superpowers/plans/2026-05-24-realtime-candle-blow.md
+++ b/docs/superpowers/plans/2026-05-24-realtime-candle-blow.md
@@ -2,7 +2,7 @@
 
 > 단계별로 진행한다. 각 단계가 끝나면 커밋하지 않고 변경 내용과 검증 결과를 공유한다.
 
-**Goal:** 실시간 파티 시작 41초 뒤 공유 촛불 9개를 끄는 단계를 시작하고, 9개 모두 꺼짐 또는 5분 타임아웃으로 종료한 뒤 기존 박터뜨리기 start API를 열어준다.
+**Goal:** 주최자가 실시간 파티에 처음 입장한 시각부터 41초 뒤 공유 촛불 9개를 끄는 단계를 시작하고, 9개 모두 꺼짐 또는 환경별 타임아웃으로 종료한 뒤 기존 박터뜨리기 start API를 열어준다.
 
 **Architecture:** 기존 `burstgame` feature 안에 촛불 phase를 추가한다. HTTP 진입점은 `api`, 흐름/트랜잭션은 `application/usecase`, 공유 상태와 정책은 `domain`, in-memory store/scheduler/SSE adapter는 `infrastructure`에 둔다.
 
@@ -13,8 +13,9 @@
 ## Decisions
 
 - 촛불끄기는 `REALTIME` 파티에서만 동작한다.
-- 시작 시각은 `party.startedAt + 41초`다.
-- 제한 시간은 개발 기간 동안 5분이다.
+- 시작 시각은 `realtime_party.host_entered_at + 41초`다.
+- `host_entered_at`은 주최자가 실시간 파티에 처음 입장할 때 한 번만 저장한다.
+- 제한 시간은 기본/개발 환경 5분, 운영 환경 45초다.
 - 촛불 수는 9개 고정이고 외부 입력으로 바꾸지 않는다.
 - 실시간 파티 참여자라면 누구나 촛불을 끌 수 있다.
 - 이미 꺼진 촛불 클릭은 `200 OK` 멱등 응답으로 처리한다.
@@ -22,7 +23,7 @@
 - 촛불 종료 후 박터뜨리기는 자동 시작하지 않는다.
 - 다음 버튼을 누른 참여자 중 가장 먼저 도착한 기존 `burst-game/start` 요청이 박터뜨리기 라운드를 생성한다.
 - 박터뜨리기 선행 조건은 촛불 `finished`다.
-- 1차 구현은 DB 저장 없이 in-memory session으로 처리한다.
+- 촛불 세션 상태는 in-memory로 처리하되, 시작 기준 시각은 DB에 저장해 서버 재시작 후 스케줄 복구가 가능하게 한다.
 - 확장성을 고려해 촛불 상태 접근은 `CandleBlowSessionStore` 포트 뒤에 둔다.
 
 ---
@@ -61,7 +62,7 @@
 
 - [x] `CANDLE_COUNT = 9`
 - [x] `START_DELAY_SECONDS = 41`
-- [x] `DURATION_SECONDS = 300`
+- [x] 기본 `duration-seconds = 300`, 운영 `duration-seconds = 45`
 - [x] 1차 store는 단일 app instance 전제의 in-memory 구현으로 둔다.
 - [x] 추후 store 구현 교체 가능성을 고려해 `CandleBlowSessionStore` 포트 뒤에 구현을 숨긴다.
 - [x] `CandleBlowSession` aggregate 상태 전이와 store mutation은 `CandleBlowService`가 담당하고, UseCase는 참여자 검증과 응답 변환 흐름만 조합한다.
@@ -84,7 +85,7 @@
 - [x] `GET /api/v1/parties/{partyId}/candle-blow`
 - [x] `POST /api/v1/parties/{partyId}/candle-blow/candles/{candleId}`
 - [x] JWT 또는 `X-Participant-Token` 참여자 검증 재사용
-- [x] `party.startedAt + 41초` 전 `WAITING` 상태 blow 요청은 `CANDLE_BLOW_NOT_STARTED`
+- [x] `hostEnteredAt + 41초` 전 `WAITING` 상태 blow 요청은 `CANDLE_BLOW_NOT_STARTED`
 - [x] `FINISHED` 상태 blow 요청은 `200 OK` 멱등 응답
 - [x] `GetCandleBlowStateUseCase`, `BlowCandleUseCase`는 `CandleBlowService`에 상태 조회/전이 처리를 위임한다.
 

--- a/docs/superpowers/plans/2026-05-24-realtime-candle-blow.md
+++ b/docs/superpowers/plans/2026-05-24-realtime-candle-blow.md
@@ -2,7 +2,7 @@
 
 > 단계별로 진행한다. 각 단계가 끝나면 커밋하지 않고 변경 내용과 검증 결과를 공유한다.
 
-**Goal:** 실시간 파티 시작 41초 뒤 공유 촛불 9개를 끄는 단계를 시작하고, 9개 모두 꺼짐 또는 45초 타임아웃으로 종료한 뒤 기존 박터뜨리기 start API를 열어준다.
+**Goal:** 실시간 파티 시작 41초 뒤 공유 촛불 9개를 끄는 단계를 시작하고, 9개 모두 꺼짐 또는 5분 타임아웃으로 종료한 뒤 기존 박터뜨리기 start API를 열어준다.
 
 **Architecture:** 기존 `burstgame` feature 안에 촛불 phase를 추가한다. HTTP 진입점은 `api`, 흐름/트랜잭션은 `application/usecase`, 공유 상태와 정책은 `domain`, in-memory store/scheduler/SSE adapter는 `infrastructure`에 둔다.
 
@@ -14,7 +14,7 @@
 
 - 촛불끄기는 `REALTIME` 파티에서만 동작한다.
 - 시작 시각은 `party.startedAt + 41초`다.
-- 제한 시간은 45초다.
+- 제한 시간은 개발 기간 동안 5분이다.
 - 촛불 수는 9개 고정이고 외부 입력으로 바꾸지 않는다.
 - 실시간 파티 참여자라면 누구나 촛불을 끌 수 있다.
 - 이미 꺼진 촛불 클릭은 `200 OK` 멱등 응답으로 처리한다.
@@ -61,7 +61,7 @@
 
 - [x] `CANDLE_COUNT = 9`
 - [x] `START_DELAY_SECONDS = 41`
-- [x] `DURATION_SECONDS = 45`
+- [x] `DURATION_SECONDS = 300`
 - [x] 1차 store는 단일 app instance 전제의 in-memory 구현으로 둔다.
 - [x] 추후 store 구현 교체 가능성을 고려해 `CandleBlowSessionStore` 포트 뒤에 구현을 숨긴다.
 - [x] `CandleBlowSession` aggregate 상태 전이와 store mutation은 `CandleBlowService`가 담당하고, UseCase는 참여자 검증과 응답 변환 흐름만 조합한다.

--- a/docs/superpowers/specs/2026-05-24-realtime-candle-blow-design.md
+++ b/docs/superpowers/specs/2026-05-24-realtime-candle-blow-design.md
@@ -14,14 +14,14 @@
 - 촛불은 파티 전체가 공유하는 9개 고정 슬롯이다.
 - 실시간 파티 참여자라면 누구나 촛불을 끌 수 있다.
 - 이미 꺼진 촛불을 다시 누르면 실패가 아니라 `200 OK`로 현재 상태를 반환한다.
-- 9개 촛불이 모두 꺼지거나 시작 후 45초가 지나면 촛불끄기 단계는 종료된다.
+- 9개 촛불이 모두 꺼지거나 시작 후 5분이 지나면 촛불끄기 단계는 종료된다.
 - 촛불끄기 종료는 박터뜨리기 자동 시작이 아니다. 참여자 중 누군가가 다음 버튼으로 기존 박터뜨리기 start API를 호출해야 한다.
 
 기본 정책:
 
 ```kotlin
 CANDLE_BLOW_START_DELAY_SECONDS = 41
-CANDLE_BLOW_DURATION_SECONDS = 45
+CANDLE_BLOW_DURATION_SECONDS = 300
 CANDLE_COUNT = 9
 ```
 
@@ -30,7 +30,7 @@ CANDLE_COUNT = 9
 | 값 | 설명 |
 |---|---|
 | `ALL_EXTINGUISHED` | 9개 촛불이 모두 꺼져 즉시 종료 |
-| `TIMEOUT` | 시작 후 45초가 지나 자동 종료 |
+| `TIMEOUT` | 시작 후 5분이 지나 자동 종료 |
 
 용어:
 
@@ -54,7 +54,7 @@ CANDLE_COUNT = 9
   │◄── 200 OK 현재 촛불 상태 ─────────│
   │◄── event: candle-blow-progress ───│
   │                                    │
-  │ 9개 모두 꺼짐 또는 45초 경과        │
+  │ 9개 모두 꺼짐 또는 5분 경과         │
   │◄── event: candle-blow-ended ──────│
   │                                    │
   │ 참여자 중 누군가 다음 버튼 클릭      │
@@ -76,7 +76,7 @@ CANDLE_COUNT = 9
 | 참여자 검증 | JWT 또는 `X-Participant-Token`으로 실시간 파티 참여자 확인 |
 | 공유 상태 관리 | 파티별 9개 촛불의 extinguished 상태를 단일 aggregate로 관리 |
 | 멱등 처리 | 이미 꺼진 촛불 클릭은 `200 OK`로 현재 촛불 상태를 그대로 반환 |
-| 종료 처리 | 9개 모두 꺼짐 또는 45초 타임아웃 시 finished 상태 전이 |
+| 종료 처리 | 9개 모두 꺼짐 또는 5분 타임아웃 시 finished 상태 전이 |
 | 박터뜨리기 연동 | `CandleBlowStatusReader` 계열 계약은 `finished` 여부를 반환하도록 정렬 |
 
 ---
@@ -247,7 +247,7 @@ data: {"partyId":1,"status":"FINISHED","candles":[{"candleId":1,"extinguished":t
 발생 조건:
 
 - 9개 촛불이 모두 꺼짐
-- 시작 후 45초 경과
+- 시작 후 5분 경과
 
 정확히 1회 발송 조건:
 
@@ -339,7 +339,7 @@ burstgame/infrastructure/scheduler
 - 촛불 1개 끄기 성공 시 해당 `candleId`의 `extinguished`가 `true`로 바뀐다.
 - 이미 꺼진 촛불 재클릭은 `200 OK`와 현재 9개 촛불 상태를 반환한다.
 - 9개가 모두 꺼지면 `FINISHED`, `finishedReason=ALL_EXTINGUISHED`.
-- 45초가 지나면 `FINISHED`, `finishedReason=TIMEOUT`.
+- 5분이 지나면 `FINISHED`, `finishedReason=TIMEOUT`.
 - 종료 후 클릭은 `200 OK`와 현재 종료 상태를 반환한다.
 - `FINISHED` 상태에서는 박터뜨리기 start가 가능하다.
 - `WAITING`/`ACTIVE` 상태에서는 박터뜨리기 start가 `BURST_GAME_NOT_READY`.

--- a/docs/superpowers/specs/2026-05-24-realtime-candle-blow-design.md
+++ b/docs/superpowers/specs/2026-05-24-realtime-candle-blow-design.md
@@ -10,18 +10,18 @@
 
 핵심 동작:
 
-- 실시간 파티가 시작된 뒤 41초가 지나면 촛불끄기 단계가 서버 기준으로 시작된다.
+- 주최자가 실시간 파티에 처음 입장한 뒤 41초가 지나면 촛불끄기 단계가 서버 기준으로 시작된다.
 - 촛불은 파티 전체가 공유하는 9개 고정 슬롯이다.
 - 실시간 파티 참여자라면 누구나 촛불을 끌 수 있다.
 - 이미 꺼진 촛불을 다시 누르면 실패가 아니라 `200 OK`로 현재 상태를 반환한다.
-- 9개 촛불이 모두 꺼지거나 시작 후 5분이 지나면 촛불끄기 단계는 종료된다.
+- 9개 촛불이 모두 꺼지거나 환경별 제한 시간이 지나면 촛불끄기 단계는 종료된다.
 - 촛불끄기 종료는 박터뜨리기 자동 시작이 아니다. 참여자 중 누군가가 다음 버튼으로 기존 박터뜨리기 start API를 호출해야 한다.
 
 기본 정책:
 
 ```kotlin
 CANDLE_BLOW_START_DELAY_SECONDS = 41
-CANDLE_BLOW_DURATION_SECONDS = 300
+CANDLE_BLOW_DURATION_SECONDS = default/dev/test 300, prod 45
 CANDLE_COUNT = 9
 ```
 
@@ -30,7 +30,7 @@ CANDLE_COUNT = 9
 | 값 | 설명 |
 |---|---|
 | `ALL_EXTINGUISHED` | 9개 촛불이 모두 꺼져 즉시 종료 |
-| `TIMEOUT` | 시작 후 5분이 지나 자동 종료 |
+| `TIMEOUT` | 시작 후 환경별 제한 시간이 지나 자동 종료 |
 
 용어:
 
@@ -46,7 +46,7 @@ CANDLE_COUNT = 9
   │                                    │
   │ 실시간 파티 입장 + SSE 연결         │
   │                                    │
-  │ party.startedAt + 41초              │
+  │ hostEnteredAt + 41초                │
   │◄── event: candle-blow-started ─────│
   │                                    │
   │── POST /parties/{id}/              │
@@ -54,7 +54,7 @@ CANDLE_COUNT = 9
   │◄── 200 OK 현재 촛불 상태 ─────────│
   │◄── event: candle-blow-progress ───│
   │                                    │
-  │ 9개 모두 꺼짐 또는 5분 경과         │
+  │ 9개 모두 꺼짐 또는 제한 시간 경과   │
   │◄── event: candle-blow-ended ──────│
   │                                    │
   │ 참여자 중 누군가 다음 버튼 클릭      │
@@ -71,12 +71,12 @@ CANDLE_COUNT = 9
 
 | 영역 | 설명 |
 |---|---|
-| 시작 예약 | `party.startedAt + 41초`에 촛불끄기 시작 예약 및 SSE 발송 |
-| 복구 | 앱 재시작, SSE 유실, 늦은 입장 시 상태 조회 또는 입장 이벤트로 현재 단계 복구 |
+| 시작 예약 | `hostEnteredAt + 41초`에 촛불끄기 시작 예약 및 SSE 발송 |
+| 복구 | `realtime_party.host_entered_at` 기준으로 앱 재시작 후 스케줄을 복구하고, SSE 유실/늦은 입장 시 상태 조회로 현재 단계 복구 |
 | 참여자 검증 | JWT 또는 `X-Participant-Token`으로 실시간 파티 참여자 확인 |
 | 공유 상태 관리 | 파티별 9개 촛불의 extinguished 상태를 단일 aggregate로 관리 |
 | 멱등 처리 | 이미 꺼진 촛불 클릭은 `200 OK`로 현재 촛불 상태를 그대로 반환 |
-| 종료 처리 | 9개 모두 꺼짐 또는 5분 타임아웃 시 finished 상태 전이 |
+| 종료 처리 | 9개 모두 꺼짐 또는 환경별 타임아웃 시 finished 상태 전이 |
 | 박터뜨리기 연동 | `CandleBlowStatusReader` 계열 계약은 `finished` 여부를 반환하도록 정렬 |
 
 ---
@@ -122,7 +122,7 @@ X-Participant-Token: {participantToken}
 
 | 값 | 설명 |
 |---|---|
-| `WAITING` | `party.startedAt + 41초` 전 |
+| `WAITING` | 주최자 미입장 또는 `hostEnteredAt + 41초` 전 |
 | `ACTIVE` | 촛불끄기 입력 가능 |
 | `FINISHED` | `ALL_EXTINGUISHED` 또는 `TIMEOUT`으로 종료 |
 
@@ -134,7 +134,7 @@ X-Participant-Token: {participantToken}
 - 아직 시작 전이면 `WAITING` 상태를 반환한다.
 - 시작/종료 예약 이벤트가 유실됐더라도 조회 시점의 서버 시간으로 lazy transition을 수행할 수 있다.
 - 조회 lazy transition은 party 단위 lock 또는 compare-and-set 안에서 수행한다.
-  - `status == WAITING && now >= party.startedAt + 41초`이면 `transitionToActiveOnce()`와 `emitStartedEventOnce()`를 같은 critical section에서 예약한다.
+  - `status == WAITING && hostEnteredAt != null && now >= hostEnteredAt + 41초`이면 `transitionToActiveOnce()`와 `emitStartedEventOnce()`를 같은 critical section에서 예약한다.
   - `status == ACTIVE && now >= endsAt`이면 `transitionToFinishedOnce()`와 `emitEndedEventOnce()`를 같은 critical section에서 예약한다.
   - persisted store로 교체할 때는 동등한 deduplication marker로 `candle-blow-started`, `candle-blow-ended`가 각각 정확히 1회만 발행되도록 보장한다.
 
@@ -193,8 +193,8 @@ X-Participant-Token: {participantToken}
 처리 정책:
 
 - `candleId`는 `1..9`만 허용한다. 범위를 벗어나면 `INVALID_INPUT`.
-- `WAITING` 상태이고 `now < party.startedAt + 41초`이면 `CANDLE_BLOW_NOT_STARTED`.
-- `WAITING` 상태지만 `now >= party.startedAt + 41초`이면 party 단위 lock 또는 compare-and-set 안에서 lazy `transitionToActiveOnce()`와 `emitStartedEventOnce()`를 예약한 뒤 촛불 끄기 요청을 처리한다.
+- `WAITING` 상태이고 주최자 미입장 또는 `now < hostEnteredAt + 41초`이면 `CANDLE_BLOW_NOT_STARTED`.
+- `WAITING` 상태지만 `hostEnteredAt != null && now >= hostEnteredAt + 41초`이면 party 단위 lock 또는 compare-and-set 안에서 lazy `transitionToActiveOnce()`와 `emitStartedEventOnce()`를 예약한 뒤 촛불 끄기 요청을 처리한다.
 - `FINISHED` 상태에서 호출하면 `200 OK`와 현재 종료 상태를 반환한다.
 - 이미 꺼진 촛불이면 `200 OK`와 현재 상태를 반환한다.
 - 새 촛불이 꺼지면 현재 9개 촛불 상태를 반환하고 progress SSE 발송 대상이 된다.
@@ -215,13 +215,13 @@ data: {"partyId":1,"status":"ACTIVE","candles":[{"candleId":1,"extinguished":fal
 
 발생 조건:
 
-- `party.startedAt + 41초` 도달
+- `hostEnteredAt + 41초` 도달
 - 서버 재시작 후 복구 시 이미 시작 시간이 지났지만 아직 종료 시간이 지나지 않은 경우
 - 상태 조회 또는 촛불 끄기 요청에서 `WAITING` lazy transition이 발생한 경우
 
 정확히 1회 발송 조건:
 
-- scheduler 시작, 서버 재시작 복구, 상태 조회 lazy transition, 촛불 끄기 요청이 동시에 시작을 시도해도 party 단위 lock 또는 compare-and-set에서 `status == WAITING && now >= party.startedAt + 41초`를 획득한 하나의 경로만 `transitionToActiveOnce()`를 수행한다.
+- scheduler 시작, 서버 재시작 복구, 상태 조회 lazy transition, 촛불 끄기 요청이 동시에 시작을 시도해도 party 단위 lock 또는 compare-and-set에서 `status == WAITING && hostEnteredAt != null && now >= hostEnteredAt + 41초`를 획득한 하나의 경로만 `transitionToActiveOnce()`를 수행한다.
 - 같은 critical section 안에서 started snapshot과 `emitStartedEventOnce()` 예약 여부를 결정한다.
 - persisted store 구현으로 교체할 경우에는 status 전이와 event deduplication marker 저장을 하나의 원자적 연산으로 처리한다.
 
@@ -247,7 +247,7 @@ data: {"partyId":1,"status":"FINISHED","candles":[{"candleId":1,"extinguished":t
 발생 조건:
 
 - 9개 촛불이 모두 꺼짐
-- 시작 후 5분 경과
+- 시작 후 환경별 제한 시간 경과
 
 정확히 1회 발송 조건:
 
@@ -280,7 +280,7 @@ interface CandleBlowStatusReader {
 
 ## 6. 상태 저장 전략 [구현]
 
-1차 구현은 DB 저장 없이 in-memory session으로 처리한다.
+촛불 세션 상태는 in-memory로 처리한다. 단, 촛불 시작 기준인 `realtime_party.host_entered_at`은 DB에 저장해 서버 재시작 후 시작/종료 스케줄을 복구할 수 있게 한다.
 
 전제:
 
@@ -334,12 +334,12 @@ burstgame/infrastructure/scheduler
 
 ## 8. 테스트 포인트
 
-- `party.startedAt + 41초` 전 상태 조회는 `WAITING`.
-- `party.startedAt + 41초` 이후 상태 조회는 `ACTIVE`.
+- 주최자 미입장 또는 `hostEnteredAt + 41초` 전 상태 조회는 `WAITING`.
+- `hostEnteredAt + 41초` 이후 상태 조회는 `ACTIVE`.
 - 촛불 1개 끄기 성공 시 해당 `candleId`의 `extinguished`가 `true`로 바뀐다.
 - 이미 꺼진 촛불 재클릭은 `200 OK`와 현재 9개 촛불 상태를 반환한다.
 - 9개가 모두 꺼지면 `FINISHED`, `finishedReason=ALL_EXTINGUISHED`.
-- 5분이 지나면 `FINISHED`, `finishedReason=TIMEOUT`.
+- 환경별 제한 시간이 지나면 `FINISHED`, `finishedReason=TIMEOUT`.
 - 종료 후 클릭은 `200 OK`와 현재 종료 상태를 반환한다.
 - `FINISHED` 상태에서는 박터뜨리기 start가 가능하다.
 - `WAITING`/`ACTIVE` 상태에서는 박터뜨리기 start가 `BURST_GAME_NOT_READY`.

--- a/src/main/kotlin/com/team2/server/burstgame/application/dto/CandleBlowScheduleTarget.kt
+++ b/src/main/kotlin/com/team2/server/burstgame/application/dto/CandleBlowScheduleTarget.kt
@@ -4,5 +4,5 @@ import java.time.LocalDateTime
 
 data class CandleBlowScheduleTarget(
     val partyId: Long,
-    val partyStartedAt: LocalDateTime,
+    val hostEnteredAt: LocalDateTime,
 )

--- a/src/main/kotlin/com/team2/server/burstgame/application/dto/CandleBlowStateLookupResult.kt
+++ b/src/main/kotlin/com/team2/server/burstgame/application/dto/CandleBlowStateLookupResult.kt
@@ -1,0 +1,8 @@
+package com.team2.server.burstgame.application.dto
+
+import com.team2.server.burstgame.domain.candle.CandleBlowSnapshot
+
+data class CandleBlowStateLookupResult(
+    val response: CandleBlowResponse,
+    val endedSnapshot: CandleBlowSnapshot?,
+)

--- a/src/main/kotlin/com/team2/server/burstgame/application/port/CandleBlowStatusReader.kt
+++ b/src/main/kotlin/com/team2/server/burstgame/application/port/CandleBlowStatusReader.kt
@@ -5,7 +5,7 @@ import java.time.LocalDateTime
 interface CandleBlowStatusReader {
     fun isCandleBlowFinished(
         partyId: Long,
-        partyStartedAt: LocalDateTime,
+        hostEnteredAt: LocalDateTime?,
         now: LocalDateTime,
     ): Boolean
 }

--- a/src/main/kotlin/com/team2/server/burstgame/application/service/BurstGameSessionService.kt
+++ b/src/main/kotlin/com/team2/server/burstgame/application/service/BurstGameSessionService.kt
@@ -40,13 +40,13 @@ class BurstGameSessionService(
 
     fun start(
         partyId: Long,
-        partyStartedAt: LocalDateTime,
+        hostEnteredAt: LocalDateTime?,
         participant: BurstGameParticipantInfo,
         now: LocalDateTime,
     ): StartResult {
         val result =
             sessionStore.start(partyId, now) {
-                validateCandleBlowFinished(partyId, partyStartedAt, now)
+                validateCandleBlowFinished(partyId, hostEnteredAt, now)
                 BurstGameSession(
                     partyId = partyId,
                     startedAt = now,
@@ -148,10 +148,10 @@ class BurstGameSessionService(
 
     private fun validateCandleBlowFinished(
         partyId: Long,
-        partyStartedAt: LocalDateTime,
+        hostEnteredAt: LocalDateTime?,
         now: LocalDateTime,
     ) {
-        if (!candleBlowStatusReader.isCandleBlowFinished(partyId, partyStartedAt, now)) {
+        if (!candleBlowStatusReader.isCandleBlowFinished(partyId, hostEnteredAt, now)) {
             throw BusinessException(ErrorCode.BURST_GAME_NOT_READY)
         }
     }

--- a/src/main/kotlin/com/team2/server/burstgame/application/usecase/BlowCandleUseCase.kt
+++ b/src/main/kotlin/com/team2/server/burstgame/application/usecase/BlowCandleUseCase.kt
@@ -4,8 +4,11 @@ import com.team2.server.burstgame.application.dto.CandleBlowResponse
 import com.team2.server.burstgame.application.port.CandleBlowSessionStore
 import com.team2.server.burstgame.application.support.BurstGameParticipantResolver
 import com.team2.server.burstgame.application.support.CandleBlowUpdateEventPublisher
+import com.team2.server.burstgame.config.CandleBlowProperties
 import com.team2.server.burstgame.domain.candle.CandleBlowSession
 import com.team2.server.burstgame.domain.candle.CandleBlowStatus
+import com.team2.server.common.exception.BusinessException
+import com.team2.server.common.exception.ErrorCode
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Clock
@@ -16,6 +19,7 @@ class BlowCandleUseCase(
     private val participantResolver: BurstGameParticipantResolver,
     private val sessionStore: CandleBlowSessionStore,
     private val updateEventPublisher: CandleBlowUpdateEventPublisher,
+    private val candleBlowProperties: CandleBlowProperties,
     private val clock: Clock,
 ) {
     @Transactional
@@ -27,12 +31,16 @@ class BlowCandleUseCase(
     ): CandleBlowResponse {
         val context = participantResolver.resolveWithParty(partyId, userId, participantToken)
         val now = LocalDateTime.now(clock)
+        val hostEnteredAt =
+            context.party.hostEnteredAt
+                ?: throw BusinessException(ErrorCode.CANDLE_BLOW_NOT_STARTED)
         return sessionStore.getOrCreateWithLock(
             partyId = partyId,
             sessionFactory = {
-                CandleBlowSession.fromPartyStartedAt(
+                CandleBlowSession.fromHostEnteredAt(
                     partyId = partyId,
-                    partyStartedAt = context.party.startedAt,
+                    hostEnteredAt = hostEnteredAt,
+                    durationSeconds = candleBlowProperties.durationSeconds,
                 )
             },
         ) { session, _ ->

--- a/src/main/kotlin/com/team2/server/burstgame/application/usecase/GetCandleBlowStateUseCase.kt
+++ b/src/main/kotlin/com/team2/server/burstgame/application/usecase/GetCandleBlowStateUseCase.kt
@@ -4,6 +4,7 @@ import com.team2.server.burstgame.application.dto.CandleBlowResponse
 import com.team2.server.burstgame.application.port.CandleBlowSessionStore
 import com.team2.server.burstgame.application.support.BurstGameParticipantResolver
 import com.team2.server.burstgame.application.support.CandleBlowEndEventPublisher
+import com.team2.server.burstgame.config.CandleBlowProperties
 import com.team2.server.burstgame.domain.candle.CandleBlowSession
 import com.team2.server.burstgame.domain.candle.CandleBlowSnapshot
 import com.team2.server.burstgame.domain.candle.CandleBlowStatus
@@ -17,6 +18,7 @@ class GetCandleBlowStateUseCase(
     private val participantResolver: BurstGameParticipantResolver,
     private val sessionStore: CandleBlowSessionStore,
     private val endEventPublisher: CandleBlowEndEventPublisher,
+    private val candleBlowProperties: CandleBlowProperties,
     private val clock: Clock,
 ) {
     @Transactional
@@ -27,13 +29,17 @@ class GetCandleBlowStateUseCase(
     ): CandleBlowResponse {
         val context = participantResolver.resolveWithParty(partyId, userId, participantToken)
         val now = LocalDateTime.now(clock)
+        val hostEnteredAt =
+            context.party.hostEnteredAt
+                ?: return CandleBlowResponse.from(CandleBlowSnapshot.waiting(partyId))
         val result =
             sessionStore.getOrCreateWithLock(
                 partyId = partyId,
                 sessionFactory = {
-                    CandleBlowSession.fromPartyStartedAt(
+                    CandleBlowSession.fromHostEnteredAt(
                         partyId = partyId,
-                        partyStartedAt = context.party.startedAt,
+                        hostEnteredAt = hostEnteredAt,
+                        durationSeconds = candleBlowProperties.durationSeconds,
                     )
                 },
             ) { session, _ ->

--- a/src/main/kotlin/com/team2/server/burstgame/application/usecase/GetCandleBlowStateUseCase.kt
+++ b/src/main/kotlin/com/team2/server/burstgame/application/usecase/GetCandleBlowStateUseCase.kt
@@ -1,6 +1,7 @@
 package com.team2.server.burstgame.application.usecase
 
 import com.team2.server.burstgame.application.dto.CandleBlowResponse
+import com.team2.server.burstgame.application.dto.CandleBlowStateLookupResult
 import com.team2.server.burstgame.application.port.CandleBlowSessionStore
 import com.team2.server.burstgame.application.support.BurstGameParticipantResolver
 import com.team2.server.burstgame.application.support.CandleBlowEndEventPublisher
@@ -11,7 +12,6 @@ import com.team2.server.burstgame.domain.candle.CandleBlowStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Clock
-import java.time.LocalDateTime
 
 @Service
 class GetCandleBlowStateUseCase(
@@ -28,10 +28,9 @@ class GetCandleBlowStateUseCase(
         participantToken: String?,
     ): CandleBlowResponse {
         val context = participantResolver.resolveWithParty(partyId, userId, participantToken)
-        val now = LocalDateTime.now(clock)
+        val now = java.time.LocalDateTime.now(clock)
         val hostEnteredAt =
-            context.party.hostEnteredAt
-                ?: return CandleBlowResponse.from(CandleBlowSnapshot.waiting(partyId))
+            context.party.hostEnteredAt ?: return CandleBlowResponse.from(CandleBlowSnapshot.waiting(partyId))
         val result =
             sessionStore.getOrCreateWithLock(
                 partyId = partyId,
@@ -58,9 +57,4 @@ class GetCandleBlowStateUseCase(
         result.endedSnapshot?.let(endEventPublisher::publishEndedAfterCommit)
         return result.response
     }
-
-    private data class CandleBlowStateLookupResult(
-        val response: CandleBlowResponse,
-        val endedSnapshot: CandleBlowSnapshot?,
-    )
 }

--- a/src/main/kotlin/com/team2/server/burstgame/application/usecase/RecoverCandleBlowScheduleUseCase.kt
+++ b/src/main/kotlin/com/team2/server/burstgame/application/usecase/RecoverCandleBlowScheduleUseCase.kt
@@ -3,7 +3,7 @@ package com.team2.server.burstgame.application.usecase
 import com.team2.server.burstgame.application.dto.CandleBlowScheduleTarget
 import com.team2.server.burstgame.config.CandleBlowProperties
 import com.team2.server.burstgame.domain.candle.CandleBlowPolicy
-import com.team2.server.party.application.service.PartyService
+import com.team2.server.party.application.usecase.FindRealtimePartiesWithHostEnteredUseCase
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Clock
@@ -11,7 +11,7 @@ import java.time.LocalDateTime
 
 @Service
 class RecoverCandleBlowScheduleUseCase(
-    private val partyService: PartyService,
+    private val findRealtimePartiesWithHostEnteredUseCase: FindRealtimePartiesWithHostEnteredUseCase,
     private val candleBlowProperties: CandleBlowProperties,
     private val clock: Clock,
 ) {
@@ -20,12 +20,11 @@ class RecoverCandleBlowScheduleUseCase(
         val now = LocalDateTime.now(clock)
         val hostEnteredAfter =
             now.minusSeconds(CandleBlowPolicy.START_DELAY_SECONDS + candleBlowProperties.durationSeconds)
-        return partyService
-            .findRealtimePartiesWithHostEnteredAfter(hostEnteredAfter)
+        return findRealtimePartiesWithHostEnteredUseCase(hostEnteredAfter)
             .map { party ->
                 CandleBlowScheduleTarget(
-                    partyId = party.id,
-                    hostEnteredAt = requireNotNull(party.hostEnteredAt),
+                    partyId = party.partyId,
+                    hostEnteredAt = party.hostEnteredAt,
                 )
             }
     }

--- a/src/main/kotlin/com/team2/server/burstgame/application/usecase/RecoverCandleBlowScheduleUseCase.kt
+++ b/src/main/kotlin/com/team2/server/burstgame/application/usecase/RecoverCandleBlowScheduleUseCase.kt
@@ -1,8 +1,9 @@
 package com.team2.server.burstgame.application.usecase
 
 import com.team2.server.burstgame.application.dto.CandleBlowScheduleTarget
+import com.team2.server.burstgame.config.CandleBlowProperties
 import com.team2.server.burstgame.domain.candle.CandleBlowPolicy
-import com.team2.server.party.application.usecase.FindRealtimePartiesWaitingAutomaticEndingUseCase
+import com.team2.server.party.application.service.PartyService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Clock
@@ -10,19 +11,21 @@ import java.time.LocalDateTime
 
 @Service
 class RecoverCandleBlowScheduleUseCase(
-    private val findRealtimePartiesWaitingAutomaticEndingUseCase: FindRealtimePartiesWaitingAutomaticEndingUseCase,
+    private val partyService: PartyService,
+    private val candleBlowProperties: CandleBlowProperties,
     private val clock: Clock,
 ) {
     @Transactional(readOnly = true)
     operator fun invoke(): List<CandleBlowScheduleTarget> {
         val now = LocalDateTime.now(clock)
-        val startedAfter =
-            now.minusSeconds(CandleBlowPolicy.START_DELAY_SECONDS + CandleBlowPolicy.DURATION_SECONDS)
-        return findRealtimePartiesWaitingAutomaticEndingUseCase(startedAfter)
+        val hostEnteredAfter =
+            now.minusSeconds(CandleBlowPolicy.START_DELAY_SECONDS + candleBlowProperties.durationSeconds)
+        return partyService
+            .findRealtimePartiesWithHostEnteredAfter(hostEnteredAfter)
             .map { party ->
                 CandleBlowScheduleTarget(
-                    partyId = party.partyId,
-                    partyStartedAt = party.startedAt,
+                    partyId = party.id,
+                    hostEnteredAt = requireNotNull(party.hostEnteredAt),
                 )
             }
     }

--- a/src/main/kotlin/com/team2/server/burstgame/application/usecase/StartBurstGameUseCase.kt
+++ b/src/main/kotlin/com/team2/server/burstgame/application/usecase/StartBurstGameUseCase.kt
@@ -29,7 +29,7 @@ class StartBurstGameUseCase(
                 startResult =
                     sessionService.start(
                         partyId = partyId,
-                        partyStartedAt = resolved.party.startedAt,
+                        hostEnteredAt = resolved.party.hostEnteredAt,
                         participant = resolved.participant,
                         now = now,
                     ),

--- a/src/main/kotlin/com/team2/server/burstgame/application/usecase/StartScheduledCandleBlowUseCase.kt
+++ b/src/main/kotlin/com/team2/server/burstgame/application/usecase/StartScheduledCandleBlowUseCase.kt
@@ -3,6 +3,7 @@ package com.team2.server.burstgame.application.usecase
 import com.team2.server.burstgame.application.dto.CandleBlowScheduleResult
 import com.team2.server.burstgame.application.port.CandleBlowEventBroadcaster
 import com.team2.server.burstgame.application.port.CandleBlowSessionStore
+import com.team2.server.burstgame.config.CandleBlowProperties
 import com.team2.server.burstgame.domain.candle.CandleBlowSession
 import com.team2.server.burstgame.domain.candle.CandleBlowSnapshot
 import com.team2.server.burstgame.domain.candle.CandleBlowStatus
@@ -15,21 +16,23 @@ import java.time.LocalDateTime
 class StartScheduledCandleBlowUseCase(
     private val sessionStore: CandleBlowSessionStore,
     private val eventBroadcaster: CandleBlowEventBroadcaster,
+    private val candleBlowProperties: CandleBlowProperties,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
     @Transactional
     operator fun invoke(
         partyId: Long,
-        partyStartedAt: LocalDateTime,
+        hostEnteredAt: LocalDateTime,
         now: LocalDateTime,
     ): CandleBlowScheduleResult =
         sessionStore.getOrCreateWithLock(
             partyId = partyId,
             sessionFactory = {
-                CandleBlowSession.fromPartyStartedAt(
+                CandleBlowSession.fromHostEnteredAt(
                     partyId = partyId,
-                    partyStartedAt = partyStartedAt,
+                    hostEnteredAt = hostEnteredAt,
+                    durationSeconds = candleBlowProperties.durationSeconds,
                 )
             },
         ) { session, _ ->

--- a/src/main/kotlin/com/team2/server/burstgame/config/CandleBlowProperties.kt
+++ b/src/main/kotlin/com/team2/server/burstgame/config/CandleBlowProperties.kt
@@ -1,0 +1,12 @@
+package com.team2.server.burstgame.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "candle-blow")
+data class CandleBlowProperties(
+    val durationSeconds: Long = 300L,
+) {
+    init {
+        require(durationSeconds > 0) { "candle-blow.duration-seconds must be positive." }
+    }
+}

--- a/src/main/kotlin/com/team2/server/burstgame/domain/candle/CandleBlowPolicy.kt
+++ b/src/main/kotlin/com/team2/server/burstgame/domain/candle/CandleBlowPolicy.kt
@@ -7,8 +7,6 @@ import java.time.Duration
 object CandleBlowPolicy {
     const val CANDLE_COUNT = 9
     const val START_DELAY_SECONDS = 41L
-    const val DEFAULT_DURATION_SECONDS = 300L
-    const val DURATION_SECONDS = DEFAULT_DURATION_SECONDS
     private const val SESSION_TTL_MINUTES = 10L
     val SESSION_TTL: Duration = Duration.ofMinutes(SESSION_TTL_MINUTES)
 

--- a/src/main/kotlin/com/team2/server/burstgame/domain/candle/CandleBlowPolicy.kt
+++ b/src/main/kotlin/com/team2/server/burstgame/domain/candle/CandleBlowPolicy.kt
@@ -7,7 +7,7 @@ import java.time.Duration
 object CandleBlowPolicy {
     const val CANDLE_COUNT = 9
     const val START_DELAY_SECONDS = 41L
-    const val DURATION_SECONDS = 45L
+    const val DURATION_SECONDS = 300L
     private const val SESSION_TTL_MINUTES = 10L
     val SESSION_TTL: Duration = Duration.ofMinutes(SESSION_TTL_MINUTES)
 

--- a/src/main/kotlin/com/team2/server/burstgame/domain/candle/CandleBlowPolicy.kt
+++ b/src/main/kotlin/com/team2/server/burstgame/domain/candle/CandleBlowPolicy.kt
@@ -7,7 +7,8 @@ import java.time.Duration
 object CandleBlowPolicy {
     const val CANDLE_COUNT = 9
     const val START_DELAY_SECONDS = 41L
-    const val DURATION_SECONDS = 300L
+    const val DEFAULT_DURATION_SECONDS = 300L
+    const val DURATION_SECONDS = DEFAULT_DURATION_SECONDS
     private const val SESSION_TTL_MINUTES = 10L
     val SESSION_TTL: Duration = Duration.ofMinutes(SESSION_TTL_MINUTES)
 

--- a/src/main/kotlin/com/team2/server/burstgame/domain/candle/CandleBlowSession.kt
+++ b/src/main/kotlin/com/team2/server/burstgame/domain/candle/CandleBlowSession.kt
@@ -118,16 +118,6 @@ class CandleBlowSession(
         )
 
     companion object {
-        fun fromPartyStartedAt(
-            partyId: Long,
-            partyStartedAt: LocalDateTime,
-        ): CandleBlowSession =
-            fromHostEnteredAt(
-                partyId = partyId,
-                hostEnteredAt = partyStartedAt,
-                durationSeconds = CandleBlowPolicy.DEFAULT_DURATION_SECONDS,
-            )
-
         fun fromHostEnteredAt(
             partyId: Long,
             hostEnteredAt: LocalDateTime,

--- a/src/main/kotlin/com/team2/server/burstgame/domain/candle/CandleBlowSession.kt
+++ b/src/main/kotlin/com/team2/server/burstgame/domain/candle/CandleBlowSession.kt
@@ -121,12 +121,23 @@ class CandleBlowSession(
         fun fromPartyStartedAt(
             partyId: Long,
             partyStartedAt: LocalDateTime,
+        ): CandleBlowSession =
+            fromHostEnteredAt(
+                partyId = partyId,
+                hostEnteredAt = partyStartedAt,
+                durationSeconds = CandleBlowPolicy.DEFAULT_DURATION_SECONDS,
+            )
+
+        fun fromHostEnteredAt(
+            partyId: Long,
+            hostEnteredAt: LocalDateTime,
+            durationSeconds: Long,
         ): CandleBlowSession {
-            val startedAt = partyStartedAt.plusSeconds(CandleBlowPolicy.START_DELAY_SECONDS)
+            val startedAt = hostEnteredAt.plusSeconds(CandleBlowPolicy.START_DELAY_SECONDS)
             return CandleBlowSession(
                 partyId = partyId,
                 startedAt = startedAt,
-                endsAt = startedAt.plusSeconds(CandleBlowPolicy.DURATION_SECONDS),
+                endsAt = startedAt.plusSeconds(durationSeconds),
             )
         }
     }

--- a/src/main/kotlin/com/team2/server/burstgame/domain/candle/CandleBlowSnapshot.kt
+++ b/src/main/kotlin/com/team2/server/burstgame/domain/candle/CandleBlowSnapshot.kt
@@ -6,4 +6,18 @@ data class CandleBlowSnapshot(
     val candles: List<CandleState>,
     val remainingCount: Int,
     val finishedReason: CandleBlowFinishedReason?,
-)
+) {
+    companion object {
+        fun waiting(partyId: Long): CandleBlowSnapshot =
+            CandleBlowSnapshot(
+                partyId = partyId,
+                status = CandleBlowStatus.WAITING,
+                candles =
+                    (1..CandleBlowPolicy.CANDLE_COUNT).map { candleId ->
+                        CandleState(candleId = candleId, extinguished = false)
+                    },
+                remainingCount = CandleBlowPolicy.CANDLE_COUNT,
+                finishedReason = null,
+            )
+    }
+}

--- a/src/main/kotlin/com/team2/server/burstgame/infrastructure/candle/InMemoryCandleBlowStatusReader.kt
+++ b/src/main/kotlin/com/team2/server/burstgame/infrastructure/candle/InMemoryCandleBlowStatusReader.kt
@@ -2,6 +2,7 @@ package com.team2.server.burstgame.infrastructure.candle
 
 import com.team2.server.burstgame.application.port.CandleBlowSessionStore
 import com.team2.server.burstgame.application.port.CandleBlowStatusReader
+import com.team2.server.burstgame.config.CandleBlowProperties
 import com.team2.server.burstgame.domain.candle.CandleBlowSession
 import org.springframework.stereotype.Component
 import java.time.LocalDateTime
@@ -9,21 +10,25 @@ import java.time.LocalDateTime
 @Component
 class InMemoryCandleBlowStatusReader(
     private val sessionStore: CandleBlowSessionStore,
+    private val candleBlowProperties: CandleBlowProperties,
 ) : CandleBlowStatusReader {
     override fun isCandleBlowFinished(
         partyId: Long,
-        partyStartedAt: LocalDateTime,
+        hostEnteredAt: LocalDateTime?,
         now: LocalDateTime,
-    ): Boolean =
-        sessionStore.getOrCreateWithLock(
+    ): Boolean {
+        if (hostEnteredAt == null) return false
+        return sessionStore.getOrCreateWithLock(
             partyId = partyId,
             sessionFactory = {
-                CandleBlowSession.fromPartyStartedAt(
+                CandleBlowSession.fromHostEnteredAt(
                     partyId = partyId,
-                    partyStartedAt = partyStartedAt,
+                    hostEnteredAt = hostEnteredAt,
+                    durationSeconds = candleBlowProperties.durationSeconds,
                 )
             },
         ) { session, _ ->
             session.snapshot(now).finishedReason != null
         }
+    }
 }

--- a/src/main/kotlin/com/team2/server/burstgame/infrastructure/scheduler/ScheduledCandleBlowScheduler.kt
+++ b/src/main/kotlin/com/team2/server/burstgame/infrastructure/scheduler/ScheduledCandleBlowScheduler.kt
@@ -4,9 +4,10 @@ import com.team2.server.burstgame.application.port.CandleBlowScheduler
 import com.team2.server.burstgame.application.usecase.EndScheduledCandleBlowUseCase
 import com.team2.server.burstgame.application.usecase.RecoverCandleBlowScheduleUseCase
 import com.team2.server.burstgame.application.usecase.StartScheduledCandleBlowUseCase
+import com.team2.server.burstgame.config.CandleBlowProperties
 import com.team2.server.burstgame.domain.candle.CandleBlowPolicy
 import com.team2.server.burstgame.domain.candle.CandleBlowStatus
-import com.team2.server.party.application.event.RealtimePartyCreatedEvent
+import com.team2.server.party.application.event.RealtimePartyHostEnteredEvent
 import jakarta.annotation.PostConstruct
 import jakarta.annotation.PreDestroy
 import org.slf4j.LoggerFactory
@@ -28,6 +29,7 @@ class ScheduledCandleBlowScheduler(
     private val recoverCandleBlowScheduleUseCase: RecoverCandleBlowScheduleUseCase,
     private val startScheduledCandleBlowUseCase: StartScheduledCandleBlowUseCase,
     private val endScheduledCandleBlowUseCase: EndScheduledCandleBlowUseCase,
+    private val candleBlowProperties: CandleBlowProperties,
 ) : CandleBlowScheduler {
     private val log = LoggerFactory.getLogger(javaClass)
     private val executor =
@@ -60,7 +62,7 @@ class ScheduledCandleBlowScheduler(
 
     private fun recoverSchedulesOnce() {
         recoverCandleBlowScheduleUseCase().forEach { target ->
-            scheduleParty(target.partyId, target.partyStartedAt)
+            scheduleParty(target.partyId, target.hostEnteredAt)
         }
     }
 
@@ -74,21 +76,21 @@ class ScheduledCandleBlowScheduler(
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    fun onRealtimePartyCreated(event: RealtimePartyCreatedEvent) {
-        scheduleParty(event.partyId, event.startedAt)
+    fun onRealtimePartyHostEntered(event: RealtimePartyHostEnteredEvent) {
+        scheduleParty(event.partyId, event.hostEnteredAt)
     }
 
     fun scheduleParty(
         partyId: Long,
-        partyStartedAt: LocalDateTime,
+        hostEnteredAt: LocalDateTime,
     ) {
-        val startsAt = partyStartedAt.plusSeconds(CandleBlowPolicy.START_DELAY_SECONDS)
-        val endsAt = startsAt.plusSeconds(CandleBlowPolicy.DURATION_SECONDS)
+        val startsAt = hostEnteredAt.plusSeconds(CandleBlowPolicy.START_DELAY_SECONDS)
+        val endsAt = startsAt.plusSeconds(candleBlowProperties.durationSeconds)
         scheduleStart(partyId, startsAt) { scheduledPartyId ->
             val snapshot =
                 startScheduledCandleBlowUseCase(
                     partyId = scheduledPartyId,
-                    partyStartedAt = partyStartedAt,
+                    hostEnteredAt = hostEnteredAt,
                     now = LocalDateTime.now(clock),
                 )
             if (snapshot.status != CandleBlowStatus.FINISHED) {

--- a/src/main/kotlin/com/team2/server/chat/application/port/RealtimePartyEntryProfilePort.kt
+++ b/src/main/kotlin/com/team2/server/chat/application/port/RealtimePartyEntryProfilePort.kt
@@ -1,0 +1,21 @@
+package com.team2.server.chat.application.port
+
+import com.team2.server.chat.dto.EnterRealtimePartyRequest
+import com.team2.server.party.domain.entity.RealtimeParty
+import java.time.LocalDateTime
+
+interface RealtimePartyEntryProfilePort {
+    fun resolve(
+        party: RealtimeParty,
+        userId: Long?,
+        request: EnterRealtimePartyRequest,
+        now: LocalDateTime,
+    ): RealtimePartyEntryProfileResult
+}
+
+data class RealtimePartyEntryProfileResult(
+    val participantToken: String,
+    val isCelebrant: Boolean,
+    val nickname: String,
+    val characterId: Long?,
+)

--- a/src/main/kotlin/com/team2/server/chat/application/support/RealtimePartyEntryProfileResolver.kt
+++ b/src/main/kotlin/com/team2/server/chat/application/support/RealtimePartyEntryProfileResolver.kt
@@ -1,0 +1,26 @@
+package com.team2.server.chat.application.support
+
+import com.team2.server.chat.application.port.RealtimePartyEntryProfilePort
+import com.team2.server.chat.application.port.RealtimePartyEntryProfileResult
+import com.team2.server.chat.dto.EnterRealtimePartyRequest
+import com.team2.server.party.domain.entity.RealtimeParty
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+
+@Component
+class RealtimePartyEntryProfileResolver(
+    private val entryProfilePort: RealtimePartyEntryProfilePort,
+) {
+    fun resolve(
+        party: RealtimeParty,
+        userId: Long?,
+        request: EnterRealtimePartyRequest,
+        now: LocalDateTime,
+    ): RealtimePartyEntryProfileResult =
+        entryProfilePort.resolve(
+            party = party,
+            userId = userId,
+            request = request,
+            now = now,
+        )
+}

--- a/src/main/kotlin/com/team2/server/chat/infrastructure/party/PartyRealtimePartyEntryProfileAdapter.kt
+++ b/src/main/kotlin/com/team2/server/chat/infrastructure/party/PartyRealtimePartyEntryProfileAdapter.kt
@@ -1,5 +1,7 @@
-package com.team2.server.chat.usecase
+package com.team2.server.chat.infrastructure.party
 
+import com.team2.server.chat.application.port.RealtimePartyEntryProfilePort
+import com.team2.server.chat.application.port.RealtimePartyEntryProfileResult
 import com.team2.server.chat.dto.EnterRealtimePartyRequest
 import com.team2.server.common.exception.BusinessException
 import com.team2.server.common.exception.ErrorCode
@@ -15,41 +17,25 @@ import org.springframework.stereotype.Component
 import java.time.LocalDateTime
 
 @Component
-class RealtimePartyEntryProfileResolver(
+class PartyRealtimePartyEntryProfileAdapter(
     private val participantService: ParticipantService,
     private val realtimeParticipantProfileService: RealtimeParticipantProfileService,
     private val characterService: CharacterService,
-) {
-    data class Result(
-        val profile: RealtimeParticipantProfile,
-        val character: Character,
-    )
-
-    fun resolve(
+) : RealtimePartyEntryProfilePort {
+    override fun resolve(
         party: RealtimeParty,
         userId: Long?,
         request: EnterRealtimePartyRequest,
         now: LocalDateTime,
-    ): Result {
+    ): RealtimePartyEntryProfileResult {
         val character = characterService.requireCharacter(request.characterId)
         val profile =
             if (request.participantToken != null) {
-                reenterByParticipantToken(
-                    party = party,
-                    participantToken = request.participantToken,
-                    nickname = request.nickname,
-                    character = character,
-                    now = now,
-                )
+                reenterByParticipantToken(party, request.participantToken, request.nickname, character, now)
             } else {
-                enterFirstTime(
-                    party = party,
-                    userId = userId,
-                    nickname = request.nickname,
-                    character = character,
-                )
+                enterFirstTime(party, userId, request.nickname, character)
             }
-        return Result(profile = profile, character = character)
+        return profile.toResult()
     }
 
     private fun enterFirstTime(
@@ -75,14 +61,8 @@ class RealtimePartyEntryProfileResolver(
         character: Character,
         now: LocalDateTime,
     ): RealtimeParticipantProfile {
-        val profile =
-            realtimeParticipantProfileService.requireByParticipantToken(participantToken, party.id)
-        val reconnectableStatuses =
-            listOf(
-                RealtimePartyStatus.LIVE_OPEN,
-                RealtimePartyStatus.LIVE_ENDING,
-            )
-        if (party.status(now) !in reconnectableStatuses) {
+        val profile = realtimeParticipantProfileService.requireByParticipantToken(participantToken, party.id)
+        if (party.status(now) !in RECONNECTABLE_STATUSES) {
             throw BusinessException(ErrorCode.CHAT_NOT_ACTIVE)
         }
         if (profile.participant.isCelebrant && profile.nickname != nickname) {
@@ -91,5 +71,21 @@ class RealtimePartyEntryProfileResolver(
         profile.nickname = nickname
         profile.character = character
         return profile
+    }
+
+    private fun RealtimeParticipantProfile.toResult(): RealtimePartyEntryProfileResult =
+        RealtimePartyEntryProfileResult(
+            participantToken = participantToken,
+            isCelebrant = participant.isCelebrant,
+            nickname = nickname,
+            characterId = character?.id,
+        )
+
+    private companion object {
+        val RECONNECTABLE_STATUSES: Set<RealtimePartyStatus> =
+            setOf(
+                RealtimePartyStatus.LIVE_OPEN,
+                RealtimePartyStatus.LIVE_ENDING,
+            )
     }
 }

--- a/src/main/kotlin/com/team2/server/chat/usecase/EnterRealtimePartyUseCase.kt
+++ b/src/main/kotlin/com/team2/server/chat/usecase/EnterRealtimePartyUseCase.kt
@@ -4,20 +4,14 @@ import com.team2.server.chat.dto.EnterRealtimePartyRequest
 import com.team2.server.common.exception.BusinessException
 import com.team2.server.common.exception.ErrorCode
 import com.team2.server.party.application.dto.RealtimePartyStateResult
-import com.team2.server.party.application.event.RealtimePartyHostEnteredEvent
-import com.team2.server.party.application.service.CharacterService
-import com.team2.server.party.application.service.ParticipantService
 import com.team2.server.party.application.service.PartyInviteService
-import com.team2.server.party.application.service.PartyService
-import com.team2.server.party.application.service.RealtimeParticipantProfileService
-import com.team2.server.party.domain.entity.Character
+import com.team2.server.party.application.usecase.MarkRealtimePartyHostEnteredUseCase
 import com.team2.server.party.domain.entity.Party
 import com.team2.server.party.domain.entity.PartyOption
 import com.team2.server.party.domain.entity.RealtimeParticipantProfile
 import com.team2.server.party.domain.entity.RealtimeParty
 import com.team2.server.party.domain.entity.RealtimePartyStatus
 import org.hibernate.Hibernate
-import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Clock
@@ -26,11 +20,8 @@ import java.time.LocalDateTime
 @Service
 class EnterRealtimePartyUseCase(
     private val partyInviteService: PartyInviteService,
-    private val participantService: ParticipantService,
-    private val partyService: PartyService,
-    private val realtimeParticipantProfileService: RealtimeParticipantProfileService,
-    private val characterService: CharacterService,
-    private val applicationEventPublisher: ApplicationEventPublisher,
+    private val profileResolver: RealtimePartyEntryProfileResolver,
+    private val markRealtimePartyHostEnteredUseCase: MarkRealtimePartyHostEnteredUseCase,
     private val clock: Clock,
 ) {
     data class EnterResult(
@@ -57,27 +48,8 @@ class EnterRealtimePartyUseCase(
             validateNewEnterable(realtimeParty, now)
         }
 
-        val character = characterService.requireCharacter(request.characterId)
-
-        val profile =
-            if (reentry) {
-                reenterByParticipantToken(
-                    party = realtimeParty,
-                    participantToken = requireNotNull(request.participantToken),
-                    nickname = request.nickname,
-                    character = character,
-                    now = now,
-                )
-            } else {
-                val user = participantService.resolveUser(userId)
-                val participant = participantService.joinAnonymousOrMember(invite.party, user)
-                realtimeParticipantProfileService.upsert(
-                    participant = participant,
-                    nickname = request.nickname,
-                    character = character,
-                    isHostNicknameLocked = participant.isCelebrant,
-                )
-            }
+        val entryProfile = profileResolver.resolve(realtimeParty, userId, request, now)
+        val profile = entryProfile.profile
         markHostEnteredIfNeeded(realtimeParty, profile, now)
 
         return EnterResult(
@@ -86,7 +58,7 @@ class EnterRealtimePartyUseCase(
             startedAt = invite.party.startedAt,
             isCelebrant = profile.participant.isCelebrant,
             nickname = profile.nickname,
-            characterId = character.id,
+            characterId = entryProfile.character.id,
             partyState = RealtimePartyStateResult.from(realtimeParty, now),
         )
     }
@@ -97,14 +69,7 @@ class EnterRealtimePartyUseCase(
         now: LocalDateTime,
     ) {
         if (!profile.participant.isCelebrant) return
-        if (!partyService.markHostEnteredIfAbsent(party.id, now)) return
-        party.hostEnteredAt = now
-        applicationEventPublisher.publishEvent(
-            RealtimePartyHostEnteredEvent(
-                partyId = party.id,
-                hostEnteredAt = now,
-            ),
-        )
+        party.hostEnteredAt = markRealtimePartyHostEnteredUseCase(party.id, now) ?: return
     }
 
     private fun validateInvite(party: Party): RealtimeParty {
@@ -122,31 +87,4 @@ class EnterRealtimePartyUseCase(
             throw BusinessException(ErrorCode.CHAT_NOT_ACTIVE)
         }
     }
-
-    private fun reenterByParticipantToken(
-        party: RealtimeParty,
-        participantToken: String,
-        nickname: String,
-        character: Character,
-        now: LocalDateTime,
-    ): RealtimeParticipantProfile {
-        val profile =
-            realtimeParticipantProfileService.requireByParticipantToken(participantToken, party.id)
-        val reconnectableStatuses =
-            listOf(
-                RealtimePartyStatus.LIVE_OPEN,
-                RealtimePartyStatus.LIVE_ENDING,
-            )
-        if (party.status(now) !in reconnectableStatuses) {
-            throwChatNotActive()
-        }
-        if (profile.participant.isCelebrant && profile.nickname != nickname) {
-            throw BusinessException(ErrorCode.PARTY_HOST_NICKNAME_NOT_EDITABLE)
-        }
-        profile.nickname = nickname
-        profile.character = character
-        return profile
-    }
-
-    private fun throwChatNotActive(): Nothing = throw BusinessException(ErrorCode.CHAT_NOT_ACTIVE)
 }

--- a/src/main/kotlin/com/team2/server/chat/usecase/EnterRealtimePartyUseCase.kt
+++ b/src/main/kotlin/com/team2/server/chat/usecase/EnterRealtimePartyUseCase.kt
@@ -1,5 +1,7 @@
 package com.team2.server.chat.usecase
 
+import com.team2.server.chat.application.port.RealtimePartyEntryProfileResult
+import com.team2.server.chat.application.support.RealtimePartyEntryProfileResolver
 import com.team2.server.chat.dto.EnterRealtimePartyRequest
 import com.team2.server.common.exception.BusinessException
 import com.team2.server.common.exception.ErrorCode
@@ -8,7 +10,6 @@ import com.team2.server.party.application.service.PartyInviteService
 import com.team2.server.party.application.usecase.MarkRealtimePartyHostEnteredUseCase
 import com.team2.server.party.domain.entity.Party
 import com.team2.server.party.domain.entity.PartyOption
-import com.team2.server.party.domain.entity.RealtimeParticipantProfile
 import com.team2.server.party.domain.entity.RealtimeParty
 import com.team2.server.party.domain.entity.RealtimePartyStatus
 import org.hibernate.Hibernate
@@ -49,26 +50,25 @@ class EnterRealtimePartyUseCase(
         }
 
         val entryProfile = profileResolver.resolve(realtimeParty, userId, request, now)
-        val profile = entryProfile.profile
-        markHostEnteredIfNeeded(realtimeParty, profile, now)
+        markHostEnteredIfNeeded(realtimeParty, entryProfile, now)
 
         return EnterResult(
-            participantToken = profile.participantToken,
+            participantToken = entryProfile.participantToken,
             partyId = invite.party.id,
             startedAt = invite.party.startedAt,
-            isCelebrant = profile.participant.isCelebrant,
-            nickname = profile.nickname,
-            characterId = entryProfile.character.id,
+            isCelebrant = entryProfile.isCelebrant,
+            nickname = entryProfile.nickname,
+            characterId = entryProfile.characterId,
             partyState = RealtimePartyStateResult.from(realtimeParty, now),
         )
     }
 
     private fun markHostEnteredIfNeeded(
         party: RealtimeParty,
-        profile: RealtimeParticipantProfile,
+        entryProfile: RealtimePartyEntryProfileResult,
         now: LocalDateTime,
     ) {
-        if (!profile.participant.isCelebrant) return
+        if (!entryProfile.isCelebrant) return
         party.hostEnteredAt = markRealtimePartyHostEnteredUseCase(party.id, now) ?: return
     }
 

--- a/src/main/kotlin/com/team2/server/chat/usecase/EnterRealtimePartyUseCase.kt
+++ b/src/main/kotlin/com/team2/server/chat/usecase/EnterRealtimePartyUseCase.kt
@@ -4,9 +4,11 @@ import com.team2.server.chat.dto.EnterRealtimePartyRequest
 import com.team2.server.common.exception.BusinessException
 import com.team2.server.common.exception.ErrorCode
 import com.team2.server.party.application.dto.RealtimePartyStateResult
+import com.team2.server.party.application.event.RealtimePartyHostEnteredEvent
 import com.team2.server.party.application.service.CharacterService
 import com.team2.server.party.application.service.ParticipantService
 import com.team2.server.party.application.service.PartyInviteService
+import com.team2.server.party.application.service.PartyService
 import com.team2.server.party.application.service.RealtimeParticipantProfileService
 import com.team2.server.party.domain.entity.Character
 import com.team2.server.party.domain.entity.Party
@@ -15,6 +17,7 @@ import com.team2.server.party.domain.entity.RealtimeParticipantProfile
 import com.team2.server.party.domain.entity.RealtimeParty
 import com.team2.server.party.domain.entity.RealtimePartyStatus
 import org.hibernate.Hibernate
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Clock
@@ -24,8 +27,10 @@ import java.time.LocalDateTime
 class EnterRealtimePartyUseCase(
     private val partyInviteService: PartyInviteService,
     private val participantService: ParticipantService,
+    private val partyService: PartyService,
     private val realtimeParticipantProfileService: RealtimeParticipantProfileService,
     private val characterService: CharacterService,
+    private val applicationEventPublisher: ApplicationEventPublisher,
     private val clock: Clock,
 ) {
     data class EnterResult(
@@ -73,6 +78,7 @@ class EnterRealtimePartyUseCase(
                     isHostNicknameLocked = participant.isCelebrant,
                 )
             }
+        markHostEnteredIfNeeded(realtimeParty, profile, now)
 
         return EnterResult(
             participantToken = profile.participantToken,
@@ -82,6 +88,22 @@ class EnterRealtimePartyUseCase(
             nickname = profile.nickname,
             characterId = character.id,
             partyState = RealtimePartyStateResult.from(realtimeParty, now),
+        )
+    }
+
+    private fun markHostEnteredIfNeeded(
+        party: RealtimeParty,
+        profile: RealtimeParticipantProfile,
+        now: LocalDateTime,
+    ) {
+        if (!profile.participant.isCelebrant) return
+        if (!partyService.markHostEnteredIfAbsent(party.id, now)) return
+        party.hostEnteredAt = now
+        applicationEventPublisher.publishEvent(
+            RealtimePartyHostEnteredEvent(
+                partyId = party.id,
+                hostEnteredAt = now,
+            ),
         )
     }
 

--- a/src/main/kotlin/com/team2/server/chat/usecase/RealtimePartyEntryProfileResolver.kt
+++ b/src/main/kotlin/com/team2/server/chat/usecase/RealtimePartyEntryProfileResolver.kt
@@ -1,0 +1,95 @@
+package com.team2.server.chat.usecase
+
+import com.team2.server.chat.dto.EnterRealtimePartyRequest
+import com.team2.server.common.exception.BusinessException
+import com.team2.server.common.exception.ErrorCode
+import com.team2.server.party.application.service.CharacterService
+import com.team2.server.party.application.service.ParticipantService
+import com.team2.server.party.application.service.RealtimeParticipantProfileService
+import com.team2.server.party.domain.entity.Character
+import com.team2.server.party.domain.entity.Party
+import com.team2.server.party.domain.entity.RealtimeParticipantProfile
+import com.team2.server.party.domain.entity.RealtimeParty
+import com.team2.server.party.domain.entity.RealtimePartyStatus
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+
+@Component
+class RealtimePartyEntryProfileResolver(
+    private val participantService: ParticipantService,
+    private val realtimeParticipantProfileService: RealtimeParticipantProfileService,
+    private val characterService: CharacterService,
+) {
+    data class Result(
+        val profile: RealtimeParticipantProfile,
+        val character: Character,
+    )
+
+    fun resolve(
+        party: RealtimeParty,
+        userId: Long?,
+        request: EnterRealtimePartyRequest,
+        now: LocalDateTime,
+    ): Result {
+        val character = characterService.requireCharacter(request.characterId)
+        val profile =
+            if (request.participantToken != null) {
+                reenterByParticipantToken(
+                    party = party,
+                    participantToken = request.participantToken,
+                    nickname = request.nickname,
+                    character = character,
+                    now = now,
+                )
+            } else {
+                enterFirstTime(
+                    party = party,
+                    userId = userId,
+                    nickname = request.nickname,
+                    character = character,
+                )
+            }
+        return Result(profile = profile, character = character)
+    }
+
+    private fun enterFirstTime(
+        party: Party,
+        userId: Long?,
+        nickname: String,
+        character: Character,
+    ): RealtimeParticipantProfile {
+        val user = participantService.resolveUser(userId)
+        val participant = participantService.joinAnonymousOrMember(party, user)
+        return realtimeParticipantProfileService.upsert(
+            participant = participant,
+            nickname = nickname,
+            character = character,
+            isHostNicknameLocked = participant.isCelebrant,
+        )
+    }
+
+    private fun reenterByParticipantToken(
+        party: RealtimeParty,
+        participantToken: String,
+        nickname: String,
+        character: Character,
+        now: LocalDateTime,
+    ): RealtimeParticipantProfile {
+        val profile =
+            realtimeParticipantProfileService.requireByParticipantToken(participantToken, party.id)
+        val reconnectableStatuses =
+            listOf(
+                RealtimePartyStatus.LIVE_OPEN,
+                RealtimePartyStatus.LIVE_ENDING,
+            )
+        if (party.status(now) !in reconnectableStatuses) {
+            throw BusinessException(ErrorCode.CHAT_NOT_ACTIVE)
+        }
+        if (profile.participant.isCelebrant && profile.nickname != nickname) {
+            throw BusinessException(ErrorCode.PARTY_HOST_NICKNAME_NOT_EDITABLE)
+        }
+        profile.nickname = nickname
+        profile.character = character
+        return profile
+    }
+}

--- a/src/main/kotlin/com/team2/server/party/application/dto/RealtimePartyHostEnteredScheduleData.kt
+++ b/src/main/kotlin/com/team2/server/party/application/dto/RealtimePartyHostEnteredScheduleData.kt
@@ -1,0 +1,17 @@
+package com.team2.server.party.application.dto
+
+import com.team2.server.party.domain.entity.RealtimeParty
+import java.time.LocalDateTime
+
+data class RealtimePartyHostEnteredScheduleData(
+    val partyId: Long,
+    val hostEnteredAt: LocalDateTime,
+) {
+    companion object {
+        fun from(party: RealtimeParty): RealtimePartyHostEnteredScheduleData =
+            RealtimePartyHostEnteredScheduleData(
+                partyId = party.id,
+                hostEnteredAt = requireNotNull(party.hostEnteredAt),
+            )
+    }
+}

--- a/src/main/kotlin/com/team2/server/party/application/event/RealtimePartyEvents.kt
+++ b/src/main/kotlin/com/team2/server/party/application/event/RealtimePartyEvents.kt
@@ -7,6 +7,11 @@ data class RealtimePartyCreatedEvent(
     val startedAt: LocalDateTime,
 )
 
+data class RealtimePartyHostEnteredEvent(
+    val partyId: Long,
+    val hostEnteredAt: LocalDateTime,
+)
+
 data class RealtimePartyEndingStartedEvent(
     val partyId: Long,
     val endingStartedAt: LocalDateTime,

--- a/src/main/kotlin/com/team2/server/party/application/event/RealtimePartyHostEnteredEventPublisher.kt
+++ b/src/main/kotlin/com/team2/server/party/application/event/RealtimePartyHostEnteredEventPublisher.kt
@@ -1,0 +1,22 @@
+package com.team2.server.party.application.event
+
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+
+@Component
+class RealtimePartyHostEnteredEventPublisher(
+    private val applicationEventPublisher: ApplicationEventPublisher,
+) {
+    fun publish(
+        partyId: Long,
+        hostEnteredAt: LocalDateTime,
+    ) {
+        applicationEventPublisher.publishEvent(
+            RealtimePartyHostEnteredEvent(
+                partyId = partyId,
+                hostEnteredAt = hostEnteredAt,
+            ),
+        )
+    }
+}

--- a/src/main/kotlin/com/team2/server/party/application/service/PartyService.kt
+++ b/src/main/kotlin/com/team2/server/party/application/service/PartyService.kt
@@ -138,6 +138,14 @@ class PartyService(
     fun findRealtimePartiesWaitingAutomaticEnding(startedAfter: LocalDateTime): List<RealtimeParty> =
         partyRepository.findRealtimePartiesWaitingAutomaticEnding(startedAfter)
 
+    fun markHostEnteredIfAbsent(
+        partyId: Long,
+        hostEnteredAt: LocalDateTime,
+    ): Boolean = partyRepository.markHostEnteredIfAbsent(partyId, hostEnteredAt) == 1
+
+    fun findRealtimePartiesWithHostEnteredAfter(hostEnteredAfter: LocalDateTime): List<RealtimeParty> =
+        partyRepository.findRealtimePartiesWithHostEnteredAfter(hostEnteredAfter)
+
     private fun requireRealtimePartyForChat(party: Party): RealtimeParty {
         if (party.partyOption != PartyOption.REALTIME) {
             throw BusinessException(ErrorCode.CHAT_NOT_SUPPORTED)

--- a/src/main/kotlin/com/team2/server/party/application/usecase/FindRealtimePartiesWithHostEnteredUseCase.kt
+++ b/src/main/kotlin/com/team2/server/party/application/usecase/FindRealtimePartiesWithHostEnteredUseCase.kt
@@ -1,0 +1,18 @@
+package com.team2.server.party.application.usecase
+
+import com.team2.server.party.application.dto.RealtimePartyHostEnteredScheduleData
+import com.team2.server.party.application.service.PartyService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service
+class FindRealtimePartiesWithHostEnteredUseCase(
+    private val partyService: PartyService,
+) {
+    @Transactional(readOnly = true)
+    operator fun invoke(hostEnteredAfter: LocalDateTime): List<RealtimePartyHostEnteredScheduleData> =
+        partyService
+            .findRealtimePartiesWithHostEnteredAfter(hostEnteredAfter)
+            .map { RealtimePartyHostEnteredScheduleData.from(it) }
+}

--- a/src/main/kotlin/com/team2/server/party/application/usecase/MarkRealtimePartyHostEnteredUseCase.kt
+++ b/src/main/kotlin/com/team2/server/party/application/usecase/MarkRealtimePartyHostEnteredUseCase.kt
@@ -1,0 +1,23 @@
+package com.team2.server.party.application.usecase
+
+import com.team2.server.party.application.event.RealtimePartyHostEnteredEventPublisher
+import com.team2.server.party.application.service.PartyService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service
+class MarkRealtimePartyHostEnteredUseCase(
+    private val partyService: PartyService,
+    private val eventPublisher: RealtimePartyHostEnteredEventPublisher,
+) {
+    @Transactional
+    operator fun invoke(
+        partyId: Long,
+        hostEnteredAt: LocalDateTime,
+    ): LocalDateTime? {
+        if (!partyService.markHostEnteredIfAbsent(partyId, hostEnteredAt)) return null
+        eventPublisher.publish(partyId = partyId, hostEnteredAt = hostEnteredAt)
+        return hostEnteredAt
+    }
+}

--- a/src/main/kotlin/com/team2/server/party/domain/entity/RealtimeParty.kt
+++ b/src/main/kotlin/com/team2/server/party/domain/entity/RealtimeParty.kt
@@ -17,6 +17,8 @@ class RealtimeParty(
     startedAt: LocalDateTime,
     @Column(name = "live_ending_started_at")
     var liveEndingStartedAt: LocalDateTime? = null,
+    @Column(name = "host_entered_at")
+    var hostEnteredAt: LocalDateTime? = null,
 ) : Party(ownerId, name, celebrantNickname, startedAt, purpose) {
     override val partyOption: PartyOption get() = PartyOption.REALTIME
 

--- a/src/main/kotlin/com/team2/server/party/infrastructure/persistence/PartyRepository.kt
+++ b/src/main/kotlin/com/team2/server/party/infrastructure/persistence/PartyRepository.kt
@@ -30,7 +30,7 @@ interface PartyRepository : JpaRepository<Party, Long> {
         endingStartedAt: LocalDateTime,
     ): Int
 
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Modifying(flushAutomatically = true)
     @Query(
         """
         UPDATE RealtimeParty party

--- a/src/main/kotlin/com/team2/server/party/infrastructure/persistence/PartyRepository.kt
+++ b/src/main/kotlin/com/team2/server/party/infrastructure/persistence/PartyRepository.kt
@@ -32,6 +32,20 @@ interface PartyRepository : JpaRepository<Party, Long> {
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(
+        """
+        UPDATE RealtimeParty party
+        SET party.hostEnteredAt = :hostEnteredAt
+        WHERE party.id = :partyId
+          AND party.hostEnteredAt IS NULL
+        """,
+    )
+    fun markHostEnteredIfAbsent(
+        partyId: Long,
+        hostEnteredAt: LocalDateTime,
+    ): Int
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
         value =
             """
             UPDATE realtime_party realtime_party
@@ -61,6 +75,17 @@ interface PartyRepository : JpaRepository<Party, Long> {
         """,
     )
     fun findRealtimePartiesWaitingAutomaticEnding(startedAfter: LocalDateTime): List<RealtimeParty>
+
+    @Query(
+        """
+        SELECT party
+        FROM RealtimeParty party
+        WHERE party.liveEndingStartedAt IS NULL
+          AND party.hostEnteredAt IS NOT NULL
+          AND party.hostEnteredAt > :hostEnteredAfter
+        """,
+    )
+    fun findRealtimePartiesWithHostEnteredAfter(hostEnteredAfter: LocalDateTime): List<RealtimeParty>
 
     @Query(
         """

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -28,3 +28,6 @@ loki:
 
 app:
   env: prod
+
+candle-blow:
+  duration-seconds: 45

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,3 +38,6 @@ spring:
 # 배포 전 환경별 yml(application-prod.yml 등)에서 실제 운영 URL로 반드시 override
 support:
   chat-url: "https://open.kakao.com/o/placeholder"
+
+candle-blow:
+  duration-seconds: 300

--- a/src/main/resources/db/migration/V5__add_realtime_party_host_entered_at.sql
+++ b/src/main/resources/db/migration/V5__add_realtime_party_host_entered_at.sql
@@ -1,0 +1,2 @@
+ALTER TABLE realtime_party
+    ADD COLUMN host_entered_at DATETIME(6) NULL;

--- a/src/test/kotlin/com/team2/server/burstgame/api/BurstGameControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/burstgame/api/BurstGameControllerTest.kt
@@ -406,6 +406,7 @@ class BurstGameControllerTest
                         name = "실시간 파티",
                         celebrantNickname = "주인공",
                         startedAt = startedAt,
+                        hostEnteredAt = startedAt,
                     ),
                 )
             val participant = participantRepository.saveAndFlush(Participant(party = party, isCelebrant = true))
@@ -435,6 +436,7 @@ class BurstGameControllerTest
                         name = "실시간 파티",
                         celebrantNickname = "주인공",
                         startedAt = LocalDateTime.now().minusMinutes(1),
+                        hostEnteredAt = LocalDateTime.now().minusMinutes(1),
                     ),
                 )
             return listOf(

--- a/src/test/kotlin/com/team2/server/burstgame/api/BurstGameControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/burstgame/api/BurstGameControllerTest.kt
@@ -148,7 +148,13 @@ class BurstGameControllerTest
 
         @Test
         fun `종료 시각이 지난 촛불끄기 조회는 TIMEOUT 종료 상태를 반환한다`() {
-            val fixture = saveRealtimeParticipant(startedAt = LocalDateTime.now().minusSeconds(90))
+            val fixture =
+                saveRealtimeParticipant(
+                    startedAt =
+                        LocalDateTime
+                            .now()
+                            .minusSeconds(CandleBlowPolicy.START_DELAY_SECONDS + CandleBlowPolicy.DURATION_SECONDS + 5),
+                )
 
             mockMvc
                 .get("/api/v1/parties/${fixture.partyId}/candle-blow") {
@@ -195,7 +201,13 @@ class BurstGameControllerTest
 
         @Test
         fun `촛불 세션이 없어도 촛불 종료 시각이 지난 파티는 박터뜨리기 시작 성공`() {
-            val fixture = saveRealtimeParticipant(startedAt = LocalDateTime.now().minusSeconds(90))
+            val fixture =
+                saveRealtimeParticipant(
+                    startedAt =
+                        LocalDateTime
+                            .now()
+                            .minusSeconds(CandleBlowPolicy.START_DELAY_SECONDS + CandleBlowPolicy.DURATION_SECONDS + 5),
+                )
 
             mockMvc
                 .post("/api/v1/parties/${fixture.partyId}/burst-game/start") {

--- a/src/test/kotlin/com/team2/server/burstgame/api/BurstGameControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/burstgame/api/BurstGameControllerTest.kt
@@ -39,6 +39,8 @@ class BurstGameControllerTest
         private val candleBlowSessionStore: CandleBlowSessionStore,
         private val databaseCleanup: DatabaseCleanup,
     ) {
+        private val candleBlowDurationSeconds = 300L
+
         @BeforeEach
         fun setUp() {
             databaseCleanup.execute()
@@ -153,7 +155,7 @@ class BurstGameControllerTest
                     startedAt =
                         LocalDateTime
                             .now()
-                            .minusSeconds(CandleBlowPolicy.START_DELAY_SECONDS + CandleBlowPolicy.DURATION_SECONDS + 5),
+                            .minusSeconds(CandleBlowPolicy.START_DELAY_SECONDS + candleBlowDurationSeconds + 5),
                 )
 
             mockMvc
@@ -206,7 +208,7 @@ class BurstGameControllerTest
                     startedAt =
                         LocalDateTime
                             .now()
-                            .minusSeconds(CandleBlowPolicy.START_DELAY_SECONDS + CandleBlowPolicy.DURATION_SECONDS + 5),
+                            .minusSeconds(CandleBlowPolicy.START_DELAY_SECONDS + candleBlowDurationSeconds + 5),
                 )
 
             mockMvc

--- a/src/test/kotlin/com/team2/server/burstgame/application/service/BurstGameSessionServiceTest.kt
+++ b/src/test/kotlin/com/team2/server/burstgame/application/service/BurstGameSessionServiceTest.kt
@@ -20,7 +20,7 @@ import kotlin.test.assertTrue
 
 class BurstGameSessionServiceTest {
     private val startedAt = LocalDateTime.of(2026, 5, 14, 20, 10)
-    private val partyStartedAt = startedAt.minusSeconds(80)
+    private val hostEnteredAt = startedAt.minusSeconds(80)
     private val candleBlowStatusReader = FakeCandleBlowStatusReader()
     private val sessionService =
         BurstGameSessionService(
@@ -36,7 +36,7 @@ class BurstGameSessionServiceTest {
         val start = CountDownLatch(1)
         sessionService.start(
             partyId = 1L,
-            partyStartedAt = partyStartedAt,
+            hostEnteredAt = hostEnteredAt,
             participant = participant(0),
             now = startedAt,
         )
@@ -81,7 +81,7 @@ class BurstGameSessionServiceTest {
             assertThrows<BusinessException> {
                 sessionService.start(
                     partyId = 1L,
-                    partyStartedAt = partyStartedAt,
+                    hostEnteredAt = hostEnteredAt,
                     participant = participant(1),
                     now = startedAt,
                 )
@@ -95,7 +95,7 @@ class BurstGameSessionServiceTest {
         val result =
             sessionService.start(
                 partyId = 1L,
-                partyStartedAt = partyStartedAt,
+                hostEnteredAt = hostEnteredAt,
                 participant = participant(1),
                 now = startedAt,
             )
@@ -109,7 +109,7 @@ class BurstGameSessionServiceTest {
     fun `active session start 재호출은 촛불끄기 상태를 다시 검증하지 않는다`() {
         sessionService.start(
             partyId = 1L,
-            partyStartedAt = partyStartedAt,
+            hostEnteredAt = hostEnteredAt,
             participant = participant(1),
             now = startedAt,
         )
@@ -118,7 +118,7 @@ class BurstGameSessionServiceTest {
         val result =
             sessionService.start(
                 partyId = 1L,
-                partyStartedAt = partyStartedAt,
+                hostEnteredAt = hostEnteredAt,
                 participant = participant(1),
                 now = startedAt.plusSeconds(1),
             )
@@ -131,7 +131,7 @@ class BurstGameSessionServiceTest {
     fun `종료 시간이 지난 active session start 재호출은 종료 상태와 endedNow를 반환한다`() {
         sessionService.start(
             partyId = 1L,
-            partyStartedAt = partyStartedAt,
+            hostEnteredAt = hostEnteredAt,
             participant = participant(1),
             now = startedAt,
         )
@@ -139,7 +139,7 @@ class BurstGameSessionServiceTest {
         val result =
             sessionService.start(
                 partyId = 1L,
-                partyStartedAt = partyStartedAt,
+                hostEnteredAt = hostEnteredAt,
                 participant = participant(1),
                 now = startedAt.plusSeconds(20),
             )
@@ -153,13 +153,13 @@ class BurstGameSessionServiceTest {
     fun `이미 종료된 session start 재호출은 endedNow false를 반환한다`() {
         sessionService.start(
             partyId = 1L,
-            partyStartedAt = partyStartedAt,
+            hostEnteredAt = hostEnteredAt,
             participant = participant(1),
             now = startedAt,
         )
         sessionService.start(
             partyId = 1L,
-            partyStartedAt = partyStartedAt,
+            hostEnteredAt = hostEnteredAt,
             participant = participant(1),
             now = startedAt.plusSeconds(20),
         )
@@ -167,7 +167,7 @@ class BurstGameSessionServiceTest {
         val result =
             sessionService.start(
                 partyId = 1L,
-                partyStartedAt = partyStartedAt,
+                hostEnteredAt = hostEnteredAt,
                 participant = participant(1),
                 now = startedAt.plusSeconds(21),
             )
@@ -181,7 +181,7 @@ class BurstGameSessionServiceTest {
     fun `종료 시간이 지난 submit은 라운드를 종료하고 accepted false를 반환한다`() {
         sessionService.start(
             partyId = 1L,
-            partyStartedAt = partyStartedAt,
+            hostEnteredAt = hostEnteredAt,
             participant = participant(1),
             now = startedAt,
         )
@@ -230,7 +230,7 @@ class BurstGameSessionServiceTest {
     fun `snapshot 조회 시 종료 시간이 지났으면 라운드를 lazy 종료한다`() {
         sessionService.start(
             partyId = 1L,
-            partyStartedAt = partyStartedAt,
+            hostEnteredAt = hostEnteredAt,
             participant = participant(1),
             now = startedAt,
         )
@@ -246,7 +246,7 @@ class BurstGameSessionServiceTest {
         assertNull(sessionService.end(404L, startedAt))
         sessionService.start(
             partyId = 1L,
-            partyStartedAt = partyStartedAt,
+            hostEnteredAt = hostEnteredAt,
             participant = participant(1),
             now = startedAt,
         )
@@ -262,7 +262,7 @@ class BurstGameSessionServiceTest {
         assertFalse(sessionService.removeStarted(404L, startedAt, startedAt))
         sessionService.start(
             partyId = 1L,
-            partyStartedAt = partyStartedAt,
+            hostEnteredAt = hostEnteredAt,
             participant = participant(1),
             now = startedAt,
         )
@@ -293,7 +293,7 @@ class BurstGameSessionServiceTest {
 
         override fun isCandleBlowFinished(
             partyId: Long,
-            partyStartedAt: LocalDateTime,
+            hostEnteredAt: LocalDateTime?,
             now: LocalDateTime,
         ): Boolean = finished
     }

--- a/src/test/kotlin/com/team2/server/burstgame/application/usecase/EndScheduledCandleBlowUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/burstgame/application/usecase/EndScheduledCandleBlowUseCaseTest.kt
@@ -16,7 +16,8 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class EndScheduledCandleBlowUseCaseTest {
-    private val partyStartedAt = LocalDateTime.of(2026, 5, 24, 20, 0)
+    private val hostEnteredAt = LocalDateTime.of(2026, 5, 24, 20, 0)
+    private val durationSeconds = 300L
     private lateinit var sessionStore: InMemoryCandleBlowSessionStore
     private lateinit var eventBroadcaster: CandleBlowEventBroadcaster
     private lateinit var useCase: EndScheduledCandleBlowUseCase
@@ -67,9 +68,10 @@ class EndScheduledCandleBlowUseCaseTest {
         sessionStore.getOrCreateWithLock(
             partyId = 1L,
             sessionFactory = {
-                CandleBlowSession.fromPartyStartedAt(
+                CandleBlowSession.fromHostEnteredAt(
                     partyId = 1L,
-                    partyStartedAt = partyStartedAt,
+                    hostEnteredAt = hostEnteredAt,
+                    durationSeconds = durationSeconds,
                 )
             },
         ) { session, _ ->
@@ -77,7 +79,7 @@ class EndScheduledCandleBlowUseCaseTest {
         }
     }
 
-    private fun candleStartedAt(): LocalDateTime = partyStartedAt.plusSeconds(CandleBlowPolicy.START_DELAY_SECONDS)
+    private fun candleStartedAt(): LocalDateTime = hostEnteredAt.plusSeconds(CandleBlowPolicy.START_DELAY_SECONDS)
 
-    private fun candleEndedAt(): LocalDateTime = candleStartedAt().plusSeconds(CandleBlowPolicy.DURATION_SECONDS)
+    private fun candleEndedAt(): LocalDateTime = candleStartedAt().plusSeconds(durationSeconds)
 }

--- a/src/test/kotlin/com/team2/server/burstgame/application/usecase/GetCandleBlowStateUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/burstgame/application/usecase/GetCandleBlowStateUseCaseTest.kt
@@ -31,12 +31,13 @@ class GetCandleBlowStateUseCaseTest {
     private val sessionStore = InMemoryCandleBlowSessionStore()
     private val eventBroadcaster: CandleBlowEventBroadcaster = mock()
     private val clock: Clock = Clock.fixed(Instant.parse("2026-05-21T11:02:00Z"), ZoneId.of("Asia/Seoul"))
+    private val candleBlowProperties = CandleBlowProperties()
     private val useCase =
         GetCandleBlowStateUseCase(
             participantResolver = participantResolver,
             sessionStore = sessionStore,
             endEventPublisher = CandleBlowEndEventPublisher(eventBroadcaster),
-            candleBlowProperties = CandleBlowProperties(),
+            candleBlowProperties = candleBlowProperties,
             clock = clock,
         )
 
@@ -48,7 +49,7 @@ class GetCandleBlowStateUseCaseTest {
                     hostEnteredAt =
                         LocalDateTime
                             .now(clock)
-                            .minusSeconds(CandleBlowPolicy.START_DELAY_SECONDS + CandleBlowPolicy.DURATION_SECONDS),
+                            .minusSeconds(CandleBlowPolicy.START_DELAY_SECONDS + candleBlowProperties.durationSeconds),
                 ),
             )
 

--- a/src/test/kotlin/com/team2/server/burstgame/application/usecase/GetCandleBlowStateUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/burstgame/application/usecase/GetCandleBlowStateUseCaseTest.kt
@@ -4,6 +4,7 @@ import com.team2.server.burstgame.application.port.CandleBlowEventBroadcaster
 import com.team2.server.burstgame.application.support.BurstGameParticipantResolver
 import com.team2.server.burstgame.application.support.BurstGameParticipantResolver.ResolvedRealtimeParticipant
 import com.team2.server.burstgame.application.support.CandleBlowEndEventPublisher
+import com.team2.server.burstgame.config.CandleBlowProperties
 import com.team2.server.burstgame.domain.BurstGameParticipantInfo
 import com.team2.server.burstgame.domain.candle.CandleBlowFinishedReason
 import com.team2.server.burstgame.domain.candle.CandleBlowPolicy
@@ -35,6 +36,7 @@ class GetCandleBlowStateUseCaseTest {
             participantResolver = participantResolver,
             sessionStore = sessionStore,
             endEventPublisher = CandleBlowEndEventPublisher(eventBroadcaster),
+            candleBlowProperties = CandleBlowProperties(),
             clock = clock,
         )
 
@@ -43,7 +45,7 @@ class GetCandleBlowStateUseCaseTest {
         whenever(participantResolver.resolveWithParty(1L, null, "tok"))
             .thenReturn(
                 resolved(
-                    partyStartedAt =
+                    hostEnteredAt =
                         LocalDateTime
                             .now(clock)
                             .minusSeconds(CandleBlowPolicy.START_DELAY_SECONDS + CandleBlowPolicy.DURATION_SECONDS),
@@ -65,14 +67,15 @@ class GetCandleBlowStateUseCaseTest {
         }
     }
 
-    private fun resolved(partyStartedAt: LocalDateTime): ResolvedRealtimeParticipant =
+    private fun resolved(hostEnteredAt: LocalDateTime): ResolvedRealtimeParticipant =
         ResolvedRealtimeParticipant(
             party =
                 RealtimeParty(
                     ownerId = 1L,
                     name = "실시간 파티",
                     celebrantNickname = "주인공",
-                    startedAt = partyStartedAt,
+                    startedAt = hostEnteredAt.minusMinutes(1),
+                    hostEnteredAt = hostEnteredAt,
                 ),
             participant =
                 BurstGameParticipantInfo(

--- a/src/test/kotlin/com/team2/server/burstgame/application/usecase/GetCandleBlowStateUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/burstgame/application/usecase/GetCandleBlowStateUseCaseTest.kt
@@ -6,6 +6,7 @@ import com.team2.server.burstgame.application.support.BurstGameParticipantResolv
 import com.team2.server.burstgame.application.support.CandleBlowEndEventPublisher
 import com.team2.server.burstgame.domain.BurstGameParticipantInfo
 import com.team2.server.burstgame.domain.candle.CandleBlowFinishedReason
+import com.team2.server.burstgame.domain.candle.CandleBlowPolicy
 import com.team2.server.burstgame.infrastructure.candle.InMemoryCandleBlowSessionStore
 import com.team2.server.party.domain.entity.RealtimeParty
 import org.junit.jupiter.api.extension.ExtendWith
@@ -40,7 +41,14 @@ class GetCandleBlowStateUseCaseTest {
     @Test
     fun `조회로 촛불끄기 timeout 종료가 발생하면 ended 이벤트를 커밋 이후 발행한다`() {
         whenever(participantResolver.resolveWithParty(1L, null, "tok"))
-            .thenReturn(resolved(partyStartedAt = LocalDateTime.of(2026, 5, 21, 20, 0)))
+            .thenReturn(
+                resolved(
+                    partyStartedAt =
+                        LocalDateTime
+                            .now(clock)
+                            .minusSeconds(CandleBlowPolicy.START_DELAY_SECONDS + CandleBlowPolicy.DURATION_SECONDS),
+                ),
+            )
 
         TransactionSynchronizationManager.initSynchronization()
         try {

--- a/src/test/kotlin/com/team2/server/burstgame/application/usecase/RecoverCandleBlowScheduleUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/burstgame/application/usecase/RecoverCandleBlowScheduleUseCaseTest.kt
@@ -2,8 +2,8 @@ package com.team2.server.burstgame.application.usecase
 
 import com.team2.server.burstgame.config.CandleBlowProperties
 import com.team2.server.burstgame.domain.candle.CandleBlowPolicy
-import com.team2.server.party.application.service.PartyService
-import com.team2.server.party.domain.entity.RealtimeParty
+import com.team2.server.party.application.dto.RealtimePartyHostEnteredScheduleData
+import com.team2.server.party.application.usecase.FindRealtimePartiesWithHostEnteredUseCase
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -15,12 +15,12 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class RecoverCandleBlowScheduleUseCaseTest {
-    private val partyService: PartyService = mock()
+    private val findRealtimePartiesWithHostEnteredUseCase: FindRealtimePartiesWithHostEnteredUseCase = mock()
     private val clock: Clock = Clock.fixed(Instant.parse("2026-05-24T11:01:20Z"), ZoneId.of("Asia/Seoul"))
     private val candleBlowProperties = CandleBlowProperties(durationSeconds = 300L)
     private val useCase =
         RecoverCandleBlowScheduleUseCase(
-            partyService = partyService,
+            findRealtimePartiesWithHostEnteredUseCase = findRealtimePartiesWithHostEnteredUseCase,
             candleBlowProperties = candleBlowProperties,
             clock = clock,
         )
@@ -31,19 +31,14 @@ class RecoverCandleBlowScheduleUseCaseTest {
         val hostEnteredAfter =
             now.minusSeconds(CandleBlowPolicy.START_DELAY_SECONDS + candleBlowProperties.durationSeconds)
         val hostEnteredAt = LocalDateTime.of(2026, 5, 24, 20, 0)
-        val party =
-            RealtimeParty(
-                ownerId = 1L,
-                startedAt = hostEnteredAt.minusMinutes(1),
-                hostEnteredAt = hostEnteredAt,
-            )
-        whenever(partyService.findRealtimePartiesWithHostEnteredAfter(hostEnteredAfter)).thenReturn(listOf(party))
+        val party = RealtimePartyHostEnteredScheduleData(partyId = 10L, hostEnteredAt = hostEnteredAt)
+        whenever(findRealtimePartiesWithHostEnteredUseCase(hostEnteredAfter)).thenReturn(listOf(party))
 
         val targets = useCase()
 
         assertEquals(1, targets.size)
-        assertEquals(party.id, targets[0].partyId)
+        assertEquals(party.partyId, targets[0].partyId)
         assertEquals(hostEnteredAt, targets[0].hostEnteredAt)
-        verify(partyService).findRealtimePartiesWithHostEnteredAfter(hostEnteredAfter)
+        verify(findRealtimePartiesWithHostEnteredUseCase).invoke(hostEnteredAfter)
     }
 }

--- a/src/test/kotlin/com/team2/server/burstgame/application/usecase/RecoverCandleBlowScheduleUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/burstgame/application/usecase/RecoverCandleBlowScheduleUseCaseTest.kt
@@ -1,8 +1,9 @@
 package com.team2.server.burstgame.application.usecase
 
+import com.team2.server.burstgame.config.CandleBlowProperties
 import com.team2.server.burstgame.domain.candle.CandleBlowPolicy
-import com.team2.server.party.application.dto.RealtimePartyScheduleData
-import com.team2.server.party.application.usecase.FindRealtimePartiesWaitingAutomaticEndingUseCase
+import com.team2.server.party.application.service.PartyService
+import com.team2.server.party.domain.entity.RealtimeParty
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -14,28 +15,35 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class RecoverCandleBlowScheduleUseCaseTest {
-    private val findRealtimePartiesWaitingAutomaticEndingUseCase:
-        FindRealtimePartiesWaitingAutomaticEndingUseCase = mock()
+    private val partyService: PartyService = mock()
     private val clock: Clock = Clock.fixed(Instant.parse("2026-05-24T11:01:20Z"), ZoneId.of("Asia/Seoul"))
+    private val candleBlowProperties = CandleBlowProperties(durationSeconds = 300L)
     private val useCase =
         RecoverCandleBlowScheduleUseCase(
-            findRealtimePartiesWaitingAutomaticEndingUseCase = findRealtimePartiesWaitingAutomaticEndingUseCase,
+            partyService = partyService,
+            candleBlowProperties = candleBlowProperties,
             clock = clock,
         )
 
     @Test
     fun `촛불끄기 복구 대상 파티를 스케줄 타겟으로 변환한다`() {
         val now = LocalDateTime.ofInstant(clock.instant(), clock.zone)
-        val startedAfter = now.minusSeconds(CandleBlowPolicy.START_DELAY_SECONDS + CandleBlowPolicy.DURATION_SECONDS)
-        val partyStartedAt = LocalDateTime.of(2026, 5, 24, 20, 0)
-        val party = RealtimePartyScheduleData(partyId = 10L, startedAt = partyStartedAt)
-        whenever(findRealtimePartiesWaitingAutomaticEndingUseCase(startedAfter)).thenReturn(listOf(party))
+        val hostEnteredAfter =
+            now.minusSeconds(CandleBlowPolicy.START_DELAY_SECONDS + candleBlowProperties.durationSeconds)
+        val hostEnteredAt = LocalDateTime.of(2026, 5, 24, 20, 0)
+        val party =
+            RealtimeParty(
+                ownerId = 1L,
+                startedAt = hostEnteredAt.minusMinutes(1),
+                hostEnteredAt = hostEnteredAt,
+            )
+        whenever(partyService.findRealtimePartiesWithHostEnteredAfter(hostEnteredAfter)).thenReturn(listOf(party))
 
         val targets = useCase()
 
         assertEquals(1, targets.size)
-        assertEquals(party.partyId, targets[0].partyId)
-        assertEquals(partyStartedAt, targets[0].partyStartedAt)
-        verify(findRealtimePartiesWaitingAutomaticEndingUseCase).invoke(startedAfter)
+        assertEquals(party.id, targets[0].partyId)
+        assertEquals(hostEnteredAt, targets[0].hostEnteredAt)
+        verify(partyService).findRealtimePartiesWithHostEnteredAfter(hostEnteredAfter)
     }
 }

--- a/src/test/kotlin/com/team2/server/burstgame/application/usecase/StartBurstGameUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/burstgame/application/usecase/StartBurstGameUseCaseTest.kt
@@ -28,7 +28,7 @@ import kotlin.test.assertEquals
 
 @ExtendWith(MockitoExtension::class)
 class StartBurstGameUseCaseTest {
-    private val partyStartedAt = LocalDateTime.of(2026, 5, 21, 20, 9)
+    private val hostEnteredAt = LocalDateTime.of(2026, 5, 21, 20, 9)
     private val participantResolver: BurstGameParticipantResolver = mock()
     private val sessionService: BurstGameSessionService = mock()
     private val startSideEffectHandler: BurstGameStartSideEffectHandler = mock()
@@ -48,7 +48,7 @@ class StartBurstGameUseCaseTest {
         val startResult = BurstGameSessionService.StartResult.Started(snapshot, created = true)
         val now = LocalDateTime.ofInstant(clock.instant(), clock.zone)
         whenever(participantResolver.resolveWithParty(1L, null, "tok")).thenReturn(resolved(participant))
-        whenever(sessionService.start(eq(1L), eq(partyStartedAt), eq(participant), any()))
+        whenever(sessionService.start(eq(1L), eq(hostEnteredAt), eq(participant), any()))
             .thenReturn(startResult)
         whenever(startSideEffectHandler.resolve(startResult)).thenReturn(startResult)
 
@@ -64,7 +64,7 @@ class StartBurstGameUseCaseTest {
         val snapshot = endedSnapshot()
         val startResult = BurstGameSessionService.StartResult.AlreadyEnded(snapshot, endedNow = true)
         whenever(participantResolver.resolveWithParty(1L, null, "tok")).thenReturn(resolved(participant))
-        whenever(sessionService.start(eq(1L), eq(partyStartedAt), eq(participant), any()))
+        whenever(sessionService.start(eq(1L), eq(hostEnteredAt), eq(participant), any()))
             .thenReturn(startResult)
         whenever(startSideEffectHandler.resolve(startResult))
             .thenThrow(BusinessException(ErrorCode.BURST_GAME_ALREADY_ENDED))
@@ -85,7 +85,8 @@ class StartBurstGameUseCaseTest {
                     ownerId = 1L,
                     name = "실시간 파티",
                     celebrantNickname = "주인공",
-                    startedAt = partyStartedAt,
+                    startedAt = hostEnteredAt.minusMinutes(1),
+                    hostEnteredAt = hostEnteredAt,
                 ),
             participant = participant,
         )

--- a/src/test/kotlin/com/team2/server/burstgame/application/usecase/StartScheduledCandleBlowUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/burstgame/application/usecase/StartScheduledCandleBlowUseCaseTest.kt
@@ -1,6 +1,7 @@
 package com.team2.server.burstgame.application.usecase
 
 import com.team2.server.burstgame.application.port.CandleBlowEventBroadcaster
+import com.team2.server.burstgame.config.CandleBlowProperties
 import com.team2.server.burstgame.domain.candle.CandleBlowFinishedReason
 import com.team2.server.burstgame.domain.candle.CandleBlowPolicy
 import com.team2.server.burstgame.domain.candle.CandleBlowStatus
@@ -16,7 +17,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class StartScheduledCandleBlowUseCaseTest {
-    private val partyStartedAt = LocalDateTime.of(2026, 5, 24, 20, 0)
+    private val hostEnteredAt = LocalDateTime.of(2026, 5, 24, 20, 0)
     private lateinit var sessionStore: InMemoryCandleBlowSessionStore
     private lateinit var eventBroadcaster: CandleBlowEventBroadcaster
     private lateinit var useCase: StartScheduledCandleBlowUseCase
@@ -29,6 +30,7 @@ class StartScheduledCandleBlowUseCaseTest {
             StartScheduledCandleBlowUseCase(
                 sessionStore = sessionStore,
                 eventBroadcaster = eventBroadcaster,
+                candleBlowProperties = CandleBlowProperties(),
             )
     }
 
@@ -37,7 +39,7 @@ class StartScheduledCandleBlowUseCaseTest {
         val result =
             useCase(
                 partyId = 1L,
-                partyStartedAt = partyStartedAt,
+                hostEnteredAt = hostEnteredAt,
                 now = candleStartedAt(),
             )
 
@@ -51,7 +53,7 @@ class StartScheduledCandleBlowUseCaseTest {
         val result =
             useCase(
                 partyId = 1L,
-                partyStartedAt = partyStartedAt,
+                hostEnteredAt = hostEnteredAt,
                 now = candleEndedAt(),
             )
 
@@ -65,12 +67,12 @@ class StartScheduledCandleBlowUseCaseTest {
     fun `같은 세션의 started 이벤트는 한 번만 발행한다`() {
         useCase(
             partyId = 1L,
-            partyStartedAt = partyStartedAt,
+            hostEnteredAt = hostEnteredAt,
             now = candleStartedAt(),
         )
         useCase(
             partyId = 1L,
-            partyStartedAt = partyStartedAt,
+            hostEnteredAt = hostEnteredAt,
             now = candleStartedAt().plusSeconds(1),
         )
 
@@ -83,7 +85,7 @@ class StartScheduledCandleBlowUseCaseTest {
         val result =
             useCase(
                 partyId = 1L,
-                partyStartedAt = partyStartedAt,
+                hostEnteredAt = hostEnteredAt,
                 now = candleStartedAt().minusNanos(1),
             )
 
@@ -92,7 +94,7 @@ class StartScheduledCandleBlowUseCaseTest {
         verify(eventBroadcaster, never()).broadcastEnded(any())
     }
 
-    private fun candleStartedAt(): LocalDateTime = partyStartedAt.plusSeconds(CandleBlowPolicy.START_DELAY_SECONDS)
+    private fun candleStartedAt(): LocalDateTime = hostEnteredAt.plusSeconds(CandleBlowPolicy.START_DELAY_SECONDS)
 
     private fun candleEndedAt(): LocalDateTime = candleStartedAt().plusSeconds(CandleBlowPolicy.DURATION_SECONDS)
 }

--- a/src/test/kotlin/com/team2/server/burstgame/application/usecase/StartScheduledCandleBlowUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/burstgame/application/usecase/StartScheduledCandleBlowUseCaseTest.kt
@@ -18,6 +18,7 @@ import kotlin.test.assertEquals
 
 class StartScheduledCandleBlowUseCaseTest {
     private val hostEnteredAt = LocalDateTime.of(2026, 5, 24, 20, 0)
+    private val candleBlowProperties = CandleBlowProperties()
     private lateinit var sessionStore: InMemoryCandleBlowSessionStore
     private lateinit var eventBroadcaster: CandleBlowEventBroadcaster
     private lateinit var useCase: StartScheduledCandleBlowUseCase
@@ -30,7 +31,7 @@ class StartScheduledCandleBlowUseCaseTest {
             StartScheduledCandleBlowUseCase(
                 sessionStore = sessionStore,
                 eventBroadcaster = eventBroadcaster,
-                candleBlowProperties = CandleBlowProperties(),
+                candleBlowProperties = candleBlowProperties,
             )
     }
 
@@ -96,5 +97,5 @@ class StartScheduledCandleBlowUseCaseTest {
 
     private fun candleStartedAt(): LocalDateTime = hostEnteredAt.plusSeconds(CandleBlowPolicy.START_DELAY_SECONDS)
 
-    private fun candleEndedAt(): LocalDateTime = candleStartedAt().plusSeconds(CandleBlowPolicy.DURATION_SECONDS)
+    private fun candleEndedAt(): LocalDateTime = candleStartedAt().plusSeconds(candleBlowProperties.durationSeconds)
 }

--- a/src/test/kotlin/com/team2/server/burstgame/application/usecase/StartScheduledCandleBlowUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/burstgame/application/usecase/StartScheduledCandleBlowUseCaseTest.kt
@@ -65,6 +65,34 @@ class StartScheduledCandleBlowUseCaseTest {
     }
 
     @Test
+    fun `종료 시각은 설정된 durationSeconds로 계산한다`() {
+        val customDurationSeconds = 45L
+        val customUseCase =
+            StartScheduledCandleBlowUseCase(
+                sessionStore = InMemoryCandleBlowSessionStore(),
+                eventBroadcaster = eventBroadcaster,
+                candleBlowProperties = CandleBlowProperties(durationSeconds = customDurationSeconds),
+            )
+
+        val activeResult =
+            customUseCase(
+                partyId = 10L,
+                hostEnteredAt = hostEnteredAt,
+                now = candleStartedAt().plusSeconds(customDurationSeconds - 1),
+            )
+        val finishedResult =
+            customUseCase(
+                partyId = 11L,
+                hostEnteredAt = hostEnteredAt,
+                now = candleStartedAt().plusSeconds(customDurationSeconds),
+            )
+
+        assertEquals(CandleBlowStatus.ACTIVE, activeResult.status)
+        assertEquals(CandleBlowStatus.FINISHED, finishedResult.status)
+        assertEquals(CandleBlowFinishedReason.TIMEOUT, finishedResult.finishedReason)
+    }
+
+    @Test
     fun `같은 세션의 started 이벤트는 한 번만 발행한다`() {
         useCase(
             partyId = 1L,

--- a/src/test/kotlin/com/team2/server/burstgame/domain/candle/CandleBlowSessionTest.kt
+++ b/src/test/kotlin/com/team2/server/burstgame/domain/candle/CandleBlowSessionTest.kt
@@ -10,13 +10,19 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class CandleBlowSessionTest {
-    private val partyStartedAt = LocalDateTime.of(2026, 5, 24, 20, 0)
-    private val startedAt = partyStartedAt.plusSeconds(CandleBlowPolicy.START_DELAY_SECONDS)
-    private val endsAt = startedAt.plusSeconds(CandleBlowPolicy.DURATION_SECONDS)
-    private val session = CandleBlowSession.fromPartyStartedAt(partyId = 1L, partyStartedAt = partyStartedAt)
+    private val hostEnteredAt = LocalDateTime.of(2026, 5, 24, 20, 0)
+    private val durationSeconds = 300L
+    private val startedAt = hostEnteredAt.plusSeconds(CandleBlowPolicy.START_DELAY_SECONDS)
+    private val endsAt = startedAt.plusSeconds(durationSeconds)
+    private val session =
+        CandleBlowSession.fromHostEnteredAt(
+            partyId = 1L,
+            hostEnteredAt = hostEnteredAt,
+            durationSeconds = durationSeconds,
+        )
 
     @Test
-    fun `파티 시작 시각으로 촛불 시작 종료 시각을 계산한다`() {
+    fun `주최자 입장 시각으로 촛불 시작 종료 시각을 계산한다`() {
         assertEquals(startedAt, session.startedAt)
         assertEquals(endsAt, session.endsAt)
     }

--- a/src/test/kotlin/com/team2/server/burstgame/infrastructure/candle/InMemoryCandleBlowSessionStoreTest.kt
+++ b/src/test/kotlin/com/team2/server/burstgame/infrastructure/candle/InMemoryCandleBlowSessionStoreTest.kt
@@ -11,7 +11,8 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class InMemoryCandleBlowSessionStoreTest {
-    private val partyStartedAt = LocalDateTime.of(2026, 5, 24, 20, 0)
+    private val hostEnteredAt = LocalDateTime.of(2026, 5, 24, 20, 0)
+    private val durationSeconds = 300L
     private val store = InMemoryCandleBlowSessionStore()
 
     @Test
@@ -113,7 +114,7 @@ class InMemoryCandleBlowSessionStoreTest {
                             session
                                 .blow(
                                     candleId = candleId,
-                                    now = partyStartedAt.plusSeconds(CandleBlowPolicy.START_DELAY_SECONDS),
+                                    now = hostEnteredAt.plusSeconds(CandleBlowPolicy.START_DELAY_SECONDS),
                                 ).changed
                         } == true
                     }
@@ -125,7 +126,7 @@ class InMemoryCandleBlowSessionStoreTest {
             assertTrue(futures.all { it.get(1, TimeUnit.SECONDS) })
             val remainingCount =
                 store.withSessionLock(1L) {
-                    it.snapshot(partyStartedAt.plusSeconds(CandleBlowPolicy.START_DELAY_SECONDS)).remainingCount
+                    it.snapshot(hostEnteredAt.plusSeconds(CandleBlowPolicy.START_DELAY_SECONDS)).remainingCount
                 }
             assertEquals(0, remainingCount)
         } finally {
@@ -140,8 +141,8 @@ class InMemoryCandleBlowSessionStoreTest {
         store.getOrCreateWithLock(1L, { session(1L) }) { _, _ -> }
 
         store.removeExpired(
-            partyStartedAt
-                .plusSeconds(CandleBlowPolicy.START_DELAY_SECONDS + CandleBlowPolicy.DURATION_SECONDS)
+            hostEnteredAt
+                .plusSeconds(CandleBlowPolicy.START_DELAY_SECONDS + durationSeconds)
                 .plus(CandleBlowPolicy.SESSION_TTL),
         )
 
@@ -153,8 +154,8 @@ class InMemoryCandleBlowSessionStoreTest {
         store.getOrCreateWithLock(1L, { session(1L) }) { _, _ -> }
 
         store.removeExpired(
-            partyStartedAt
-                .plusSeconds(CandleBlowPolicy.START_DELAY_SECONDS + CandleBlowPolicy.DURATION_SECONDS)
+            hostEnteredAt
+                .plusSeconds(CandleBlowPolicy.START_DELAY_SECONDS + durationSeconds)
                 .plus(CandleBlowPolicy.SESSION_TTL)
                 .minusNanos(1),
         )
@@ -163,8 +164,9 @@ class InMemoryCandleBlowSessionStoreTest {
     }
 
     private fun session(partyId: Long): CandleBlowSession =
-        CandleBlowSession.fromPartyStartedAt(
+        CandleBlowSession.fromHostEnteredAt(
             partyId = partyId,
-            partyStartedAt = partyStartedAt,
+            hostEnteredAt = hostEnteredAt,
+            durationSeconds = durationSeconds,
         )
 }

--- a/src/test/kotlin/com/team2/server/burstgame/infrastructure/candle/InMemoryCandleBlowStatusReaderTest.kt
+++ b/src/test/kotlin/com/team2/server/burstgame/infrastructure/candle/InMemoryCandleBlowStatusReaderTest.kt
@@ -12,8 +12,9 @@ import kotlin.test.assertTrue
 class InMemoryCandleBlowStatusReaderTest {
     private val hostEnteredAt = LocalDateTime.of(2026, 5, 24, 20, 0)
     private val startedAt = hostEnteredAt.plusSeconds(CandleBlowPolicy.START_DELAY_SECONDS)
+    private val candleBlowProperties = CandleBlowProperties()
     private val store = InMemoryCandleBlowSessionStore()
-    private val reader = InMemoryCandleBlowStatusReader(store, CandleBlowProperties())
+    private val reader = InMemoryCandleBlowStatusReader(store, candleBlowProperties)
 
     @Test
     fun `세션이 없으면 촛불끄기 미완료로 판단한다`() {
@@ -52,7 +53,7 @@ class InMemoryCandleBlowStatusReaderTest {
             reader.isCandleBlowFinished(
                 partyId = 1L,
                 hostEnteredAt = hostEnteredAt,
-                now = startedAt.plusSeconds(CandleBlowPolicy.DURATION_SECONDS),
+                now = startedAt.plusSeconds(candleBlowProperties.durationSeconds),
             ),
         )
         assertTrue(
@@ -68,7 +69,7 @@ class InMemoryCandleBlowStatusReaderTest {
             reader.isCandleBlowFinished(
                 partyId = 1L,
                 hostEnteredAt = hostEnteredAt,
-                now = startedAt.plusSeconds(CandleBlowPolicy.DURATION_SECONDS),
+                now = startedAt.plusSeconds(candleBlowProperties.durationSeconds),
             ),
         )
         assertTrue(
@@ -82,6 +83,6 @@ class InMemoryCandleBlowStatusReaderTest {
         CandleBlowSession.fromHostEnteredAt(
             partyId = partyId,
             hostEnteredAt = hostEnteredAt,
-            durationSeconds = CandleBlowPolicy.DEFAULT_DURATION_SECONDS,
+            durationSeconds = candleBlowProperties.durationSeconds,
         )
 }

--- a/src/test/kotlin/com/team2/server/burstgame/infrastructure/candle/InMemoryCandleBlowStatusReaderTest.kt
+++ b/src/test/kotlin/com/team2/server/burstgame/infrastructure/candle/InMemoryCandleBlowStatusReaderTest.kt
@@ -1,5 +1,6 @@
 package com.team2.server.burstgame.infrastructure.candle
 
+import com.team2.server.burstgame.config.CandleBlowProperties
 import com.team2.server.burstgame.domain.candle.CandleBlowFinishedReason
 import com.team2.server.burstgame.domain.candle.CandleBlowPolicy
 import com.team2.server.burstgame.domain.candle.CandleBlowSession
@@ -9,21 +10,21 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class InMemoryCandleBlowStatusReaderTest {
-    private val partyStartedAt = LocalDateTime.of(2026, 5, 24, 20, 0)
-    private val startedAt = partyStartedAt.plusSeconds(CandleBlowPolicy.START_DELAY_SECONDS)
+    private val hostEnteredAt = LocalDateTime.of(2026, 5, 24, 20, 0)
+    private val startedAt = hostEnteredAt.plusSeconds(CandleBlowPolicy.START_DELAY_SECONDS)
     private val store = InMemoryCandleBlowSessionStore()
-    private val reader = InMemoryCandleBlowStatusReader(store)
+    private val reader = InMemoryCandleBlowStatusReader(store, CandleBlowProperties())
 
     @Test
     fun `세션이 없으면 촛불끄기 미완료로 판단한다`() {
-        assertFalse(reader.isCandleBlowFinished(partyId = 1L, partyStartedAt = partyStartedAt, now = startedAt))
+        assertFalse(reader.isCandleBlowFinished(partyId = 1L, hostEnteredAt = hostEnteredAt, now = startedAt))
     }
 
     @Test
     fun `촛불끄기가 active이면 미완료로 판단한다`() {
         store.getOrCreateWithLock(1L, { session(1L) }) { _, _ -> }
 
-        assertFalse(reader.isCandleBlowFinished(partyId = 1L, partyStartedAt = partyStartedAt, now = startedAt))
+        assertFalse(reader.isCandleBlowFinished(partyId = 1L, hostEnteredAt = hostEnteredAt, now = startedAt))
     }
 
     @Test
@@ -37,7 +38,7 @@ class InMemoryCandleBlowStatusReaderTest {
         assertTrue(
             reader.isCandleBlowFinished(
                 partyId = 1L,
-                partyStartedAt = partyStartedAt,
+                hostEnteredAt = hostEnteredAt,
                 now = startedAt.plusSeconds(10),
             ),
         )
@@ -50,7 +51,7 @@ class InMemoryCandleBlowStatusReaderTest {
         assertTrue(
             reader.isCandleBlowFinished(
                 partyId = 1L,
-                partyStartedAt = partyStartedAt,
+                hostEnteredAt = hostEnteredAt,
                 now = startedAt.plusSeconds(CandleBlowPolicy.DURATION_SECONDS),
             ),
         )
@@ -66,7 +67,7 @@ class InMemoryCandleBlowStatusReaderTest {
         assertTrue(
             reader.isCandleBlowFinished(
                 partyId = 1L,
-                partyStartedAt = partyStartedAt,
+                hostEnteredAt = hostEnteredAt,
                 now = startedAt.plusSeconds(CandleBlowPolicy.DURATION_SECONDS),
             ),
         )
@@ -78,8 +79,9 @@ class InMemoryCandleBlowStatusReaderTest {
     }
 
     private fun session(partyId: Long): CandleBlowSession =
-        CandleBlowSession.fromPartyStartedAt(
+        CandleBlowSession.fromHostEnteredAt(
             partyId = partyId,
-            partyStartedAt = partyStartedAt,
+            hostEnteredAt = hostEnteredAt,
+            durationSeconds = CandleBlowPolicy.DEFAULT_DURATION_SECONDS,
         )
 }

--- a/src/test/kotlin/com/team2/server/burstgame/infrastructure/scheduler/ScheduledCandleBlowSchedulerTest.kt
+++ b/src/test/kotlin/com/team2/server/burstgame/infrastructure/scheduler/ScheduledCandleBlowSchedulerTest.kt
@@ -3,6 +3,7 @@ package com.team2.server.burstgame.infrastructure.scheduler
 import com.team2.server.burstgame.application.usecase.EndScheduledCandleBlowUseCase
 import com.team2.server.burstgame.application.usecase.RecoverCandleBlowScheduleUseCase
 import com.team2.server.burstgame.application.usecase.StartScheduledCandleBlowUseCase
+import com.team2.server.burstgame.config.CandleBlowProperties
 import org.mockito.kotlin.mock
 import java.time.Clock
 import java.time.Duration
@@ -25,6 +26,7 @@ class ScheduledCandleBlowSchedulerTest {
             recoverCandleBlowScheduleUseCase = recoverCandleBlowScheduleUseCase,
             startScheduledCandleBlowUseCase = startScheduledCandleBlowUseCase,
             endScheduledCandleBlowUseCase = endScheduledCandleBlowUseCase,
+            candleBlowProperties = CandleBlowProperties(),
         )
 
     @AfterTest

--- a/src/test/kotlin/com/team2/server/chat/infrastructure/party/PartyRealtimePartyEntryProfileAdapterTest.kt
+++ b/src/test/kotlin/com/team2/server/chat/infrastructure/party/PartyRealtimePartyEntryProfileAdapterTest.kt
@@ -1,0 +1,184 @@
+package com.team2.server.chat.infrastructure.party
+
+import com.team2.server.chat.dto.EnterRealtimePartyRequest
+import com.team2.server.common.exception.BusinessException
+import com.team2.server.common.exception.ErrorCode
+import com.team2.server.party.application.service.CharacterService
+import com.team2.server.party.application.service.ParticipantService
+import com.team2.server.party.application.service.RealtimeParticipantProfileService
+import com.team2.server.party.domain.entity.Character
+import com.team2.server.party.domain.entity.Participant
+import com.team2.server.party.domain.entity.RealtimeParticipantProfile
+import com.team2.server.party.domain.entity.RealtimeParty
+import com.team2.server.user.entity.AuthProvider
+import com.team2.server.user.entity.User
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.LocalDateTime
+import kotlin.test.assertEquals
+
+@ExtendWith(MockitoExtension::class)
+class PartyRealtimePartyEntryProfileAdapterTest {
+    @Mock lateinit var participantService: ParticipantService
+
+    @Mock lateinit var realtimeParticipantProfileService: RealtimeParticipantProfileService
+
+    @Mock lateinit var characterService: CharacterService
+
+    private val adapter: PartyRealtimePartyEntryProfileAdapter by lazy {
+        PartyRealtimePartyEntryProfileAdapter(
+            participantService = participantService,
+            realtimeParticipantProfileService = realtimeParticipantProfileService,
+            characterService = characterService,
+        )
+    }
+
+    private val now = LocalDateTime.of(2026, 5, 23, 10, 0)
+    private val request = EnterRealtimePartyRequest(nickname = "토끼왕", characterId = 1L)
+
+    @Test
+    fun `첫 입장은 participant와 profile을 생성하고 entry result로 변환한다`() {
+        val party = RealtimeParty(ownerId = 1L, startedAt = now.minusMinutes(1))
+        val character = Character(name = "토끼")
+        val participant = Participant(party = party, user = user(), isCelebrant = true)
+        val profile =
+            RealtimeParticipantProfile(
+                participant = participant,
+                nickname = "토끼왕",
+                character = character,
+                participantToken = "participant-token",
+            )
+
+        whenever(characterService.requireCharacter(1L)).thenReturn(character)
+        whenever(participantService.resolveUser(1L)).thenReturn(participant.user)
+        whenever(participantService.joinAnonymousOrMember(party, participant.user)).thenReturn(participant)
+        whenever(
+            realtimeParticipantProfileService.upsert(
+                participant = participant,
+                nickname = "토끼왕",
+                character = character,
+                isHostNicknameLocked = true,
+            ),
+        ).thenReturn(profile)
+
+        val result = adapter.resolve(party = party, userId = 1L, request = request, now = now)
+
+        assertEquals("participant-token", result.participantToken)
+        assertEquals(true, result.isCelebrant)
+        assertEquals("토끼왕", result.nickname)
+        assertEquals(character.id, result.characterId)
+    }
+
+    @Test
+    fun `participantToken 재입장은 LIVE_ENDING 상태에서 profile을 갱신한다`() {
+        val party = RealtimeParty(ownerId = 1L, startedAt = now.minusMinutes(10).minusSeconds(1))
+        val character = Character(name = "토끼")
+        val participant = Participant(party = party)
+        val profile =
+            RealtimeParticipantProfile(
+                participant = participant,
+                nickname = "기존닉네임",
+                character = null,
+                participantToken = "existing-token",
+            )
+        val reenterRequest =
+            EnterRealtimePartyRequest(
+                nickname = "새닉네임",
+                characterId = 1L,
+                participantToken = "existing-token",
+            )
+
+        whenever(characterService.requireCharacter(1L)).thenReturn(character)
+        whenever(
+            realtimeParticipantProfileService.requireByParticipantToken(
+                participantToken = "existing-token",
+                partyId = party.id,
+            ),
+        ).thenReturn(profile)
+
+        val result = adapter.resolve(party = party, userId = 99L, request = reenterRequest, now = now)
+
+        assertEquals("existing-token", result.participantToken)
+        assertEquals("새닉네임", profile.nickname)
+        assertEquals(character, profile.character)
+    }
+
+    @Test
+    fun `주최자는 participantToken 재입장으로 닉네임을 변경할 수 없다`() {
+        val party = RealtimeParty(ownerId = 1L, startedAt = now.minusMinutes(1))
+        val character = Character(name = "토끼")
+        val participant = Participant(party = party, isCelebrant = true)
+        val profile =
+            RealtimeParticipantProfile(
+                participant = participant,
+                nickname = "기존닉네임",
+                character = null,
+                participantToken = "existing-token",
+            )
+        val reenterRequest =
+            EnterRealtimePartyRequest(
+                nickname = "새닉네임",
+                characterId = 1L,
+                participantToken = "existing-token",
+            )
+
+        whenever(characterService.requireCharacter(1L)).thenReturn(character)
+        whenever(
+            realtimeParticipantProfileService.requireByParticipantToken(
+                participantToken = "existing-token",
+                partyId = party.id,
+            ),
+        ).thenReturn(profile)
+
+        val ex =
+            assertThrows<BusinessException> {
+                adapter.resolve(party = party, userId = 1L, request = reenterRequest, now = now)
+            }
+
+        assertEquals(ErrorCode.PARTY_HOST_NICKNAME_NOT_EDITABLE, ex.errorCode)
+        assertEquals("기존닉네임", profile.nickname)
+    }
+
+    @Test
+    fun `첫 입장은 주최자 여부로 닉네임 잠금 옵션을 전달한다`() {
+        val party = RealtimeParty(ownerId = 1L, startedAt = now.minusMinutes(1))
+        val character = Character(name = "토끼")
+        val participant = Participant(party = party, isCelebrant = false)
+        val profile = RealtimeParticipantProfile(participant = participant, nickname = "토끼왕", character = character)
+
+        whenever(characterService.requireCharacter(1L)).thenReturn(character)
+        whenever(participantService.resolveUser(null)).thenReturn(null)
+        whenever(participantService.joinAnonymousOrMember(party, null)).thenReturn(participant)
+        whenever(
+            realtimeParticipantProfileService.upsert(
+                participant = participant,
+                nickname = "토끼왕",
+                character = character,
+                isHostNicknameLocked = false,
+            ),
+        ).thenReturn(profile)
+
+        adapter.resolve(party = party, userId = null, request = request, now = now)
+
+        verify(realtimeParticipantProfileService).upsert(
+            participant = participant,
+            nickname = "토끼왕",
+            character = character,
+            isHostNicknameLocked = false,
+        )
+    }
+
+    private fun user(): User =
+        User(
+            name = "회원",
+            birthDay = "01-01",
+            provider = AuthProvider.KAKAO,
+            providerId = "member-1",
+            email = "member@example.com",
+        )
+}

--- a/src/test/kotlin/com/team2/server/chat/usecase/EnterRealtimePartyUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/chat/usecase/EnterRealtimePartyUseCaseTest.kt
@@ -3,9 +3,11 @@ package com.team2.server.chat.usecase
 import com.team2.server.chat.dto.EnterRealtimePartyRequest
 import com.team2.server.common.exception.BusinessException
 import com.team2.server.common.exception.ErrorCode
+import com.team2.server.party.application.event.RealtimePartyHostEnteredEvent
 import com.team2.server.party.application.service.CharacterService
 import com.team2.server.party.application.service.ParticipantService
 import com.team2.server.party.application.service.PartyInviteService
+import com.team2.server.party.application.service.PartyService
 import com.team2.server.party.application.service.RealtimeParticipantProfileService
 import com.team2.server.party.domain.entity.Character
 import com.team2.server.party.domain.entity.PaperOnlyParty
@@ -24,6 +26,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.springframework.context.ApplicationEventPublisher
 import java.time.Clock
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -36,9 +39,13 @@ class EnterRealtimePartyUseCaseTest {
 
     @Mock lateinit var participantService: ParticipantService
 
+    @Mock lateinit var partyService: PartyService
+
     @Mock lateinit var realtimeParticipantProfileService: RealtimeParticipantProfileService
 
     @Mock lateinit var characterService: CharacterService
+
+    @Mock lateinit var applicationEventPublisher: ApplicationEventPublisher
 
     lateinit var useCase: EnterRealtimePartyUseCase
 
@@ -53,8 +60,10 @@ class EnterRealtimePartyUseCaseTest {
             EnterRealtimePartyUseCase(
                 partyInviteService = partyInviteService,
                 participantService = participantService,
+                partyService = partyService,
                 realtimeParticipantProfileService = realtimeParticipantProfileService,
                 characterService = characterService,
+                applicationEventPublisher = applicationEventPublisher,
                 clock = clock,
             )
     }
@@ -146,6 +155,7 @@ class EnterRealtimePartyUseCaseTest {
         whenever(characterService.requireCharacter(1L)).thenReturn(character)
         whenever(participantService.resolveUser(1L)).thenReturn(user)
         whenever(participantService.joinAnonymousOrMember(party, user)).thenReturn(participant)
+        whenever(partyService.markHostEnteredIfAbsent(party.id, now)).thenReturn(true)
         whenever(
             realtimeParticipantProfileService.upsert(
                 participant = participant,
@@ -163,6 +173,14 @@ class EnterRealtimePartyUseCaseTest {
             character = character,
             isHostNicknameLocked = true,
         )
+        verify(partyService).markHostEnteredIfAbsent(party.id, now)
+        verify(applicationEventPublisher).publishEvent(
+            RealtimePartyHostEnteredEvent(
+                partyId = party.id,
+                hostEnteredAt = now,
+            ),
+        )
+        assertEquals(now, party.hostEnteredAt)
     }
 
     @Test

--- a/src/test/kotlin/com/team2/server/chat/usecase/EnterRealtimePartyUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/chat/usecase/EnterRealtimePartyUseCaseTest.kt
@@ -1,21 +1,16 @@
 package com.team2.server.chat.usecase
 
+import com.team2.server.chat.application.port.RealtimePartyEntryProfilePort
+import com.team2.server.chat.application.port.RealtimePartyEntryProfileResult
+import com.team2.server.chat.application.support.RealtimePartyEntryProfileResolver
 import com.team2.server.chat.dto.EnterRealtimePartyRequest
 import com.team2.server.common.exception.BusinessException
 import com.team2.server.common.exception.ErrorCode
-import com.team2.server.party.application.service.CharacterService
-import com.team2.server.party.application.service.ParticipantService
 import com.team2.server.party.application.service.PartyInviteService
-import com.team2.server.party.application.service.RealtimeParticipantProfileService
 import com.team2.server.party.application.usecase.MarkRealtimePartyHostEnteredUseCase
-import com.team2.server.party.domain.entity.Character
 import com.team2.server.party.domain.entity.PaperOnlyParty
-import com.team2.server.party.domain.entity.Participant
 import com.team2.server.party.domain.entity.PartyInvite
-import com.team2.server.party.domain.entity.RealtimeParticipantProfile
 import com.team2.server.party.domain.entity.RealtimeParty
-import com.team2.server.user.entity.AuthProvider
-import com.team2.server.user.entity.User
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -23,6 +18,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -36,11 +32,7 @@ import kotlin.test.assertNotNull
 class EnterRealtimePartyUseCaseTest {
     @Mock lateinit var partyInviteService: PartyInviteService
 
-    @Mock lateinit var participantService: ParticipantService
-
-    @Mock lateinit var realtimeParticipantProfileService: RealtimeParticipantProfileService
-
-    @Mock lateinit var characterService: CharacterService
+    @Mock lateinit var entryProfilePort: RealtimePartyEntryProfilePort
 
     @Mock lateinit var markRealtimePartyHostEnteredUseCase: MarkRealtimePartyHostEnteredUseCase
 
@@ -56,12 +48,7 @@ class EnterRealtimePartyUseCaseTest {
         useCase =
             EnterRealtimePartyUseCase(
                 partyInviteService = partyInviteService,
-                profileResolver =
-                    RealtimePartyEntryProfileResolver(
-                        participantService = participantService,
-                        realtimeParticipantProfileService = realtimeParticipantProfileService,
-                        characterService = characterService,
-                    ),
+                profileResolver = RealtimePartyEntryProfileResolver(entryProfilePort),
                 markRealtimePartyHostEnteredUseCase = markRealtimePartyHostEnteredUseCase,
                 clock = clock,
             )
@@ -110,7 +97,8 @@ class EnterRealtimePartyUseCaseTest {
         val party = RealtimeParty(ownerId = 1L, startedAt = now.minusMinutes(1))
         val invite = PartyInvite(party = party, token = "tok", expiresAt = now.plusDays(7))
         whenever(partyInviteService.findUsableInvite(any(), any())).thenReturn(invite)
-        whenever(characterService.requireCharacter(1L)).thenThrow(BusinessException(ErrorCode.CHARACTER_NOT_FOUND))
+        whenever(resolveEntry(party, userId = null, request))
+            .thenThrow(BusinessException(ErrorCode.CHARACTER_NOT_FOUND))
 
         val ex = assertThrows<BusinessException> { useCase.enter("tok", userId = null, request) }
         assertEquals(ErrorCode.CHARACTER_NOT_FOUND, ex.errorCode)
@@ -120,21 +108,8 @@ class EnterRealtimePartyUseCaseTest {
     fun `비로그인 사용자 첫 입장 - 익명 Participant + Profile 생성 후 token 반환`() {
         val party = RealtimeParty(ownerId = 1L, startedAt = now.minusMinutes(1))
         val invite = PartyInvite(party = party, token = "tok", expiresAt = now.plusDays(7))
-        val character = Character(name = "토끼")
-        val participant = Participant(party = party)
-        val profile = RealtimeParticipantProfile(participant = participant, nickname = "토끼왕", character = character)
-
         whenever(partyInviteService.findUsableInvite(any(), any())).thenReturn(invite)
-        whenever(characterService.requireCharacter(1L)).thenReturn(character)
-        whenever(participantService.joinAnonymousOrMember(party, null)).thenReturn(participant)
-        whenever(
-            realtimeParticipantProfileService.upsert(
-                participant = participant,
-                nickname = "토끼왕",
-                character = character,
-                isHostNicknameLocked = false,
-            ),
-        ).thenReturn(profile)
+        whenever(resolveEntry(party, userId = null, request)).thenReturn(entryResult())
 
         val result = useCase.enter("tok", userId = null, request)
 
@@ -142,36 +117,16 @@ class EnterRealtimePartyUseCaseTest {
     }
 
     @Test
-    fun `주최자 첫 채팅 입장은 닉네임 잠금 옵션을 적용한다`() {
+    fun `주최자 첫 채팅 입장은 주최자 입장 시각을 기록한다`() {
         val party = RealtimeParty(ownerId = 1L, startedAt = now.minusMinutes(1))
         val invite = PartyInvite(party = party, token = "tok", expiresAt = now.plusDays(7))
-        val character = Character(name = "토끼")
-        val participant = Participant(party = party, isCelebrant = true)
-        val profile = RealtimeParticipantProfile(participant = participant, nickname = "주최자", character = character)
-        val user = user()
 
         whenever(partyInviteService.findUsableInvite(any(), any())).thenReturn(invite)
-        whenever(characterService.requireCharacter(1L)).thenReturn(character)
-        whenever(participantService.resolveUser(1L)).thenReturn(user)
-        whenever(participantService.joinAnonymousOrMember(party, user)).thenReturn(participant)
+        whenever(resolveEntry(party, userId = 1L, request)).thenReturn(entryResult(isCelebrant = true))
         whenever(markRealtimePartyHostEnteredUseCase(party.id, now)).thenReturn(now)
-        whenever(
-            realtimeParticipantProfileService.upsert(
-                participant = participant,
-                nickname = "토끼왕",
-                character = character,
-                isHostNicknameLocked = true,
-            ),
-        ).thenReturn(profile)
 
         useCase.enter("tok", userId = 1L, request)
 
-        verify(realtimeParticipantProfileService).upsert(
-            participant = participant,
-            nickname = "토끼왕",
-            character = character,
-            isHostNicknameLocked = true,
-        )
         verify(markRealtimePartyHostEnteredUseCase).invoke(party.id, now)
         assertEquals(now, party.hostEnteredAt)
     }
@@ -180,21 +135,9 @@ class EnterRealtimePartyUseCaseTest {
     fun `주최자가 아니면 입장해도 주최자 입장 시각을 기록하지 않는다`() {
         val party = RealtimeParty(ownerId = 1L, startedAt = now.minusMinutes(1))
         val invite = PartyInvite(party = party, token = "tok", expiresAt = now.plusDays(7))
-        val character = Character(name = "토끼")
-        val participant = Participant(party = party, isCelebrant = false)
-        val profile = RealtimeParticipantProfile(participant = participant, nickname = "참여자", character = character)
 
         whenever(partyInviteService.findUsableInvite(any(), any())).thenReturn(invite)
-        whenever(characterService.requireCharacter(1L)).thenReturn(character)
-        whenever(participantService.joinAnonymousOrMember(party, null)).thenReturn(participant)
-        whenever(
-            realtimeParticipantProfileService.upsert(
-                participant = participant,
-                nickname = "토끼왕",
-                character = character,
-                isHostNicknameLocked = false,
-            ),
-        ).thenReturn(profile)
+        whenever(resolveEntry(party, userId = null, request)).thenReturn(entryResult(isCelebrant = false))
 
         useCase.enter("tok", userId = null, request)
 
@@ -207,24 +150,10 @@ class EnterRealtimePartyUseCaseTest {
         val existingHostEnteredAt = now.minusSeconds(10)
         val party = RealtimeParty(ownerId = 1L, startedAt = now.minusMinutes(1), hostEnteredAt = existingHostEnteredAt)
         val invite = PartyInvite(party = party, token = "tok", expiresAt = now.plusDays(7))
-        val character = Character(name = "토끼")
-        val participant = Participant(party = party, isCelebrant = true)
-        val profile = RealtimeParticipantProfile(participant = participant, nickname = "주최자", character = character)
-        val user = user()
 
         whenever(partyInviteService.findUsableInvite(any(), any())).thenReturn(invite)
-        whenever(characterService.requireCharacter(1L)).thenReturn(character)
-        whenever(participantService.resolveUser(1L)).thenReturn(user)
-        whenever(participantService.joinAnonymousOrMember(party, user)).thenReturn(participant)
+        whenever(resolveEntry(party, userId = 1L, request)).thenReturn(entryResult(isCelebrant = true))
         whenever(markRealtimePartyHostEnteredUseCase(party.id, now)).thenReturn(null)
-        whenever(
-            realtimeParticipantProfileService.upsert(
-                participant = participant,
-                nickname = "토끼왕",
-                character = character,
-                isHostNicknameLocked = true,
-            ),
-        ).thenReturn(profile)
 
         useCase.enter("tok", userId = 1L, request)
 
@@ -236,27 +165,9 @@ class EnterRealtimePartyUseCaseTest {
     fun `이미 프로필이 있는 사용자 재입장 - 기존 token 반환`() {
         val party = RealtimeParty(ownerId = 1L, startedAt = now.minusMinutes(1))
         val invite = PartyInvite(party = party, token = "tok", expiresAt = now.plusDays(7))
-        val character = Character(name = "토끼")
-        val participant = Participant(party = party)
-        val existingProfile =
-            RealtimeParticipantProfile(
-                participant = participant,
-                nickname = "기존닉네임",
-                character = null,
-                participantToken = "existing-uuid",
-            )
-
         whenever(partyInviteService.findUsableInvite(any(), any())).thenReturn(invite)
-        whenever(characterService.requireCharacter(1L)).thenReturn(character)
-        whenever(participantService.joinAnonymousOrMember(party, null)).thenReturn(participant)
-        whenever(
-            realtimeParticipantProfileService.upsert(
-                participant = participant,
-                nickname = "토끼왕",
-                character = character,
-                isHostNicknameLocked = false,
-            ),
-        ).thenReturn(existingProfile)
+        whenever(resolveEntry(party, userId = null, request))
+            .thenReturn(entryResult(participantToken = "existing-uuid"))
 
         val result = useCase.enter("tok", userId = null, request)
 
@@ -267,79 +178,65 @@ class EnterRealtimePartyUseCaseTest {
     fun `회원도 participantToken이 있으면 LIVE_ENDING에서 재입장할 수 있다`() {
         val party = RealtimeParty(ownerId = 1L, startedAt = now.minusMinutes(10).minusSeconds(1))
         val invite = PartyInvite(party = party, token = "tok", expiresAt = now.plusDays(7))
-        val character = Character(name = "토끼")
-        val participant = Participant(party = party)
-        val existingProfile =
-            RealtimeParticipantProfile(
-                participant = participant,
-                nickname = "기존닉네임",
-                character = null,
-                participantToken = "existing-uuid",
-            )
         val reenterRequest =
             EnterRealtimePartyRequest(
                 nickname = "새닉네임",
                 characterId = 1L,
-                participantToken = existingProfile.participantToken,
+                participantToken = "existing-uuid",
             )
 
         whenever(partyInviteService.findUsableInvite(any(), any())).thenReturn(invite)
-        whenever(characterService.requireCharacter(1L)).thenReturn(character)
-        whenever(
-            realtimeParticipantProfileService.requireByParticipantToken(
-                participantToken = existingProfile.participantToken,
-                partyId = party.id,
-            ),
-        ).thenReturn(existingProfile)
+        whenever(resolveEntry(party, userId = 99L, reenterRequest))
+            .thenReturn(entryResult(participantToken = "existing-uuid", nickname = "새닉네임"))
 
         val result = useCase.enter("tok", userId = 99L, reenterRequest)
 
         assertEquals("existing-uuid", result.participantToken)
-        assertEquals("새닉네임", existingProfile.nickname)
-        assertEquals(character, existingProfile.character)
+        assertEquals("새닉네임", result.nickname)
     }
 
     @Test
     fun `주최자는 participantToken 재입장으로 닉네임을 변경할 수 없다`() {
         val party = RealtimeParty(ownerId = 1L, startedAt = now.minusMinutes(1))
         val invite = PartyInvite(party = party, token = "tok", expiresAt = now.plusDays(7))
-        val character = Character(name = "토끼")
-        val participant = Participant(party = party, isCelebrant = true)
-        val existingProfile =
-            RealtimeParticipantProfile(
-                participant = participant,
-                nickname = "기존닉네임",
-                character = null,
-                participantToken = "existing-uuid",
-            )
         val reenterRequest =
             EnterRealtimePartyRequest(
                 nickname = "새닉네임",
                 characterId = 1L,
-                participantToken = existingProfile.participantToken,
+                participantToken = "existing-uuid",
             )
 
         whenever(partyInviteService.findUsableInvite(any(), any())).thenReturn(invite)
-        whenever(characterService.requireCharacter(1L)).thenReturn(character)
-        whenever(
-            realtimeParticipantProfileService.requireByParticipantToken(
-                participantToken = existingProfile.participantToken,
-                partyId = party.id,
-            ),
-        ).thenReturn(existingProfile)
+        whenever(resolveEntry(party, userId = 1L, reenterRequest))
+            .thenThrow(BusinessException(ErrorCode.PARTY_HOST_NICKNAME_NOT_EDITABLE))
 
         val ex = assertThrows<BusinessException> { useCase.enter("tok", userId = 1L, reenterRequest) }
 
         assertEquals(ErrorCode.PARTY_HOST_NICKNAME_NOT_EDITABLE, ex.errorCode)
-        assertEquals("기존닉네임", existingProfile.nickname)
     }
 
-    private fun user(): User =
-        User(
-            name = "회원",
-            birthDay = "01-01",
-            provider = AuthProvider.KAKAO,
-            providerId = "member-1",
-            email = "member@example.com",
+    private fun resolveEntry(
+        party: RealtimeParty,
+        userId: Long?,
+        request: EnterRealtimePartyRequest,
+    ): RealtimePartyEntryProfileResult =
+        entryProfilePort.resolve(
+            party = eq(party),
+            userId = eq(userId),
+            request = eq(request),
+            now = eq(now),
+        )
+
+    private fun entryResult(
+        participantToken: String = "participant-token",
+        isCelebrant: Boolean = false,
+        nickname: String = "토끼왕",
+        characterId: Long? = 1L,
+    ): RealtimePartyEntryProfileResult =
+        RealtimePartyEntryProfileResult(
+            participantToken = participantToken,
+            isCelebrant = isCelebrant,
+            nickname = nickname,
+            characterId = characterId,
         )
 }

--- a/src/test/kotlin/com/team2/server/chat/usecase/EnterRealtimePartyUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/chat/usecase/EnterRealtimePartyUseCaseTest.kt
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.time.Clock
@@ -173,6 +174,62 @@ class EnterRealtimePartyUseCaseTest {
         )
         verify(markRealtimePartyHostEnteredUseCase).invoke(party.id, now)
         assertEquals(now, party.hostEnteredAt)
+    }
+
+    @Test
+    fun `주최자가 아니면 입장해도 주최자 입장 시각을 기록하지 않는다`() {
+        val party = RealtimeParty(ownerId = 1L, startedAt = now.minusMinutes(1))
+        val invite = PartyInvite(party = party, token = "tok", expiresAt = now.plusDays(7))
+        val character = Character(name = "토끼")
+        val participant = Participant(party = party, isCelebrant = false)
+        val profile = RealtimeParticipantProfile(participant = participant, nickname = "참여자", character = character)
+
+        whenever(partyInviteService.findUsableInvite(any(), any())).thenReturn(invite)
+        whenever(characterService.requireCharacter(1L)).thenReturn(character)
+        whenever(participantService.joinAnonymousOrMember(party, null)).thenReturn(participant)
+        whenever(
+            realtimeParticipantProfileService.upsert(
+                participant = participant,
+                nickname = "토끼왕",
+                character = character,
+                isHostNicknameLocked = false,
+            ),
+        ).thenReturn(profile)
+
+        useCase.enter("tok", userId = null, request)
+
+        verify(markRealtimePartyHostEnteredUseCase, never()).invoke(any(), any())
+        assertEquals(null, party.hostEnteredAt)
+    }
+
+    @Test
+    fun `주최자 입장 시각이 이미 저장되어 있으면 기존 값을 유지한다`() {
+        val existingHostEnteredAt = now.minusSeconds(10)
+        val party = RealtimeParty(ownerId = 1L, startedAt = now.minusMinutes(1), hostEnteredAt = existingHostEnteredAt)
+        val invite = PartyInvite(party = party, token = "tok", expiresAt = now.plusDays(7))
+        val character = Character(name = "토끼")
+        val participant = Participant(party = party, isCelebrant = true)
+        val profile = RealtimeParticipantProfile(participant = participant, nickname = "주최자", character = character)
+        val user = user()
+
+        whenever(partyInviteService.findUsableInvite(any(), any())).thenReturn(invite)
+        whenever(characterService.requireCharacter(1L)).thenReturn(character)
+        whenever(participantService.resolveUser(1L)).thenReturn(user)
+        whenever(participantService.joinAnonymousOrMember(party, user)).thenReturn(participant)
+        whenever(markRealtimePartyHostEnteredUseCase(party.id, now)).thenReturn(null)
+        whenever(
+            realtimeParticipantProfileService.upsert(
+                participant = participant,
+                nickname = "토끼왕",
+                character = character,
+                isHostNicknameLocked = true,
+            ),
+        ).thenReturn(profile)
+
+        useCase.enter("tok", userId = 1L, request)
+
+        verify(markRealtimePartyHostEnteredUseCase).invoke(party.id, now)
+        assertEquals(existingHostEnteredAt, party.hostEnteredAt)
     }
 
     @Test

--- a/src/test/kotlin/com/team2/server/chat/usecase/EnterRealtimePartyUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/chat/usecase/EnterRealtimePartyUseCaseTest.kt
@@ -3,12 +3,11 @@ package com.team2.server.chat.usecase
 import com.team2.server.chat.dto.EnterRealtimePartyRequest
 import com.team2.server.common.exception.BusinessException
 import com.team2.server.common.exception.ErrorCode
-import com.team2.server.party.application.event.RealtimePartyHostEnteredEvent
 import com.team2.server.party.application.service.CharacterService
 import com.team2.server.party.application.service.ParticipantService
 import com.team2.server.party.application.service.PartyInviteService
-import com.team2.server.party.application.service.PartyService
 import com.team2.server.party.application.service.RealtimeParticipantProfileService
+import com.team2.server.party.application.usecase.MarkRealtimePartyHostEnteredUseCase
 import com.team2.server.party.domain.entity.Character
 import com.team2.server.party.domain.entity.PaperOnlyParty
 import com.team2.server.party.domain.entity.Participant
@@ -26,7 +25,6 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.springframework.context.ApplicationEventPublisher
 import java.time.Clock
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -39,13 +37,11 @@ class EnterRealtimePartyUseCaseTest {
 
     @Mock lateinit var participantService: ParticipantService
 
-    @Mock lateinit var partyService: PartyService
-
     @Mock lateinit var realtimeParticipantProfileService: RealtimeParticipantProfileService
 
     @Mock lateinit var characterService: CharacterService
 
-    @Mock lateinit var applicationEventPublisher: ApplicationEventPublisher
+    @Mock lateinit var markRealtimePartyHostEnteredUseCase: MarkRealtimePartyHostEnteredUseCase
 
     lateinit var useCase: EnterRealtimePartyUseCase
 
@@ -59,11 +55,13 @@ class EnterRealtimePartyUseCaseTest {
         useCase =
             EnterRealtimePartyUseCase(
                 partyInviteService = partyInviteService,
-                participantService = participantService,
-                partyService = partyService,
-                realtimeParticipantProfileService = realtimeParticipantProfileService,
-                characterService = characterService,
-                applicationEventPublisher = applicationEventPublisher,
+                profileResolver =
+                    RealtimePartyEntryProfileResolver(
+                        participantService = participantService,
+                        realtimeParticipantProfileService = realtimeParticipantProfileService,
+                        characterService = characterService,
+                    ),
+                markRealtimePartyHostEnteredUseCase = markRealtimePartyHostEnteredUseCase,
                 clock = clock,
             )
     }
@@ -155,7 +153,7 @@ class EnterRealtimePartyUseCaseTest {
         whenever(characterService.requireCharacter(1L)).thenReturn(character)
         whenever(participantService.resolveUser(1L)).thenReturn(user)
         whenever(participantService.joinAnonymousOrMember(party, user)).thenReturn(participant)
-        whenever(partyService.markHostEnteredIfAbsent(party.id, now)).thenReturn(true)
+        whenever(markRealtimePartyHostEnteredUseCase(party.id, now)).thenReturn(now)
         whenever(
             realtimeParticipantProfileService.upsert(
                 participant = participant,
@@ -173,13 +171,7 @@ class EnterRealtimePartyUseCaseTest {
             character = character,
             isHostNicknameLocked = true,
         )
-        verify(partyService).markHostEnteredIfAbsent(party.id, now)
-        verify(applicationEventPublisher).publishEvent(
-            RealtimePartyHostEnteredEvent(
-                partyId = party.id,
-                hostEnteredAt = now,
-            ),
-        )
+        verify(markRealtimePartyHostEnteredUseCase).invoke(party.id, now)
         assertEquals(now, party.hostEnteredAt)
     }
 

--- a/src/test/kotlin/com/team2/server/db/FlywayMigrationTest.kt
+++ b/src/test/kotlin/com/team2/server/db/FlywayMigrationTest.kt
@@ -28,6 +28,10 @@ class FlywayMigrationTest {
                 ColumnDefinition(dataType = "datetime", datetimePrecision = 6, nullable = true),
                 connection.findColumn("realtime_party", "live_ending_started_at"),
             )
+            assertEquals(
+                ColumnDefinition(dataType = "datetime", datetimePrecision = 6, nullable = true),
+                connection.findColumn("realtime_party", "host_entered_at"),
+            )
         }
     }
 

--- a/src/test/kotlin/com/team2/server/party/application/usecase/FindRealtimePartiesWithHostEnteredUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/party/application/usecase/FindRealtimePartiesWithHostEnteredUseCaseTest.kt
@@ -1,0 +1,35 @@
+package com.team2.server.party.application.usecase
+
+import com.team2.server.party.application.dto.RealtimePartyHostEnteredScheduleData
+import com.team2.server.party.application.service.PartyService
+import com.team2.server.party.domain.entity.RealtimeParty
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.LocalDateTime
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FindRealtimePartiesWithHostEnteredUseCaseTest {
+    private val partyService: PartyService = mock()
+    private val useCase = FindRealtimePartiesWithHostEnteredUseCase(partyService)
+
+    @Test
+    fun `주최자 입장 시각이 있는 실시간 파티를 스케줄 데이터로 변환한다`() {
+        val hostEnteredAfter = LocalDateTime.of(2026, 5, 24, 19, 55)
+        val hostEnteredAt = LocalDateTime.of(2026, 5, 24, 20, 0)
+        val party =
+            RealtimeParty(
+                ownerId = 1L,
+                startedAt = hostEnteredAt.minusMinutes(1),
+                hostEnteredAt = hostEnteredAt,
+            )
+        whenever(partyService.findRealtimePartiesWithHostEnteredAfter(hostEnteredAfter))
+            .thenReturn(listOf(party))
+
+        val result = useCase(hostEnteredAfter)
+
+        assertEquals(listOf(RealtimePartyHostEnteredScheduleData.from(party)), result)
+        verify(partyService).findRealtimePartiesWithHostEnteredAfter(hostEnteredAfter)
+    }
+}

--- a/src/test/kotlin/com/team2/server/party/application/usecase/MarkRealtimePartyHostEnteredUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/party/application/usecase/MarkRealtimePartyHostEnteredUseCaseTest.kt
@@ -1,0 +1,40 @@
+package com.team2.server.party.application.usecase
+
+import com.team2.server.party.application.event.RealtimePartyHostEnteredEventPublisher
+import com.team2.server.party.application.service.PartyService
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.LocalDateTime
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class MarkRealtimePartyHostEnteredUseCaseTest {
+    private val partyService: PartyService = mock()
+    private val eventPublisher: RealtimePartyHostEnteredEventPublisher = mock()
+    private val useCase = MarkRealtimePartyHostEnteredUseCase(partyService, eventPublisher)
+
+    @Test
+    fun `주최자 입장 시각을 처음 저장하면 이벤트를 발행한다`() {
+        val hostEnteredAt = LocalDateTime.of(2026, 5, 24, 20, 0)
+        whenever(partyService.markHostEnteredIfAbsent(1L, hostEnteredAt)).thenReturn(true)
+
+        val result = useCase(partyId = 1L, hostEnteredAt = hostEnteredAt)
+
+        assertEquals(hostEnteredAt, result)
+        verify(eventPublisher).publish(partyId = 1L, hostEnteredAt = hostEnteredAt)
+    }
+
+    @Test
+    fun `이미 저장되어 있으면 이벤트를 발행하지 않는다`() {
+        val hostEnteredAt = LocalDateTime.of(2026, 5, 24, 20, 0)
+        whenever(partyService.markHostEnteredIfAbsent(1L, hostEnteredAt)).thenReturn(false)
+
+        val result = useCase(partyId = 1L, hostEnteredAt = hostEnteredAt)
+
+        assertNull(result)
+        verify(eventPublisher, never()).publish(partyId = 1L, hostEnteredAt = hostEnteredAt)
+    }
+}

--- a/src/test/kotlin/com/team2/server/party/infrastructure/persistence/PartyRepositoryTest.kt
+++ b/src/test/kotlin/com/team2/server/party/infrastructure/persistence/PartyRepositoryTest.kt
@@ -1,0 +1,82 @@
+package com.team2.server.party.infrastructure.persistence
+
+import com.team2.server.party.domain.entity.RealtimeParty
+import com.team2.server.support.JpaSliceTestSupport
+import jakarta.persistence.EntityManager
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.time.LocalDateTime
+import kotlin.test.assertEquals
+
+class PartyRepositoryTest
+    @Autowired
+    constructor(
+        private val partyRepository: PartyRepository,
+        private val entityManager: EntityManager,
+    ) : JpaSliceTestSupport() {
+        @Test
+        fun `markHostEnteredIfAbsent는 hostEnteredAt을 한 번만 저장한다`() {
+            val party = partyRepository.save(realtimeParty(startedAt = BASE_TIME.minusMinutes(1)))
+            val firstHostEnteredAt = BASE_TIME
+            val secondHostEnteredAt = BASE_TIME.plusSeconds(5)
+
+            val firstUpdated = partyRepository.markHostEnteredIfAbsent(party.id, firstHostEnteredAt)
+            val secondUpdated = partyRepository.markHostEnteredIfAbsent(party.id, secondHostEnteredAt)
+            entityManager.flush()
+            entityManager.clear()
+
+            val found = partyRepository.findById(party.id).orElseThrow() as RealtimeParty
+            assertEquals(1, firstUpdated)
+            assertEquals(0, secondUpdated)
+            assertEquals(firstHostEnteredAt, found.hostEnteredAt)
+        }
+
+        @Test
+        fun `findRealtimePartiesWithHostEnteredAfter는 진행 중이고 주최자 입장 시각이 기준 이후인 파티만 찾는다`() {
+            val hostEnteredAfter = BASE_TIME.minusMinutes(5)
+            val target =
+                partyRepository.save(
+                    realtimeParty(
+                        startedAt = BASE_TIME.minusMinutes(1),
+                        hostEnteredAt = BASE_TIME,
+                    ),
+                )
+            partyRepository.save(
+                realtimeParty(
+                    startedAt = BASE_TIME.minusMinutes(10),
+                    hostEnteredAt = hostEnteredAfter.minusNanos(1),
+                ),
+            )
+            partyRepository.save(realtimeParty(startedAt = BASE_TIME.minusMinutes(1)))
+            partyRepository.save(
+                realtimeParty(
+                    startedAt = BASE_TIME.minusMinutes(1),
+                    liveEndingStartedAt = BASE_TIME.minusSeconds(30),
+                    hostEnteredAt = BASE_TIME,
+                ),
+            )
+            entityManager.flush()
+            entityManager.clear()
+
+            val result = partyRepository.findRealtimePartiesWithHostEnteredAfter(hostEnteredAfter)
+
+            assertEquals(listOf(target.id), result.map { it.id })
+        }
+
+        private fun realtimeParty(
+            startedAt: LocalDateTime,
+            liveEndingStartedAt: LocalDateTime? = null,
+            hostEnteredAt: LocalDateTime? = null,
+        ): RealtimeParty =
+            RealtimeParty(
+                ownerId = 1L,
+                name = "테스트파티",
+                startedAt = startedAt,
+                liveEndingStartedAt = liveEndingStartedAt,
+                hostEnteredAt = hostEnteredAt,
+            )
+
+        private companion object {
+            val BASE_TIME: LocalDateTime = LocalDateTime.of(2026, 5, 24, 20, 0)
+        }
+    }


### PR DESCRIPTION
## 🔗 Issue
- closes #193

## 💬 Context
주최자가 실시간 파티에 실제로 입장한 뒤 41초부터 촛불끄기가 시작되도록 기준 시각을 `party.startedAt`에서 `hostEnteredAt`으로 변경합니다.
개발 검증 편의를 위해 기본/개발 환경은 5분 timeout을 유지하고, 운영 환경은 45초 timeout을 사용합니다.

## 🛠 Changes
- `realtime_party.host_entered_at` 컬럼과 Flyway 마이그레이션 추가
- 주최자 최초 입장 시각 저장 및 `hostEnteredAt + 41초` 기준 촛불끄기 스케줄링/복구 적용
- `candle-blow.duration-seconds` 설정 추가 및 prod 45초 override 적용
- party UseCase/DTO 경유로 촛불 복구 경계를 정리하고 컴파일타임 duration 상수 제거
- 촛불/입장/Flyway 관련 테스트와 설계 문서 갱신

## 👀 Review Focus
- 주최자 최초 입장 저장이 한 번만 수행되고 이벤트가 중복 발행되지 않는지
- 서버 재시작 후 `hostEnteredAt` 기반 촛불 스케줄 복구가 의도대로 동작하는지
- 기본/개발 5분, 운영 45초 timeout 설정 분리가 적절한지
- Flyway 마이그레이션과 엔티티 컬럼 추가가 같은 PR에 포함된 점이 배포 순서상 적절한지

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 호스트 입장 시각 기반으로 촛불 끄기 타이밍 조정
  * 환경별 게임 지속 시간 설정 가능화 (개발: 300초, 운영: 45초)
  * 서버 재시작 후 게임 스케줄 복구 기능 개선

* **Bug Fixes**
  * 호스트 미입장 시 촛불 끄기 요청 에러 처리 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/18th-team2-server/pull/195?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->