### PR TITLE
[Feat] 다가오는 파티 정렬 및 기본 초대 토큰 생성

### DIFF
--- a/docs/superpowers/plans/2026-05-12-pr3-party-layered-architecture.md
+++ b/docs/superpowers/plans/2026-05-12-pr3-party-layered-architecture.md
@@ -1496,6 +1496,13 @@ class MePartyController(
 }
 ```
 
+확정 정책:
+
+- 다가오는 파티는 `party.startedAt ASC`, `participant.createdAt DESC`, `participant.id DESC` 순으로 정렬한다.
+- REALTIME과 PAPER_ONLY 파티 생성 시 기본 초대 토큰을 함께 생성한다.
+- 종료 전 파티 중 유효 초대 토큰이 없는 파티는 Flyway 마이그레이션으로 생성한다.
+- 다가오는 파티 응답은 유효한 `inviteToken`을 반환한다.
+
 - [ ] **Step 8: `CharacterController` 매핑 확인**
 
 이미 `getCharactersUseCase.invoke().map(CharacterResponse::from)` 패턴 — 변경 없음. 단 `CharacterResponse.from(result: CharacterResult)` 의 `CharacterResult` import 가 `party.application.dto.CharacterResult` 로 정상 갱신되었는지 확인.

--- a/docs/superpowers/specs/2026-05-04-party-invite-lookup-design.md
+++ b/docs/superpowers/specs/2026-05-04-party-invite-lookup-design.md
@@ -204,7 +204,10 @@ data class RealtimeSchedule(
 
 결정:
 
-- 기존 `PartyInviteService.activateInviteLink(...)`는 유효한 초대 토큰 재사용을 위해 `PartyInvite.expiresAt`을 사용한다.
+- REALTIME과 PAPER_ONLY 파티 생성 시 기본 초대 토큰을 함께 생성한다.
+- 종료 전 파티 중 유효 초대 토큰이 없는 파티는 Flyway 마이그레이션으로 생성한다.
+- 다가오는 파티 응답은 유효 초대 토큰을 `inviteToken`으로 내려준다.
+- `PartyInviteService.activateInviteLink(...)`는 유효한 초대 토큰 재사용을 위해 `PartyInvite.expiresAt`을 사용한다.
 - 신규 기획은 "실시간 파티 종료 여부와 관계없이 `realtimeSchedule`을 내려준다"고 되어 있고, `partyEnded`는 `Party.endedAt()` 기준이다.
 - 초대장 조회 API는 `PartyInvite.expiresAt`이 지났어도 조회 가능하게 한다.
 

--- a/docs/superpowers/specs/2026-05-05-rolling-paper-list-design.md
+++ b/docs/superpowers/specs/2026-05-05-rolling-paper-list-design.md
@@ -86,13 +86,13 @@
 
 주최자용 화면의 공유하기 버튼은 목록 API에 포함하지 않는다.
 
-공유하기 버튼 클릭 시 기존 초대 링크 API를 별도로 호출한다.
+다가오는 파티 카드에서는 `GET /api/v1/me/upcoming-parties` 응답의 `inviteToken`으로 공유 링크를 만든다.
 
 ```http
 POST /api/v1/parties/{partyId}/invite-link
 ```
 
-이 API는 현재 유효한 초대 토큰이 있으면 재사용하고, 없으면 새로 생성해 `token`을 반환한다.
+이 API는 유효한 초대 토큰이 있으면 재사용하고, 없으면 새로 생성해 `token`을 반환한다.
 
 ---
 
@@ -259,7 +259,7 @@ GET /api/v1/parties/{partyId}/rolling-papers?page=1
 |---|---|
 | `partyOption` | 주최자 목록 화면의 응답 요구사항에는 필요하지 않다. 열람 가능 여부는 서버가 검증한다. |
 | `pageSize` | 한 페이지 기준은 `PAGE_SIZE = 7`로 고정이므로 응답에 반복해서 내려주지 않는다. |
-| `inviteToken`, `shareLink` | 공유하기 버튼 클릭 시 기존 초대 링크 API를 별도로 호출한다. |
+| `inviteToken`, `shareLink` | 다가오는 파티 카드에서 다가오는 파티 응답의 `inviteToken`을 사용한다. |
 
 ### 3-3. 주최자용 상세 조회
 

--- a/docs/superpowers/specs/2026-06-05-upcoming-party-default-invite-design.md
+++ b/docs/superpowers/specs/2026-06-05-upcoming-party-default-invite-design.md
@@ -1,0 +1,35 @@
+# 다가오는 파티 정렬 및 기본 초대 토큰 정책
+
+- 작성일: 2026-06-05
+- 대상 API: `GET /api/v1/me/upcoming-parties`
+
+## 1. 다가오는 파티 정렬
+
+다가오는 파티는 사용자가 참여 중이며 아직 종료되지 않은 파티를 파티 시작 시각이 가까운 순으로 반환한다.
+
+정렬 기준:
+
+1. `party.startedAt ASC`
+2. 시작 시각이 같으면 `participant.createdAt DESC`
+3. 참여 시각도 같으면 `participant.id DESC`
+
+## 2. 기본 초대 토큰
+
+REALTIME과 PAPER_ONLY 파티 모두 생성 트랜잭션에서 기본 초대 토큰을 함께 생성한다.
+
+- 생성 유스케이스가 파티 생성 후 `PartyInviteService.activateInviteLink(...)`를 호출한다.
+- 유효 토큰이 있으면 재사용하고, 없으면 새 토큰을 생성한다.
+- 토큰 만료 시각은 `Party.endedAt()`과 같다.
+- 다가오는 파티 응답은 해당 파티의 유효 초대 토큰을 `inviteToken`으로 반환한다.
+- 종료 전 파티의 `inviteToken`은 유효한 토큰이다.
+
+Flyway 마이그레이션으로 종료 전 파티의 기본 초대 토큰을 생성한다.
+
+- 종료 전 파티 중 유효 초대 토큰이 없는 파티가 대상이다.
+- 토큰 만료 시각은 `Party.endedAt()`과 같다.
+
+## 3. 공유 동작
+
+다가오는 파티 카드의 링크 복사는 응답의 `inviteToken`으로 공유 링크를 만든다.
+
+`POST /api/v1/parties/{partyId}/invite-link`는 유효 토큰을 반환하고, 유효 토큰이 없으면 새로 생성한다.

--- a/src/main/kotlin/com/team2/server/party/application/usecase/CreatePaperOnlyPartyUseCase.kt
+++ b/src/main/kotlin/com/team2/server/party/application/usecase/CreatePaperOnlyPartyUseCase.kt
@@ -3,6 +3,7 @@ package com.team2.server.party.application.usecase
 import com.team2.server.common.exception.BusinessException
 import com.team2.server.common.exception.ErrorCode
 import com.team2.server.party.application.dto.CreatePaperOnlyPartyCommand
+import com.team2.server.party.application.service.PartyInviteService
 import com.team2.server.party.application.service.PartyService
 import com.team2.server.user.repository.UserRepository
 import org.springframework.data.repository.findByIdOrNull
@@ -12,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class CreatePaperOnlyPartyUseCase(
     private val partyService: PartyService,
+    private val partyInviteService: PartyInviteService,
     private val userRepository: UserRepository,
 ) {
     @Transactional
@@ -22,6 +24,8 @@ class CreatePaperOnlyPartyUseCase(
         val user =
             userRepository.findByIdOrNull(userId)
                 ?: throw BusinessException(ErrorCode.AUTH_USER_NOT_FOUND)
-        return partyService.createPaperOnlyParty(userId = userId, user = user, command = command)
+        val partyId = partyService.createPaperOnlyParty(userId = userId, user = user, command = command)
+        partyInviteService.activateInviteLink(partyId = partyId, userId = userId)
+        return partyId
     }
 }

--- a/src/main/kotlin/com/team2/server/party/application/usecase/CreateRealtimePartyUseCase.kt
+++ b/src/main/kotlin/com/team2/server/party/application/usecase/CreateRealtimePartyUseCase.kt
@@ -4,6 +4,7 @@ import com.team2.server.common.exception.BusinessException
 import com.team2.server.common.exception.ErrorCode
 import com.team2.server.party.application.dto.CreateRealtimePartyCommand
 import com.team2.server.party.application.event.RealtimePartyCreatedEvent
+import com.team2.server.party.application.service.PartyInviteService
 import com.team2.server.party.application.service.PartyService
 import com.team2.server.user.repository.UserRepository
 import org.springframework.context.ApplicationEventPublisher
@@ -14,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class CreateRealtimePartyUseCase(
     private val partyService: PartyService,
+    private val partyInviteService: PartyInviteService,
     private val userRepository: UserRepository,
     private val applicationEventPublisher: ApplicationEventPublisher,
 ) {
@@ -26,6 +28,7 @@ class CreateRealtimePartyUseCase(
             userRepository.findByIdOrNull(userId)
                 ?: throw BusinessException(ErrorCode.AUTH_USER_NOT_FOUND)
         val partyId = partyService.createRealtimeParty(userId = userId, user = user, command = command)
+        partyInviteService.activateInviteLink(partyId = partyId, userId = userId)
         applicationEventPublisher.publishEvent(
             RealtimePartyCreatedEvent(
                 partyId = partyId,

--- a/src/main/kotlin/com/team2/server/party/infrastructure/persistence/ParticipantRepository.kt
+++ b/src/main/kotlin/com/team2/server/party/infrastructure/persistence/ParticipantRepository.kt
@@ -38,7 +38,7 @@ interface ParticipantRepository : JpaRepository<Participant, Long> {
         JOIN FETCH participant.party party
         WHERE participant.user.id = :userId
           AND party.startedAt > :startedAfter
-        ORDER BY participant.createdAt DESC, participant.id DESC
+        ORDER BY party.startedAt ASC, participant.createdAt DESC, participant.id DESC
         """,
     )
     fun findNotEndedByUserId(

--- a/src/main/resources/db/migration/V6__backfill_default_party_invites.sql
+++ b/src/main/resources/db/migration/V6__backfill_default_party_invites.sql
@@ -1,0 +1,21 @@
+insert into party_invite (
+    created_at,
+    updated_at,
+    party_id,
+    token,
+    expires_at
+)
+select
+    current_timestamp(6),
+    current_timestamp(6),
+    p.id,
+    left(replace(uuid(), '-', ''), 16),
+    date_add(p.started_at, interval 7 day)
+from party p
+where date_add(p.started_at, interval 7 day) > current_timestamp(6)
+  and not exists (
+      select 1
+      from party_invite pi
+      where pi.party_id = p.id
+        and pi.expires_at > current_timestamp(6)
+  );

--- a/src/main/resources/db/migration/V6__backfill_default_party_invites.sql
+++ b/src/main/resources/db/migration/V6__backfill_default_party_invites.sql
@@ -9,7 +9,7 @@ select
     current_timestamp(6),
     current_timestamp(6),
     p.id,
-    left(replace(uuid(), '-', ''), 16),
+    lower(hex(random_bytes(8))),
     date_add(p.started_at, interval 7 day)
 from party p
 where date_add(p.started_at, interval 7 day) > current_timestamp(6)

--- a/src/test/kotlin/com/team2/server/party/api/MePartyControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/party/api/MePartyControllerTest.kt
@@ -59,7 +59,7 @@ class MePartyControllerTest
         }
 
         @Test
-        fun `내가 참여 중이고 종료되지 않은 파티 목록을 조회한다`() {
+        fun `내가 참여 중이고 종료되지 않은 파티 목록을 시작일 가까운 순으로 조회한다`() {
             val user = saveUser("kakao-upcoming-member", "upcoming-member@kakao.local")
             val other = saveUser("kakao-upcoming-other", "upcoming-other@kakao.local")
             val token = tokenProvider.issue(user)
@@ -115,8 +115,8 @@ class MePartyControllerTest
                 }.andExpect {
                     status { isOk() }
                     jsonPath("$.data.length()") { value(2) }
-                    expectPaperOnlyParty(paperOnlyParty, index = 0)
-                    expectRealtimeParty(realtimeParty, liveStartAt, index = 1)
+                    expectRealtimeParty(realtimeParty, liveStartAt, index = 0)
+                    expectPaperOnlyParty(paperOnlyParty, index = 1)
                 }
         }
 

--- a/src/test/kotlin/com/team2/server/party/api/PartyControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/party/api/PartyControllerTest.kt
@@ -67,7 +67,7 @@ class PartyControllerTest
                         """
                         {
                           "celebrantNickname": "홍길동",
-                          "startedDate": "2026-04-28",
+                          "startedDate": "2099-04-28",
                           "startTime": "14:30",
                           "characterId": 1
                         }
@@ -99,44 +99,52 @@ class PartyControllerTest
         fun `REALTIME 파티 생성 성공`() {
             val token = tokenProvider.issue(saveUser("kakao-create-1", "create@kakao.local"))
 
-            mockMvc
-                .post("/api/v1/parties/realtime") {
-                    contentType = MediaType.APPLICATION_JSON
-                    content =
-                        """
-                        {
-                          "celebrantNickname": "홍길동",
-                          "startedDate": "2026-04-28",
-                          "startTime": "14:30",
-                          "characterId": $defaultCharacterId
-                        }
-                        """.trimIndent()
-                    header("Authorization", "Bearer $token")
-                }.andExpect {
-                    status { isCreated() }
-                    jsonPath("$.data.partyId") { isNumber() }
-                }
+            val result =
+                mockMvc
+                    .post("/api/v1/parties/realtime") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content =
+                            """
+                            {
+                              "celebrantNickname": "홍길동",
+                              "startedDate": "2099-04-28",
+                              "startTime": "14:30",
+                              "characterId": $defaultCharacterId
+                            }
+                            """.trimIndent()
+                        header("Authorization", "Bearer $token")
+                    }.andExpect {
+                        status { isCreated() }
+                        jsonPath("$.data.partyId") { isNumber() }
+                    }.andReturn()
+            val partyId = objectMapper.readTree(result.response.contentAsString)["data"]["partyId"].asLong()
+
+            assertDefaultInviteCreated(partyId)
         }
 
         @Test
         fun `PAPER_ONLY 파티 생성 성공 - startTime 없이 가능`() {
             val token = tokenProvider.issue(saveUser("kakao-create-2", "create2@kakao.local"))
 
-            mockMvc
-                .post("/api/v1/parties/paper-only") {
-                    contentType = MediaType.APPLICATION_JSON
-                    content =
-                        """
-                        {
-                          "celebrantNickname": "홍길동",
-                          "startedDate": "2026-04-28"
-                        }
-                        """.trimIndent()
-                    header("Authorization", "Bearer $token")
-                }.andExpect {
-                    status { isCreated() }
-                    jsonPath("$.data.partyId") { isNumber() }
-                }
+            val result =
+                mockMvc
+                    .post("/api/v1/parties/paper-only") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content =
+                            """
+                            {
+                              "celebrantNickname": "홍길동",
+                              "startedDate": "2099-04-28"
+                            }
+                            """.trimIndent()
+                        header("Authorization", "Bearer $token")
+                    }.andExpect {
+                        status { isCreated() }
+                        jsonPath("$.data.partyId") { isNumber() }
+                    }.andReturn()
+            val partyId = objectMapper.readTree(result.response.contentAsString)["data"]["partyId"].asLong()
+
+            assertDefaultInviteCreated(partyId)
         }
 
         @Test
@@ -194,7 +202,9 @@ class PartyControllerTest
         @Test
         fun `이미 시작된 파티 삭제 시 409`() {
             val token = tokenProvider.issue(saveUser("kakao-del-started", "del-started@kakao.local"))
-            val partyId = createParty(token, "2000-01-01", "00:00")
+            val startedAt = LocalDateTime.now().minusMinutes(1)
+            val startTime = startedAt.toLocalTime().withSecond(0).withNano(0)
+            val partyId = createParty(token, startedAt.toLocalDate().toString(), startTime.toString())
 
             mockMvc
                 .delete("/api/v1/parties/$partyId") {
@@ -336,6 +346,15 @@ class PartyControllerTest
             val body = result.response.contentAsString
             val node = objectMapper.readTree(body)
             return node["data"]["partyId"].asLong()
+        }
+
+        private fun assertDefaultInviteCreated(partyId: Long) {
+            val invites =
+                partyInviteRepository.findAllByPartyIdInAndExpiresAtAfter(
+                    listOf(partyId),
+                    LocalDateTime.now(),
+                )
+            assertEquals(1, invites.size)
         }
 
         private fun saveRealtimeParty(

--- a/src/test/kotlin/com/team2/server/party/application/usecase/CreatePaperOnlyPartyUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/party/application/usecase/CreatePaperOnlyPartyUseCaseTest.kt
@@ -1,6 +1,7 @@
 package com.team2.server.party.application.usecase
 
 import com.team2.server.party.application.dto.CreatePaperOnlyPartyCommand
+import com.team2.server.party.application.service.PartyInviteService
 import com.team2.server.party.application.service.PartyService
 import com.team2.server.user.entity.AuthProvider
 import com.team2.server.user.entity.User
@@ -21,6 +22,9 @@ class CreatePaperOnlyPartyUseCaseTest {
     lateinit var partyService: PartyService
 
     @Mock
+    lateinit var partyInviteService: PartyInviteService
+
+    @Mock
     lateinit var userRepository: UserRepository
 
     @Test
@@ -31,14 +35,16 @@ class CreatePaperOnlyPartyUseCaseTest {
                 startedDate = LocalDate.of(2026, 6, 1),
             )
         val user = user()
-        val useCase = CreatePaperOnlyPartyUseCase(partyService, userRepository)
+        val useCase = CreatePaperOnlyPartyUseCase(partyService, partyInviteService, userRepository)
         whenever(userRepository.findById(42L)).thenReturn(Optional.of(user))
         whenever(partyService.createPaperOnlyParty(userId = 42L, user = user, command = command)).thenReturn(101L)
+        whenever(partyInviteService.activateInviteLink(partyId = 101L, userId = 42L)).thenReturn("invite-token")
 
         val partyId = useCase.invoke(userId = 42L, command = command)
 
         assertEquals(101L, partyId)
         verify(partyService).createPaperOnlyParty(userId = 42L, user = user, command = command)
+        verify(partyInviteService).activateInviteLink(partyId = 101L, userId = 42L)
     }
 
     private fun user(): User =

--- a/src/test/kotlin/com/team2/server/party/application/usecase/CreateRealtimePartyUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/party/application/usecase/CreateRealtimePartyUseCaseTest.kt
@@ -2,6 +2,7 @@ package com.team2.server.party.application.usecase
 
 import com.team2.server.party.application.dto.CreateRealtimePartyCommand
 import com.team2.server.party.application.event.RealtimePartyCreatedEvent
+import com.team2.server.party.application.service.PartyInviteService
 import com.team2.server.party.application.service.PartyService
 import com.team2.server.user.entity.AuthProvider
 import com.team2.server.user.entity.User
@@ -25,6 +26,9 @@ class CreateRealtimePartyUseCaseTest {
     lateinit var partyService: PartyService
 
     @Mock
+    lateinit var partyInviteService: PartyInviteService
+
+    @Mock
     lateinit var userRepository: UserRepository
 
     @Mock
@@ -37,6 +41,7 @@ class CreateRealtimePartyUseCaseTest {
         useCase =
             CreateRealtimePartyUseCase(
                 partyService = partyService,
+                partyInviteService = partyInviteService,
                 userRepository = userRepository,
                 applicationEventPublisher = applicationEventPublisher,
             )
@@ -54,11 +59,13 @@ class CreateRealtimePartyUseCaseTest {
         val user = user()
         whenever(userRepository.findById(42L)).thenReturn(Optional.of(user))
         whenever(partyService.createRealtimeParty(userId = 42L, user = user, command = command)).thenReturn(100L)
+        whenever(partyInviteService.activateInviteLink(partyId = 100L, userId = 42L)).thenReturn("invite-token")
 
         val partyId = useCase.invoke(userId = 42L, command = command)
 
         assertEquals(100L, partyId)
         verify(partyService).createRealtimeParty(userId = 42L, user = user, command = command)
+        verify(partyInviteService).activateInviteLink(partyId = 100L, userId = 42L)
         verify(applicationEventPublisher).publishEvent(
             RealtimePartyCreatedEvent(
                 partyId = 100L,


### PR DESCRIPTION
## 🔗 Issue
- closes #202

## 💬 Context
다가오는 파티 카드에서 가까운 파티를 먼저 노출하고, 응답의 `inviteToken`으로 공유 링크를 만들 수 있도록 기본 초대 토큰을 보장합니다.

## 🛠 Changes
- 다가오는 파티를 `party.startedAt ASC` 기준으로 정렬
- REALTIME, PAPER_ONLY 파티 생성 시 기본 초대 토큰 생성
- 종료 전 파티 중 유효 초대 토큰이 없는 데이터 백필 마이그레이션 추가
- 생성 및 정렬 테스트와 정책 문서 수정

## 👀 Review Focus
- 파티 생성 트랜잭션에서 기본 초대 토큰을 생성하는 흐름
- 기존 데이터 백필 대상과 토큰 만료 시각
- 다가오는 파티 정렬 우선순위

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] `./gradlew check` 통과

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 파티 생성 시 기본 초대 토큰이 자동으로 생성됩니다.
  * 다가오는 파티 목록이 시작 시각 기준으로 정렬되어 표시됩니다.
  * 파티 공유 링크가 자동 생성된 초대 토큰으로부터 생성됩니다.

* **버그 수정**
  * 종료되지 않은 파티에 유효한 초대 토큰이 없는 경우를 자동으로 복구합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->