### PR TITLE
[Fix] realtime-next-action Swagger 순환 참조 제거

### DIFF
--- a/src/main/kotlin/com/team2/server/party/application/dto/RealtimePartyEndResults.kt
+++ b/src/main/kotlin/com/team2/server/party/application/dto/RealtimePartyEndResults.kt
@@ -67,7 +67,7 @@ data class RealtimePartyStateResult(
 
 @Schema(
     description = "실시간 파티 종료 후 다음 행동 조회 응답",
-    oneOf = [RealtimePartyNextActionResult.Host::class, RealtimePartyNextActionResult.Participant::class],
+    oneOf = [RealtimePartyNextActionHostSchema::class, RealtimePartyNextActionParticipantSchema::class],
 )
 sealed interface RealtimePartyNextActionResult {
     @get:Schema(
@@ -95,3 +95,29 @@ sealed interface RealtimePartyNextActionResult {
         override val type: String = "PARTICIPANT_ROLLING_PAPER_WRITE"
     }
 }
+
+@Schema(name = "Host", description = "주최자용 다음 행동 응답")
+data class RealtimePartyNextActionHostSchema(
+    @Schema(
+        description = "다음 행동 타입",
+        allowableValues = ["HOST_ROLLING_PAPER_LIST"],
+        example = "HOST_ROLLING_PAPER_LIST",
+    )
+    val type: String,
+    @Schema(description = "롤링페이퍼 목록으로 이동할 파티 ID", example = "1")
+    val partyId: Long,
+)
+
+@Schema(name = "Participant", description = "참가자용 다음 행동 응답")
+data class RealtimePartyNextActionParticipantSchema(
+    @Schema(
+        description = "다음 행동 타입",
+        allowableValues = ["PARTICIPANT_ROLLING_PAPER_WRITE"],
+        example = "PARTICIPANT_ROLLING_PAPER_WRITE",
+    )
+    val type: String,
+    @Schema(description = "롤링페이퍼 작성 화면 진입에 사용할 유효 초대 토큰", example = "exampletoken0000")
+    val inviteToken: String,
+    @Schema(description = "현재 참가자의 롤링페이퍼 작성 완료 여부", example = "false")
+    val rollingPaperWritten: Boolean,
+)

--- a/src/test/kotlin/com/team2/server/common/config/SwaggerConfigTest.kt
+++ b/src/test/kotlin/com/team2/server/common/config/SwaggerConfigTest.kt
@@ -10,6 +10,7 @@ import org.springframework.context.annotation.Import
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @SpringBootTest
@@ -22,14 +23,7 @@ class SwaggerConfigTest
     ) {
         @Test
         fun `선택 인증 API는 OpenAPI security에 bearer와 익명 인증을 함께 노출한다`() {
-            val apiDocs =
-                mockMvc
-                    .get("/v3/api-docs")
-                    .andExpect {
-                        status { isOk() }
-                    }.andReturn()
-                    .response
-                    .contentAsString
+            val apiDocs = getApiDocs()
 
             assertOptionalAuthSecurity(
                 apiDocs,
@@ -44,6 +38,50 @@ class SwaggerConfigTest
                 "$.paths['/api/v1/party-invites/{inviteToken}/rolling-papers'].get.security",
             )
         }
+
+        @Test
+        fun `실시간 파티 다음 행동 Swagger schema는 순환 참조 없이 독립된 oneOf schema를 노출한다`() {
+            val apiDocs = getApiDocs()
+            val result: Map<String, Any> =
+                JsonPath.read(apiDocs, "$.components.schemas.RealtimePartyNextActionResult")
+            val host: Map<String, Any> = JsonPath.read(apiDocs, "$.components.schemas.Host")
+            val participant: Map<String, Any> = JsonPath.read(apiDocs, "$.components.schemas.Participant")
+
+            assertEquals(
+                listOf(
+                    mapOf("\$ref" to "#/components/schemas/Host"),
+                    mapOf("\$ref" to "#/components/schemas/Participant"),
+                ),
+                result["oneOf"],
+            )
+            assertFalse(host.containsKey("allOf"))
+            assertFalse(participant.containsKey("allOf"))
+            assertEquals(
+                setOf("type", "partyId"),
+                (host["properties"] as Map<*, *>).keys,
+            )
+            assertEquals(
+                listOf("HOST_ROLLING_PAPER_LIST"),
+                ((host["properties"] as Map<*, *>)["type"] as Map<*, *>)["enum"],
+            )
+            assertEquals(
+                setOf("type", "inviteToken", "rollingPaperWritten"),
+                (participant["properties"] as Map<*, *>).keys,
+            )
+            assertEquals(
+                listOf("PARTICIPANT_ROLLING_PAPER_WRITE"),
+                ((participant["properties"] as Map<*, *>)["type"] as Map<*, *>)["enum"],
+            )
+        }
+
+        private fun getApiDocs(): String =
+            mockMvc
+                .get("/v3/api-docs")
+                .andExpect {
+                    status { isOk() }
+                }.andReturn()
+                .response
+                .contentAsString
 
         private fun assertOptionalAuthSecurity(
             apiDocs: String,


### PR DESCRIPTION
## 🔗 Issue
- closes #200

## 💬 Context
`GET /api/v1/parties/{partyId}/realtime-next-action` 응답의 Swagger schema가 순환 참조를 생성했습니다.

`RealtimePartyNextActionResult`는 `oneOf`로 `Host`, `Participant`를 참조하고, 기존 `Host`, `Participant`는 `allOf`로 다시 부모 schema를 참조했습니다. 이 구조로 프론트 `api.ts`를 생성하면 `openapi-typescript`가 순환 타입을 생성해 TypeScript CI가 실패합니다.

실제 API 응답 필드와 런타임 동작은 유지하고 Swagger schema만 독립 구조로 분리했습니다.

## 🛠 Changes
- Swagger 전용 `Host`, `Participant` 독립 schema 추가
- `RealtimePartyNextActionResult.oneOf`가 독립 schema를 참조하도록 변경
- `Host`, `Participant`에 `allOf` 역참조가 없고 각 `type`이 단일 enum인지 검증하는 회귀 테스트 추가

## 👀 Review Focus
- 생성된 OpenAPI schema에서 `Host`, `Participant`가 `RealtimePartyNextActionResult`를 다시 참조하지 않는지
- 기존 응답 필드가 유지되는지

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] `./gradlew check` 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * API 응답 스키마 구조 개선으로 더 명확한 API 문서 제공

* **테스트**
  * API 문서 구조 검증 테스트 강화로 API 안정성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->