### PR TITLE
[Feat] 폭죽 애니메이션 broadcast API 구현

### DIFF
--- a/src/main/kotlin/com/team2/server/auth/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/team2/server/auth/config/SecurityConfig.kt
@@ -66,6 +66,7 @@ class SecurityConfig(
                 auth.requestMatchers(HttpMethod.POST, "/api/v1/parties/*/candle-blow/candles/*").permitAll()
                 auth.requestMatchers(HttpMethod.POST, "/api/v1/parties/*/burst-game/start").permitAll()
                 auth.requestMatchers(HttpMethod.POST, "/api/v1/parties/*/burst-game/taps").permitAll()
+                auth.requestMatchers(HttpMethod.POST, "/api/v1/parties/*/fireworks").permitAll()
                 auth.requestMatchers(HttpMethod.GET, "/api/v1/parties/*/burst-game").permitAll()
                 auth.requestMatchers(HttpMethod.GET, "/api/v1/parties/*/realtime-state").permitAll()
                 auth.requestMatchers(HttpMethod.GET, "/api/v1/parties/*/realtime-next-action").permitAll()

--- a/src/main/kotlin/com/team2/server/common/image/application/port/ImageUrlPort.kt
+++ b/src/main/kotlin/com/team2/server/common/image/application/port/ImageUrlPort.kt
@@ -1,0 +1,10 @@
+package com.team2.server.common.image.application.port
+
+import com.team2.server.common.image.entity.ImageTargetType
+
+interface ImageUrlPort {
+    fun findFirstImageUrlByTargetIds(
+        targetType: ImageTargetType,
+        targetIds: Collection<Long>,
+    ): Map<Long, String>
+}

--- a/src/main/kotlin/com/team2/server/common/image/persistence/ImageUrlReader.kt
+++ b/src/main/kotlin/com/team2/server/common/image/persistence/ImageUrlReader.kt
@@ -1,13 +1,14 @@
 package com.team2.server.common.image.persistence
 
+import com.team2.server.common.image.application.port.ImageUrlPort
 import com.team2.server.common.image.entity.ImageTargetType
 import org.springframework.stereotype.Component
 
 @Component
 class ImageUrlReader(
     private val imageRepository: ImageRepository,
-) {
-    fun findFirstImageUrlByTargetIds(
+) : ImageUrlPort {
+    override fun findFirstImageUrlByTargetIds(
         targetType: ImageTargetType,
         targetIds: Collection<Long>,
     ): Map<Long, String> {

--- a/src/main/kotlin/com/team2/server/fireworks/api/FireworksApi.kt
+++ b/src/main/kotlin/com/team2/server/fireworks/api/FireworksApi.kt
@@ -27,11 +27,7 @@ event: fireworks
 data: {
   "partyId": 1,
   "participantId": 5,
-  "nickname": "토끼왕",
-  "characterId": 2,
-  "characterImageUrl": "https://cdn.example.com/char2.png",
-  "role": "PARTICIPANT",
-  "serverTime": "2026-05-29T10:00:00"
+  "nickname": "토끼왕"
 }
 ```
 """,

--- a/src/main/kotlin/com/team2/server/fireworks/api/FireworksApi.kt
+++ b/src/main/kotlin/com/team2/server/fireworks/api/FireworksApi.kt
@@ -1,0 +1,108 @@
+package com.team2.server.fireworks.api
+
+import com.team2.server.auth.principal.UserPrincipal
+import com.team2.server.common.web.ErrorResponse
+import com.team2.server.common.web.swagger.InternalServerErrorResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.enums.ParameterIn
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.tags.Tag
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
+
+@Tag(name = "Fireworks", description = "폭죽 애니메이션 API")
+interface FireworksApi {
+    @Operation(
+        summary = "폭죽 트리거",
+        description = """
+파티 참가자가 폭죽 아이콘을 클릭하면 해당 파티의 모든 SSE 구독자에게 `fireworks` 이벤트를 broadcast합니다.
+
+**인증:** 로그인 사용자는 `Authorization: Bearer {token}`, 비로그인 참여자는 `X-Participant-Token: {token}` 헤더 사용.
+
+**broadcast되는 SSE 이벤트**
+```
+event: fireworks
+data: {
+  "partyId": 1,
+  "participantId": 5,
+  "nickname": "토끼왕",
+  "characterId": 2,
+  "characterImageUrl": "https://cdn.example.com/char2.png",
+  "role": "PARTICIPANT",
+  "serverTime": "2026-05-29T10:00:00"
+}
+```
+""",
+    )
+    @SwaggerApiResponse(responseCode = "204", description = "폭죽 트리거 성공")
+    @SwaggerApiResponse(
+        responseCode = "400",
+        description = "파티가 LIVE_OPEN 상태가 아님",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = ErrorResponse::class),
+                examples = [
+                    ExampleObject(
+                        value =
+                            """{"status":400,"error":{"code":"CHAT_NOT_ACTIVE","message":"현재 채팅이 활성화된 시간이 아닙니다"}}""",
+                    ),
+                ],
+            ),
+        ],
+    )
+    @SwaggerApiResponse(
+        responseCode = "401",
+        description = "인증 실패",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = ErrorResponse::class),
+                examples = [
+                    ExampleObject(
+                        value = """{"status":401,"error":{"code":"UNAUTHORIZED","message":"로그인이 필요합니다"}}""",
+                    ),
+                ],
+            ),
+        ],
+    )
+    @SwaggerApiResponse(
+        responseCode = "403",
+        description = "파티 참가자가 아님",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = ErrorResponse::class),
+                examples = [
+                    ExampleObject(
+                        value = """{"status":403,"error":{"code":"PARTY_FORBIDDEN","message":"파티에 대한 권한이 없습니다"}}""",
+                    ),
+                ],
+            ),
+        ],
+    )
+    @SwaggerApiResponse(
+        responseCode = "404",
+        description = "파티 없음",
+        content = [
+            Content(
+                mediaType = "application/json",
+                schema = Schema(implementation = ErrorResponse::class),
+                examples = [
+                    ExampleObject(
+                        value = """{"status":404,"error":{"code":"PARTY_NOT_FOUND","message":"파티를 찾을 수 없습니다"}}""",
+                    ),
+                ],
+            ),
+        ],
+    )
+    @InternalServerErrorResponse
+    fun triggerFireworks(
+        @Parameter(description = "파티 ID") partyId: Long,
+        @Parameter(hidden = true) principal: UserPrincipal?,
+        @Parameter(description = "비로그인 참여자 토큰", `in` = ParameterIn.HEADER, name = "X-Participant-Token")
+        participantToken: String?,
+    )
+}

--- a/src/main/kotlin/com/team2/server/fireworks/api/FireworksController.kt
+++ b/src/main/kotlin/com/team2/server/fireworks/api/FireworksController.kt
@@ -1,0 +1,26 @@
+package com.team2.server.fireworks.api
+
+import com.team2.server.auth.principal.UserPrincipal
+import com.team2.server.fireworks.application.usecase.TriggerFireworksUseCase
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class FireworksController(
+    private val triggerFireworksUseCase: TriggerFireworksUseCase,
+) : FireworksApi {
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PostMapping("/api/v1/parties/{partyId}/fireworks")
+    override fun triggerFireworks(
+        @PathVariable partyId: Long,
+        @AuthenticationPrincipal principal: UserPrincipal?,
+        @RequestHeader(value = "X-Participant-Token", required = false) participantToken: String?,
+    ) {
+        triggerFireworksUseCase.invoke(partyId, principal?.userId, participantToken)
+    }
+}

--- a/src/main/kotlin/com/team2/server/fireworks/application/dto/FireworksPayload.kt
+++ b/src/main/kotlin/com/team2/server/fireworks/application/dto/FireworksPayload.kt
@@ -1,0 +1,7 @@
+package com.team2.server.fireworks.application.dto
+
+data class FireworksPayload(
+    val partyId: Long,
+    val participantId: Long,
+    val nickname: String,
+)

--- a/src/main/kotlin/com/team2/server/fireworks/application/usecase/TriggerFireworksUseCase.kt
+++ b/src/main/kotlin/com/team2/server/fireworks/application/usecase/TriggerFireworksUseCase.kt
@@ -1,0 +1,66 @@
+package com.team2.server.fireworks.application.usecase
+
+import com.team2.server.chat.application.port.PartySseEventPublisher
+import com.team2.server.common.image.entity.ImageTargetType
+import com.team2.server.common.image.persistence.ImageUrlReader
+import com.team2.server.party.application.usecase.ResolveLiveOpenRealtimePartyUseCase
+import com.team2.server.party.application.usecase.ResolveRealtimeParticipantProfileUseCase
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import java.time.Clock
+import java.time.LocalDateTime
+
+@Service
+class TriggerFireworksUseCase(
+    private val resolveLiveOpenRealtimePartyUseCase: ResolveLiveOpenRealtimePartyUseCase,
+    private val resolveRealtimeParticipantProfileUseCase: ResolveRealtimeParticipantProfileUseCase,
+    private val imageUrlReader: ImageUrlReader,
+    private val partySseEventPublisher: PartySseEventPublisher,
+    private val clock: Clock,
+) {
+    @Transactional(readOnly = true)
+    fun invoke(
+        partyId: Long,
+        userId: Long?,
+        participantToken: String?,
+    ) {
+        resolveLiveOpenRealtimePartyUseCase.invoke(partyId)
+        val profile = resolveRealtimeParticipantProfileUseCase.invoke(partyId, userId, participantToken)
+
+        val characterImageUrl =
+            profile.character?.id?.let {
+                imageUrlReader.findFirstImageUrlByTargetIds(ImageTargetType.CHARACTER, listOf(it))[it]
+            }
+
+        val payload =
+            FireworksPayload(
+                partyId = partyId,
+                participantId = profile.participant.id,
+                nickname = profile.nickname,
+                characterId = profile.character?.id,
+                characterImageUrl = characterImageUrl,
+                role = if (profile.participant.isCelebrant) "CELEBRANT" else "PARTICIPANT",
+                serverTime = LocalDateTime.now(clock),
+            )
+
+        partySseEventPublisher.broadcastAfterCommit(
+            partyId,
+            SseEmitter
+                .event()
+                .name("fireworks")
+                .data(payload)
+                .build(),
+        )
+    }
+
+    data class FireworksPayload(
+        val partyId: Long,
+        val participantId: Long,
+        val nickname: String,
+        val characterId: Long?,
+        val characterImageUrl: String?,
+        val role: String,
+        val serverTime: LocalDateTime,
+    )
+}

--- a/src/main/kotlin/com/team2/server/fireworks/application/usecase/TriggerFireworksUseCase.kt
+++ b/src/main/kotlin/com/team2/server/fireworks/application/usecase/TriggerFireworksUseCase.kt
@@ -1,23 +1,18 @@
 package com.team2.server.fireworks.application.usecase
 
 import com.team2.server.chat.application.port.PartySseEventPublisher
-import com.team2.server.common.image.entity.ImageTargetType
-import com.team2.server.common.image.persistence.ImageUrlReader
+import com.team2.server.fireworks.application.dto.FireworksPayload
 import com.team2.server.party.application.usecase.ResolveLiveOpenRealtimePartyUseCase
 import com.team2.server.party.application.usecase.ResolveRealtimeParticipantProfileUseCase
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
-import java.time.Clock
-import java.time.LocalDateTime
 
 @Service
 class TriggerFireworksUseCase(
     private val resolveLiveOpenRealtimePartyUseCase: ResolveLiveOpenRealtimePartyUseCase,
     private val resolveRealtimeParticipantProfileUseCase: ResolveRealtimeParticipantProfileUseCase,
-    private val imageUrlReader: ImageUrlReader,
     private val partySseEventPublisher: PartySseEventPublisher,
-    private val clock: Clock,
 ) {
     @Transactional(readOnly = true)
     fun invoke(
@@ -28,20 +23,11 @@ class TriggerFireworksUseCase(
         resolveLiveOpenRealtimePartyUseCase.invoke(partyId)
         val profile = resolveRealtimeParticipantProfileUseCase.invoke(partyId, userId, participantToken)
 
-        val characterImageUrl =
-            profile.character?.id?.let {
-                imageUrlReader.findFirstImageUrlByTargetIds(ImageTargetType.CHARACTER, listOf(it))[it]
-            }
-
         val payload =
             FireworksPayload(
                 partyId = partyId,
                 participantId = profile.participant.id,
                 nickname = profile.nickname,
-                characterId = profile.character?.id,
-                characterImageUrl = characterImageUrl,
-                role = if (profile.participant.isCelebrant) "CELEBRANT" else "PARTICIPANT",
-                serverTime = LocalDateTime.now(clock),
             )
 
         partySseEventPublisher.broadcastAfterCommit(
@@ -53,14 +39,4 @@ class TriggerFireworksUseCase(
                 .build(),
         )
     }
-
-    data class FireworksPayload(
-        val partyId: Long,
-        val participantId: Long,
-        val nickname: String,
-        val characterId: Long?,
-        val characterImageUrl: String?,
-        val role: String,
-        val serverTime: LocalDateTime,
-    )
 }

--- a/src/test/kotlin/com/team2/server/fireworks/application/usecase/TriggerFireworksUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/fireworks/application/usecase/TriggerFireworksUseCaseTest.kt
@@ -1,0 +1,134 @@
+package com.team2.server.fireworks.application.usecase
+
+import com.team2.server.chat.application.port.PartySseEventPublisher
+import com.team2.server.common.exception.BusinessException
+import com.team2.server.common.exception.ErrorCode
+import com.team2.server.common.image.entity.ImageTargetType
+import com.team2.server.common.image.persistence.ImageUrlReader
+import com.team2.server.party.application.usecase.ResolveLiveOpenRealtimePartyUseCase
+import com.team2.server.party.application.usecase.ResolveRealtimeParticipantProfileUseCase
+import com.team2.server.party.domain.entity.Character
+import com.team2.server.party.domain.entity.Participant
+import com.team2.server.party.domain.entity.RealtimeParticipantProfile
+import com.team2.server.party.domain.entity.RealtimeParty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import kotlin.test.assertEquals
+
+@ExtendWith(MockitoExtension::class)
+class TriggerFireworksUseCaseTest {
+    @Mock lateinit var resolveLiveOpenRealtimePartyUseCase: ResolveLiveOpenRealtimePartyUseCase
+
+    @Mock lateinit var resolveRealtimeParticipantProfileUseCase: ResolveRealtimeParticipantProfileUseCase
+
+    @Mock lateinit var imageUrlReader: ImageUrlReader
+
+    @Mock lateinit var partySseEventPublisher: PartySseEventPublisher
+
+    private val fixedClock: Clock = Clock.fixed(Instant.parse("2026-05-29T10:00:00Z"), ZoneId.of("Asia/Seoul"))
+
+    private lateinit var useCase: TriggerFireworksUseCase
+
+    @BeforeEach
+    fun setUp() {
+        useCase =
+            TriggerFireworksUseCase(
+                resolveLiveOpenRealtimePartyUseCase = resolveLiveOpenRealtimePartyUseCase,
+                resolveRealtimeParticipantProfileUseCase = resolveRealtimeParticipantProfileUseCase,
+                imageUrlReader = imageUrlReader,
+                partySseEventPublisher = partySseEventPublisher,
+                clock = fixedClock,
+            )
+    }
+
+    private fun makeParty(): RealtimeParty = mock()
+
+    private fun makeProfile(
+        participantId: Long = 1L,
+        nickname: String = "토끼왕",
+        isCelebrant: Boolean = false,
+        character: Character? = null,
+    ): RealtimeParticipantProfile {
+        val participant: Participant = mock()
+        whenever(participant.id).thenReturn(participantId)
+        whenever(participant.isCelebrant).thenReturn(isCelebrant)
+
+        val profile: RealtimeParticipantProfile = mock()
+        whenever(profile.participant).thenReturn(participant)
+        whenever(profile.nickname).thenReturn(nickname)
+        whenever(profile.character).thenReturn(character)
+        return profile
+    }
+
+    @Test
+    fun `파티가 LIVE_OPEN이 아니면 CHAT_NOT_ACTIVE를 던진다`() {
+        whenever(resolveLiveOpenRealtimePartyUseCase.invoke(10L))
+            .thenThrow(BusinessException(ErrorCode.CHAT_NOT_ACTIVE))
+
+        val ex = assertThrows<BusinessException> { useCase.invoke(10L, null, "tok") }
+        assertEquals(ErrorCode.CHAT_NOT_ACTIVE, ex.errorCode)
+    }
+
+    @Test
+    fun `파티 참가자가 아니면 PARTY_FORBIDDEN을 던진다`() {
+        whenever(resolveLiveOpenRealtimePartyUseCase.invoke(10L)).thenReturn(makeParty())
+        whenever(resolveRealtimeParticipantProfileUseCase.invoke(10L, null, "tok"))
+            .thenThrow(BusinessException(ErrorCode.PARTY_FORBIDDEN))
+
+        val ex = assertThrows<BusinessException> { useCase.invoke(10L, null, "tok") }
+        assertEquals(ErrorCode.PARTY_FORBIDDEN, ex.errorCode)
+    }
+
+    @Test
+    fun `참가자가 폭죽을 트리거하면 SSE fireworks 이벤트가 broadcast된다`() {
+        val character: Character = mock()
+        whenever(character.id).thenReturn(2L)
+        val profile = makeProfile(participantId = 5L, nickname = "토끼왕", isCelebrant = false, character = character)
+
+        whenever(resolveLiveOpenRealtimePartyUseCase.invoke(10L)).thenReturn(makeParty())
+        whenever(resolveRealtimeParticipantProfileUseCase.invoke(10L, null, "tok")).thenReturn(profile)
+        whenever(imageUrlReader.findFirstImageUrlByTargetIds(eq(ImageTargetType.CHARACTER), eq(listOf(2L))))
+            .thenReturn(mapOf(2L to "https://cdn.example.com/char2.png"))
+
+        useCase.invoke(10L, null, "tok")
+
+        verify(partySseEventPublisher).broadcastAfterCommit(eq(10L), any(), anyOrNull())
+    }
+
+    @Test
+    fun `캐릭터 없는 참가자도 broadcast된다`() {
+        val profile = makeProfile(participantId = 5L, nickname = "익명", character = null)
+
+        whenever(resolveLiveOpenRealtimePartyUseCase.invoke(10L)).thenReturn(makeParty())
+        whenever(resolveRealtimeParticipantProfileUseCase.invoke(10L, null, "tok")).thenReturn(profile)
+
+        useCase.invoke(10L, null, "tok")
+
+        verify(partySseEventPublisher).broadcastAfterCommit(eq(10L), any(), anyOrNull())
+    }
+
+    @Test
+    fun `주최자(CELEBRANT)가 트리거해도 broadcast된다`() {
+        val profile = makeProfile(participantId = 1L, nickname = "주최자", isCelebrant = true)
+
+        whenever(resolveLiveOpenRealtimePartyUseCase.invoke(10L)).thenReturn(makeParty())
+        whenever(resolveRealtimeParticipantProfileUseCase.invoke(10L, null, "tok")).thenReturn(profile)
+
+        useCase.invoke(10L, null, "tok")
+
+        verify(partySseEventPublisher).broadcastAfterCommit(eq(10L), any(), anyOrNull())
+    }
+}

--- a/src/test/kotlin/com/team2/server/fireworks/application/usecase/TriggerFireworksUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/fireworks/application/usecase/TriggerFireworksUseCaseTest.kt
@@ -3,11 +3,8 @@ package com.team2.server.fireworks.application.usecase
 import com.team2.server.chat.application.port.PartySseEventPublisher
 import com.team2.server.common.exception.BusinessException
 import com.team2.server.common.exception.ErrorCode
-import com.team2.server.common.image.entity.ImageTargetType
-import com.team2.server.common.image.persistence.ImageUrlReader
 import com.team2.server.party.application.usecase.ResolveLiveOpenRealtimePartyUseCase
 import com.team2.server.party.application.usecase.ResolveRealtimeParticipantProfileUseCase
-import com.team2.server.party.domain.entity.Character
 import com.team2.server.party.domain.entity.Participant
 import com.team2.server.party.domain.entity.RealtimeParticipantProfile
 import com.team2.server.party.domain.entity.RealtimeParty
@@ -23,9 +20,6 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import java.time.Clock
-import java.time.Instant
-import java.time.ZoneId
 import kotlin.test.assertEquals
 
 @ExtendWith(MockitoExtension::class)
@@ -34,11 +28,7 @@ class TriggerFireworksUseCaseTest {
 
     @Mock lateinit var resolveRealtimeParticipantProfileUseCase: ResolveRealtimeParticipantProfileUseCase
 
-    @Mock lateinit var imageUrlReader: ImageUrlReader
-
     @Mock lateinit var partySseEventPublisher: PartySseEventPublisher
-
-    private val fixedClock: Clock = Clock.fixed(Instant.parse("2026-05-29T10:00:00Z"), ZoneId.of("Asia/Seoul"))
 
     private lateinit var useCase: TriggerFireworksUseCase
 
@@ -48,9 +38,7 @@ class TriggerFireworksUseCaseTest {
             TriggerFireworksUseCase(
                 resolveLiveOpenRealtimePartyUseCase = resolveLiveOpenRealtimePartyUseCase,
                 resolveRealtimeParticipantProfileUseCase = resolveRealtimeParticipantProfileUseCase,
-                imageUrlReader = imageUrlReader,
                 partySseEventPublisher = partySseEventPublisher,
-                clock = fixedClock,
             )
     }
 
@@ -59,17 +47,13 @@ class TriggerFireworksUseCaseTest {
     private fun makeProfile(
         participantId: Long = 1L,
         nickname: String = "토끼왕",
-        isCelebrant: Boolean = false,
-        character: Character? = null,
     ): RealtimeParticipantProfile {
         val participant: Participant = mock()
         whenever(participant.id).thenReturn(participantId)
-        whenever(participant.isCelebrant).thenReturn(isCelebrant)
 
         val profile: RealtimeParticipantProfile = mock()
         whenever(profile.participant).thenReturn(participant)
         whenever(profile.nickname).thenReturn(nickname)
-        whenever(profile.character).thenReturn(character)
         return profile
     }
 
@@ -94,35 +78,7 @@ class TriggerFireworksUseCaseTest {
 
     @Test
     fun `참가자가 폭죽을 트리거하면 SSE fireworks 이벤트가 broadcast된다`() {
-        val character: Character = mock()
-        whenever(character.id).thenReturn(2L)
-        val profile = makeProfile(participantId = 5L, nickname = "토끼왕", isCelebrant = false, character = character)
-
-        whenever(resolveLiveOpenRealtimePartyUseCase.invoke(10L)).thenReturn(makeParty())
-        whenever(resolveRealtimeParticipantProfileUseCase.invoke(10L, null, "tok")).thenReturn(profile)
-        whenever(imageUrlReader.findFirstImageUrlByTargetIds(eq(ImageTargetType.CHARACTER), eq(listOf(2L))))
-            .thenReturn(mapOf(2L to "https://cdn.example.com/char2.png"))
-
-        useCase.invoke(10L, null, "tok")
-
-        verify(partySseEventPublisher).broadcastAfterCommit(eq(10L), any(), anyOrNull())
-    }
-
-    @Test
-    fun `캐릭터 없는 참가자도 broadcast된다`() {
-        val profile = makeProfile(participantId = 5L, nickname = "익명", character = null)
-
-        whenever(resolveLiveOpenRealtimePartyUseCase.invoke(10L)).thenReturn(makeParty())
-        whenever(resolveRealtimeParticipantProfileUseCase.invoke(10L, null, "tok")).thenReturn(profile)
-
-        useCase.invoke(10L, null, "tok")
-
-        verify(partySseEventPublisher).broadcastAfterCommit(eq(10L), any(), anyOrNull())
-    }
-
-    @Test
-    fun `주최자(CELEBRANT)가 트리거해도 broadcast된다`() {
-        val profile = makeProfile(participantId = 1L, nickname = "주최자", isCelebrant = true)
+        val profile = makeProfile(participantId = 5L, nickname = "토끼왕")
 
         whenever(resolveLiveOpenRealtimePartyUseCase.invoke(10L)).thenReturn(makeParty())
         whenever(resolveRealtimeParticipantProfileUseCase.invoke(10L, null, "tok")).thenReturn(profile)


### PR DESCRIPTION
## 🔗 Issue
- closes #197

## 💬 Context
파티 참가자가 폭죽 아이콘을 클릭하면 해당 파티의 모든 SSE 구독자에게 실시간으로 폭죽 애니메이션 이벤트를 전파해야 한다는 요구사항이 있었습니다. 기존에 촛불 끄기 등에서 사용하던 SSE 인프라(`PartySseEventPublisher` → `SseEmitterRegistry`)를 재사용해 신규 `fireworks` 피처 패키지를 신설했습니다.

## 🛠 Changes
- `POST /api/v1/parties/{partyId}/fireworks` 엔드포인트 추가
- `TriggerFireworksUseCase`: 파티 LIVE_OPEN 상태 검증 + 참가자 프로필 조회 + SSE `fireworks` 이벤트 broadcast
- `FireworksController` / `FireworksApi`: HTTP 엔드포인트 및 Swagger 문서
- `SecurityConfig`: `POST /api/v1/parties/*/fireworks` permitAll 추가 (비로그인 참여자 지원)
- `TriggerFireworksUseCaseTest`: 유즈케이스 단위 테스트 5건 (Mockito-Kotlin)

## 👀 Review Focus
- `TriggerFireworksUseCase`의 `broadcastAfterCommit` 호출 타이밍 — 트랜잭션 커밋 이후 SSE 전송이 보장되는지
- `ResolveRealtimeParticipantProfileUseCase` 재사용 방식이 기존 candle-blow 패턴과 일관성이 있는지
- `SecurityConfig`의 `permitAll` 범위가 적절한지 (비로그인 참여자 토큰 기반 인증 위임)

## ⚠️ Side Effects
- **DB 마이그레이션**: 없음
- **환경변수/설정**: 없음
- **의존성 변경**: 없음
- **API 변경(Breaking)**: 신규 엔드포인트 추가 — `POST /api/v1/parties/{partyId}/fireworks` (기존 API 영향 없음), 프론트엔드에 SSE `fireworks` 이벤트 페이로드 스펙 공유 필요
- **외부 시스템 영향**: SSE 구독 중인 클라이언트가 `fireworks` 이벤트를 수신하게 되므로 프론트엔드 대응 필요
- **운영 작업**: 없음

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [ ] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능

* 파티에 폭죽 애니메이션 기능이 추가되었습니다. 로그인 여부와 관계없이 모든 참여자가 폭죽을 트리거할 수 있으며, 파티의 모든 참여자에게 실시간으로 표시됩니다. 폭죽 이벤트에는 참여자의 닉네임, 캐릭터 정보 및 역할 정보가 포함됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/18th-team2-server/pull/198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->