### PR TITLE
[Chore] 익명 파티 퇴장 API SecurityConfig permitAll 설정 추가

### DIFF
--- a/src/main/kotlin/com/team2/server/auth/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/team2/server/auth/config/SecurityConfig.kt
@@ -61,6 +61,7 @@ class SecurityConfig(
                         HttpMethod.POST,
                         "/api/v1/party-invites/*/realtime-participants/stream",
                     ).permitAll()
+                auth.requestMatchers(HttpMethod.DELETE, "/api/v1/parties/*/realtime-participants").permitAll()
                 auth.requestMatchers(HttpMethod.POST, "/api/v1/parties/*/chat-messages").permitAll()
                 auth.requestMatchers(HttpMethod.GET, "/api/v1/parties/*/candle-blow").permitAll()
                 auth.requestMatchers(HttpMethod.POST, "/api/v1/parties/*/candle-blow/candles/*").permitAll()


### PR DESCRIPTION
## 🔗 Issue
- closes #196 

## 💬 Context
익명 사용자(비로그인)가 파티 퇴장 API(`DELETE /api/v1/parties/*/realtime-participants`)를 호출할 때 Spring Security에서 인증이 필요하다고 판단해 401을 반환하는 문제가 있었습니다. 해당 엔드포인트는 비로그인 상태에서도 접근 가능해야 하므로 `permitAll()` 설정을 추가합니다.

## 🛠 Changes
- `SecurityConfig`에 `DELETE /api/v1/parties/*/realtime-participants` 엔드포인트 `permitAll()` 추가

## 👀 Review Focus
- 기존 `POST /api/v1/parties/*/chat-messages` 등 익명 허용 패턴과 일관성 확인

## ⚠️ Side Effects
- **DB 마이그레이션**: 없음
- **환경변수/설정**: 없음
- **의존성 변경**: 없음
- **API 변경(Breaking)**: 없음
- **외부 시스템 영향**: 없음
- **운영 작업**: 없음

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견