### PR TITLE
[Feat] 실시간 파티 종료 표시 정보 제공

### DIFF
--- a/docs/superpowers/specs/2026-05-19-realtime-party-end-design.md
+++ b/docs/superpowers/specs/2026-05-19-realtime-party-end-design.md
@@ -6,13 +6,13 @@
 
 ## 1. 정책
 
-실시간 파티 종료는 `Party.endedAt()`과 별개의 실시간 세션 종료이다.
+실시간 파티 종료는 실시간 세션의 종료 시점을 관리한다.
 
 - 주최자만 수동 종료 가능
-- 수동 종료 가능 조건: `LIVE_OPEN` 상태의 주최자는 별도 시간 제한이나 박터뜨리기 종료 조건 없이 언제든 종료 가능
-- 박터뜨리기 종료는 실시간 파티 종료 가능 여부에 영향을 주지 않음
+- 수동 종료 가능 조건: `LIVE_OPEN` 상태의 주최자는 언제든 종료 가능
 - 자동 종료 트리거: `startedAt + 10분`
-- 종료 트리거 후 즉시 종료하지 않고 60초 카운트다운 진행
+- 종료 트리거부터 60초 카운트다운 진행
+- 종료 카운트다운 화면은 `HOST_REQUEST`, `TIME_LIMIT_REACHED` 두 종료 시작 원인을 구분해 표시
 - `party-ending` 전송 후 60초 뒤 `party-ended` 전송
 - `party-ended` 전송 후 짧은 grace time 뒤 남은 SSE emitter 정리
 - 실시간 세션 종료 후 재오픈, 신규 입장, 채팅 전송 불가
@@ -25,8 +25,6 @@ RealtimeParty.LIVE_DURATION_MINUTES = 10
 RealtimeParty.LIVE_END_COUNTDOWN_SECONDS = 60
 ```
 
-기존 `PartyEndScheduler.WARN_BEFORE_END_MINUTES`와 `startedAt + 9분` 알림 예약은 제거한다.
-
 ## 2. 상태 모델
 
 `realtime_party`에 컬럼을 추가한다.
@@ -35,7 +33,33 @@ RealtimeParty.LIVE_END_COUNTDOWN_SECONDS = 60
 |---|---|---:|---|
 | `live_ending_started_at` | DATETIME | O | 60초 종료 카운트다운 시작 시각 |
 
-종료 완료 시각은 `live_ending_started_at + 60초`로 계산하고, 종료 원인 컬럼은 두지 않는다.
+종료 완료 시각은 `live_ending_started_at + 60초`로 계산한다.
+종료 시작 원인은 저장된 `live_ending_started_at`과 자동 종료 기준 시각으로 계산한다.
+
+```kotlin
+enum class RealtimePartyEndingReason {
+    HOST_REQUEST,
+    TIME_LIMIT_REACHED,
+}
+```
+
+| 종료 시작 원인 | 조건 | 의미 | `hostNickname` |
+|---|---|---|---|
+| `HOST_REQUEST` | `liveEndingStartedAt < automaticEndingStartedAt` | 주최자가 제한 시간 전에 종료 요청 | 종료를 요청한 주최자의 닉네임 |
+| `TIME_LIMIT_REACHED` | `liveEndingStartedAt >= automaticEndingStartedAt` | 10분 제한 시간 도달 | 파티 주최자의 닉네임 |
+
+주최자가 정확히 `startedAt + 10분`에 종료 요청한 경우에도 사용자 관점의 원인을 우선해 `TIME_LIMIT_REACHED`로 계산한다.
+`hostNickname`은 파티 주최자의 표시 닉네임이며 종료 원인과 관계없이 항상 제공한다.
+값은 주최자의 `RealtimeParticipantProfile.nickname`을 사용한다. 실시간 파티 생성 시 주최자 프로필이 함께 생성되고 프로필 닉네임은 필수 값이므로, `hostNickname`은 non-null 계약으로 제공한다.
+주최자 프로필은 `Participant.isCelebrant = true`인 참가자의 `RealtimeParticipantProfile`로 식별한다. 실시간 파티에는 주최자 프로필이 한 개 존재한다.
+
+종료 표시 정보인 `endingReason`, `hostNickname`은 내부에서 하나의 공통 종료 정보 객체로 계산한다.
+종료 요청 API, 상태 복구 API, `party-state`, `party-ending`, `party-ended`는 같은 공통 종료 정보를 사용하고 각 payload에는 평평한 필드로 노출한다.
+`party-ended`는 최종 종료 문구에 사용하는 `hostNickname`을 제공한다.
+백엔드는 주최자와 참가자에게 동일한 종료 정보를 제공하고, 조회자 역할에 따른 화면 문구 차이는 프론트에서 처리한다.
+
+스케줄러가 사용하는 `RealtimeEndingScheduleTarget`은 `endingReason`, `hostNickname`을 포함한다.
+앱 시작 시 스케줄 복구와 종료 이벤트 예약은 같은 종료 표시 정보를 사용한다.
 
 도메인 계산:
 
@@ -76,7 +100,9 @@ Authorization: Bearer {accessToken}
 {
   "partyId": 1,
   "endingStartedAt": "2026-05-19T20:06:30",
-  "endedAt": "2026-05-19T20:07:30"
+  "endedAt": "2026-05-19T20:07:30",
+  "endingReason": "HOST_REQUEST",
+  "hostNickname": "홍길동"
 }
 ```
 
@@ -86,10 +112,10 @@ Authorization: Bearer {accessToken}
 2. `partyOption == REALTIME`
 3. 요청자가 주최자
 4. `LIVE_CLOSED`이면 `REALTIME_PARTY_ALREADY_ENDED`
-5. `LIVE_ENDING`이면 기존 `endingStartedAt`, `endedAt` 반환
-6. `LIVE_OPEN`이면 별도 unlock 조건 없이 조건부 update 실행
+5. `LIVE_ENDING`이면 현재 `endingStartedAt`, `endedAt` 반환
+6. `LIVE_OPEN`이면 조건부 update 실행
 7. 그 외 상태이면 `REALTIME_PARTY_INVALID_STATE`
-8. affected row 기준으로 신규 시작 또는 기존 카운트다운 반환
+8. affected row 기준으로 신규 시작 또는 진행 중인 카운트다운 반환
 
 동시성:
 
@@ -102,7 +128,7 @@ WHERE id = :partyId
 
 - affected row `1`: 이번 요청이 카운트다운 시작
 - affected row `0`: 이미 시작된 카운트다운 조회 후 반환
-- 자동 종료 트리거도 조건부 update를 사용하되 저장값은 현재 시각이 아니라 `startedAt + 10분`
+- 자동 종료 트리거는 조건부 update로 `startedAt + 10분`을 저장
 
 ### 3-2. 실시간 상태 복구 조회
 
@@ -111,7 +137,7 @@ GET /api/v1/parties/{partyId}/realtime-state
 Authorization: Bearer {accessToken} 또는 X-Participant-Token: {participantToken}
 ```
 
-주최자와 기존 참가자 모두 사용한다.
+주최자와 참가자 모두 사용한다.
 
 ```json
 {
@@ -119,9 +145,21 @@ Authorization: Bearer {accessToken} 또는 X-Participant-Token: {participantToke
   "status": "LIVE_ENDING",
   "liveStartAt": "2026-05-19T20:00:00",
   "endingStartedAt": "2026-05-19T20:10:00",
-  "endedAt": "2026-05-19T20:11:00"
+  "endedAt": "2026-05-19T20:11:00",
+  "endingReason": "TIME_LIMIT_REACHED",
+  "hostNickname": "홍길동"
 }
 ```
+
+`endingReason`은 `LIVE_ENDING`, `LIVE_CLOSED`에서만 제공하고, 종료 카운트다운 시작 전에는 `null`이다.
+`hostNickname`은 종료 원인과 상태에 관계없이 항상 제공한다. 따라서 종료 시작 전 상태 응답은 `endingReason = null`, `hostNickname = 주최자 닉네임`으로 내려준다.
+
+| 응답 또는 이벤트 | `endingReason` | `hostNickname` |
+|---|---|---|
+| 주최자 종료 요청 API | non-null | non-null |
+| `realtime-state`, `party-state` | nullable | non-null |
+| `party-ending` | non-null | non-null |
+| `party-ended` | 미포함 | non-null |
 
 ### 3-3. 종료 후 다음 행동 조회
 
@@ -168,28 +206,29 @@ SSE 연결 직후 항상 현재 상태를 1회 전송한다.
 
 ```text
 event: party-state
-data: {"partyId":1,"status":"LIVE_ENDING","liveStartAt":"2026-05-19T20:00:00","endingStartedAt":"2026-05-19T20:10:00","endedAt":"2026-05-19T20:11:00"}
+data: {"partyId":1,"status":"LIVE_ENDING","liveStartAt":"2026-05-19T20:00:00","endingStartedAt":"2026-05-19T20:10:00","endedAt":"2026-05-19T20:11:00","endingReason":"TIME_LIMIT_REACHED","hostNickname":"홍길동"}
 ```
 
 ### party-ending
 
 ```text
 event: party-ending
-data: {"partyId":1,"endingStartedAt":"2026-05-19T20:10:00","endedAt":"2026-05-19T20:11:00"}
+data: {"partyId":1,"endingStartedAt":"2026-05-19T20:10:00","endedAt":"2026-05-19T20:11:00","endingReason":"TIME_LIMIT_REACHED","hostNickname":"홍길동"}
 ```
 
 ### party-ended
 
 공통 payload만 전송한다. 개인화 이동 정보는 `realtime-next-action`에서 조회한다.
+`party-ended` payload는 `partyId`, `endedAt`, `hostNickname`을 제공한다.
 
 ```text
 event: party-ended
-data: {"partyId":1,"endedAt":"2026-05-19T20:11:00"}
+data: {"partyId":1,"endedAt":"2026-05-19T20:11:00","hostNickname":"홍길동"}
 ```
 
 ## 5. 스케줄링
 
-`PartyEndScheduler`는 1초 반복 polling을 사용하지 않는다. DB는 source of truth로 두고, 평상시에는 `TaskScheduler` 예약과 트랜잭션 commit 이후 이벤트로 동작한다. SSE 발송은 트랜잭션 안에서 직접 수행하지 않는다.
+`PartyEndScheduler`는 DB를 source of truth로 두고 `TaskScheduler` 예약과 트랜잭션 commit 이후 이벤트로 동작한다. SSE는 트랜잭션 commit 이후 발송한다.
 
 앱 시작 시 1회 복구:
 
@@ -257,7 +296,7 @@ fun isLiveOpen(now: LocalDateTime): Boolean =
     now >= startedAt && now < effectiveEndingStartedAt
 ```
 
-기존 참가자 SSE 재연결:
+참가자 SSE 재연결:
 
 - `participantToken`으로 기존 profile 확인 가능하면 `LIVE_ENDING`에서도 허용
 - 연결 직후 `party-state` 전송
@@ -287,15 +326,13 @@ REALTIME_PARTY_ALREADY_ENDED(HttpStatus.CONFLICT, "이미 종료된 실시간 �
 5. 주최자 종료 요청 API 추가
 6. 실시간 상태 복구 API 추가
 7. 종료 후 다음 행동 조회 API 추가
-8. `party-state`, `party-ending`, `party-ended` SSE 처리
+8. `party-state`, `party-ending`, `party-ended` SSE에 종료 표시 정보 제공
 9. `PartyEndScheduler`를 startup recovery + event 기반 예약 구조로 변경
-10. 기존 `WARN_BEFORE_END_MINUTES`, 9분 트리거, `host-end-available` 제거
-11. 종료 시작 조건부 update 구현
-12. `party-ended` 후 grace cleanup 적용
-13. 신규 입장/채팅 검증에서 `LIVE_ENDING`, `LIVE_CLOSED` 차단
-14. 기존 참가자 `LIVE_ENDING` SSE 재연결 허용
-15. 박터뜨리기 종료와 실시간 파티 종료 가능 여부 연결 제거
-16. 테스트 추가
+10. 종료 시작 조건부 update 구현
+11. `party-ended` 후 grace cleanup 적용
+12. 신규 입장/채팅 검증에서 `LIVE_OPEN` 허용
+13. 참가자 `LIVE_ENDING` SSE 재연결 허용
+14. `HOST_REQUEST`, `TIME_LIMIT_REACHED` 경계 및 응답 필드 테스트 추가
 
 ## 9. 참가자 next action 계산 기준
 

--- a/src/main/kotlin/com/team2/server/chat/application/dto/EnterRealtimePartyResult.kt
+++ b/src/main/kotlin/com/team2/server/chat/application/dto/EnterRealtimePartyResult.kt
@@ -1,0 +1,14 @@
+package com.team2.server.chat.application.dto
+
+import com.team2.server.party.application.dto.RealtimePartyStateResult
+import java.time.LocalDateTime
+
+data class EnterRealtimePartyResult(
+    val participantToken: String,
+    val partyId: Long,
+    val startedAt: LocalDateTime,
+    val isCelebrant: Boolean,
+    val nickname: String,
+    val characterId: Long?,
+    val partyState: RealtimePartyStateResult,
+)

--- a/src/main/kotlin/com/team2/server/chat/application/support/RealtimePartyEntryProfileResolver.kt
+++ b/src/main/kotlin/com/team2/server/chat/application/support/RealtimePartyEntryProfileResolver.kt
@@ -3,7 +3,13 @@ package com.team2.server.chat.application.support
 import com.team2.server.chat.application.port.RealtimePartyEntryProfilePort
 import com.team2.server.chat.application.port.RealtimePartyEntryProfileResult
 import com.team2.server.chat.dto.EnterRealtimePartyRequest
+import com.team2.server.common.exception.BusinessException
+import com.team2.server.common.exception.ErrorCode
+import com.team2.server.party.domain.entity.Party
+import com.team2.server.party.domain.entity.PartyOption
 import com.team2.server.party.domain.entity.RealtimeParty
+import com.team2.server.party.domain.entity.RealtimePartyStatus
+import org.hibernate.Hibernate
 import org.springframework.stereotype.Component
 import java.time.LocalDateTime
 
@@ -11,6 +17,18 @@ import java.time.LocalDateTime
 class RealtimePartyEntryProfileResolver(
     private val entryProfilePort: RealtimePartyEntryProfilePort,
 ) {
+    fun requireRealtime(party: Party): RealtimeParty {
+        if (party.partyOption != PartyOption.REALTIME) throw BusinessException(ErrorCode.CHAT_NOT_SUPPORTED)
+        return Hibernate.unproxy(party) as RealtimeParty
+    }
+
+    fun validateNewEntry(
+        party: RealtimeParty,
+        now: LocalDateTime,
+    ) {
+        if (party.status(now) != RealtimePartyStatus.LIVE_OPEN) throw BusinessException(ErrorCode.CHAT_NOT_ACTIVE)
+    }
+
     fun resolve(
         party: RealtimeParty,
         userId: Long?,

--- a/src/main/kotlin/com/team2/server/chat/infrastructure/sse/ChatRealtimePartyEventBroadcaster.kt
+++ b/src/main/kotlin/com/team2/server/chat/infrastructure/sse/ChatRealtimePartyEventBroadcaster.kt
@@ -1,6 +1,7 @@
 package com.team2.server.chat.infrastructure.sse
 
 import com.team2.server.party.application.port.RealtimePartyEventBroadcaster
+import com.team2.server.party.domain.entity.RealtimePartyEndingReason
 import com.team2.server.party.domain.vo.PartyPhase
 import org.springframework.stereotype.Component
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
@@ -14,6 +15,8 @@ class ChatRealtimePartyEventBroadcaster(
         partyId: Long,
         endingStartedAt: LocalDateTime,
         endedAt: LocalDateTime,
+        endingReason: RealtimePartyEndingReason,
+        hostNickname: String,
     ) {
         sseEmitterRegistry.broadcast(
             partyId,
@@ -25,6 +28,8 @@ class ChatRealtimePartyEventBroadcaster(
                         partyId = partyId,
                         endingStartedAt = endingStartedAt,
                         endedAt = endedAt,
+                        endingReason = endingReason,
+                        hostNickname = hostNickname,
                     ),
                 ).build(),
         )
@@ -33,13 +38,14 @@ class ChatRealtimePartyEventBroadcaster(
     override fun broadcastPartyEnded(
         partyId: Long,
         endedAt: LocalDateTime,
+        hostNickname: String,
     ) {
         sseEmitterRegistry.broadcast(
             partyId,
             SseEmitter
                 .event()
                 .name("party-ended")
-                .data(PartyEndedPayload(partyId = partyId, endedAt = endedAt))
+                .data(PartyEndedPayload(partyId = partyId, endedAt = endedAt, hostNickname = hostNickname))
                 .build(),
         )
     }
@@ -68,11 +74,14 @@ class ChatRealtimePartyEventBroadcaster(
         val partyId: Long,
         val endingStartedAt: LocalDateTime,
         val endedAt: LocalDateTime,
+        val endingReason: RealtimePartyEndingReason,
+        val hostNickname: String,
     )
 
     data class PartyEndedPayload(
         val partyId: Long,
         val endedAt: LocalDateTime,
+        val hostNickname: String,
     )
 
     data class PhaseChangedPayload(

--- a/src/main/kotlin/com/team2/server/chat/usecase/EnterRealtimePartyUseCase.kt
+++ b/src/main/kotlin/com/team2/server/chat/usecase/EnterRealtimePartyUseCase.kt
@@ -6,8 +6,8 @@ import com.team2.server.chat.application.support.RealtimePartyEntryProfileResolv
 import com.team2.server.chat.dto.EnterRealtimePartyRequest
 import com.team2.server.party.application.dto.RealtimePartyStateResult
 import com.team2.server.party.application.service.PartyInviteService
-import com.team2.server.party.application.support.RealtimePartyEndingInfoResolver
 import com.team2.server.party.application.usecase.MarkRealtimePartyHostEnteredUseCase
+import com.team2.server.party.application.usecase.ResolveRealtimePartyEndingInfoUseCase
 import com.team2.server.party.domain.entity.RealtimeParty
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -19,7 +19,7 @@ class EnterRealtimePartyUseCase(
     private val partyInviteService: PartyInviteService,
     private val profileResolver: RealtimePartyEntryProfileResolver,
     private val markRealtimePartyHostEnteredUseCase: MarkRealtimePartyHostEnteredUseCase,
-    private val endingInfoResolver: RealtimePartyEndingInfoResolver,
+    private val resolveRealtimePartyEndingInfoUseCase: ResolveRealtimePartyEndingInfoUseCase,
     private val clock: Clock,
 ) {
     @Transactional
@@ -35,6 +35,7 @@ class EnterRealtimePartyUseCase(
 
         val entryProfile = profileResolver.resolve(realtimeParty, userId, request, now)
         markHostEnteredIfNeeded(realtimeParty, entryProfile, now)
+        val endingInfo = resolveRealtimePartyEndingInfoUseCase(realtimeParty, now)
 
         return EnterRealtimePartyResult(
             participantToken = entryProfile.participantToken,
@@ -43,7 +44,7 @@ class EnterRealtimePartyUseCase(
             isCelebrant = entryProfile.isCelebrant,
             nickname = entryProfile.nickname,
             characterId = entryProfile.characterId,
-            partyState = RealtimePartyStateResult.from(realtimeParty, now, endingInfoResolver.get(realtimeParty, now)),
+            partyState = RealtimePartyStateResult.from(realtimeParty, now, endingInfo),
         )
     }
 

--- a/src/main/kotlin/com/team2/server/chat/usecase/EnterRealtimePartyUseCase.kt
+++ b/src/main/kotlin/com/team2/server/chat/usecase/EnterRealtimePartyUseCase.kt
@@ -1,18 +1,14 @@
 package com.team2.server.chat.usecase
 
+import com.team2.server.chat.application.dto.EnterRealtimePartyResult
 import com.team2.server.chat.application.port.RealtimePartyEntryProfileResult
 import com.team2.server.chat.application.support.RealtimePartyEntryProfileResolver
 import com.team2.server.chat.dto.EnterRealtimePartyRequest
-import com.team2.server.common.exception.BusinessException
-import com.team2.server.common.exception.ErrorCode
 import com.team2.server.party.application.dto.RealtimePartyStateResult
 import com.team2.server.party.application.service.PartyInviteService
+import com.team2.server.party.application.support.RealtimePartyEndingInfoResolver
 import com.team2.server.party.application.usecase.MarkRealtimePartyHostEnteredUseCase
-import com.team2.server.party.domain.entity.Party
-import com.team2.server.party.domain.entity.PartyOption
 import com.team2.server.party.domain.entity.RealtimeParty
-import com.team2.server.party.domain.entity.RealtimePartyStatus
-import org.hibernate.Hibernate
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Clock
@@ -23,43 +19,31 @@ class EnterRealtimePartyUseCase(
     private val partyInviteService: PartyInviteService,
     private val profileResolver: RealtimePartyEntryProfileResolver,
     private val markRealtimePartyHostEnteredUseCase: MarkRealtimePartyHostEnteredUseCase,
+    private val endingInfoResolver: RealtimePartyEndingInfoResolver,
     private val clock: Clock,
 ) {
-    data class EnterResult(
-        val participantToken: String,
-        val partyId: Long,
-        val startedAt: LocalDateTime,
-        val isCelebrant: Boolean,
-        val nickname: String,
-        val characterId: Long?,
-        val partyState: RealtimePartyStateResult,
-    )
-
     @Transactional
     fun enter(
         inviteToken: String,
         userId: Long?,
         request: EnterRealtimePartyRequest,
-    ): EnterResult {
+    ): EnterRealtimePartyResult {
         val now = LocalDateTime.now(clock)
         val invite = partyInviteService.findUsableInvite(inviteToken, now)
-        val realtimeParty = validateInvite(invite.party)
-        val reentry = request.participantToken != null
-        if (!reentry) {
-            validateNewEnterable(realtimeParty, now)
-        }
+        val realtimeParty = profileResolver.requireRealtime(invite.party)
+        if (request.participantToken == null) profileResolver.validateNewEntry(realtimeParty, now)
 
         val entryProfile = profileResolver.resolve(realtimeParty, userId, request, now)
         markHostEnteredIfNeeded(realtimeParty, entryProfile, now)
 
-        return EnterResult(
+        return EnterRealtimePartyResult(
             participantToken = entryProfile.participantToken,
             partyId = invite.party.id,
             startedAt = invite.party.startedAt,
             isCelebrant = entryProfile.isCelebrant,
             nickname = entryProfile.nickname,
             characterId = entryProfile.characterId,
-            partyState = RealtimePartyStateResult.from(realtimeParty, now),
+            partyState = RealtimePartyStateResult.from(realtimeParty, now, endingInfoResolver.get(realtimeParty, now)),
         )
     }
 
@@ -70,21 +54,5 @@ class EnterRealtimePartyUseCase(
     ) {
         if (!entryProfile.isCelebrant) return
         party.hostEnteredAt = markRealtimePartyHostEnteredUseCase(party.id, now) ?: return
-    }
-
-    private fun validateInvite(party: Party): RealtimeParty {
-        if (party.partyOption != PartyOption.REALTIME) {
-            throw BusinessException(ErrorCode.CHAT_NOT_SUPPORTED)
-        }
-        return Hibernate.unproxy(party) as RealtimeParty
-    }
-
-    private fun validateNewEnterable(
-        realtimeParty: RealtimeParty,
-        now: LocalDateTime,
-    ) {
-        if (realtimeParty.status(now) != RealtimePartyStatus.LIVE_OPEN) {
-            throw BusinessException(ErrorCode.CHAT_NOT_ACTIVE)
-        }
     }
 }

--- a/src/main/kotlin/com/team2/server/party/application/dto/RealtimePartyEndResults.kt
+++ b/src/main/kotlin/com/team2/server/party/application/dto/RealtimePartyEndResults.kt
@@ -1,9 +1,15 @@
 package com.team2.server.party.application.dto
 
 import com.team2.server.party.domain.entity.RealtimeParty
+import com.team2.server.party.domain.entity.RealtimePartyEndingReason
 import com.team2.server.party.domain.entity.RealtimePartyStatus
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
+
+data class RealtimePartyEndingInfo(
+    val endingReason: RealtimePartyEndingReason?,
+    val hostNickname: String,
+)
 
 @Schema(description = "실시간 파티 종료 카운트다운 시작 응답")
 data class RealtimePartyEndResult(
@@ -13,13 +19,22 @@ data class RealtimePartyEndResult(
     val endingStartedAt: LocalDateTime,
     @Schema(description = "실시간 라이브 종료 시각", example = "2026-05-19T20:11:00")
     val endedAt: LocalDateTime,
+    @Schema(description = "종료 카운트다운 시작 원인", example = "HOST_REQUEST")
+    val endingReason: RealtimePartyEndingReason,
+    @Schema(description = "파티 주최자 닉네임", example = "홍길동")
+    val hostNickname: String,
 ) {
     companion object {
-        fun from(party: RealtimeParty): RealtimePartyEndResult =
+        fun from(
+            party: RealtimeParty,
+            endingInfo: RealtimePartyEndingInfo,
+        ): RealtimePartyEndResult =
             RealtimePartyEndResult(
                 partyId = party.id,
                 endingStartedAt = requireNotNull(party.liveEndingStartedAt),
                 endedAt = requireNotNull(party.liveEndedAt()),
+                endingReason = requireNotNull(endingInfo.endingReason),
+                hostNickname = endingInfo.hostNickname,
             )
     }
 }
@@ -40,11 +55,16 @@ data class RealtimePartyStateResult(
     val endingStartedAt: LocalDateTime?,
     @Schema(description = "실시간 라이브 종료 시각", example = "2026-05-19T20:11:00")
     val endedAt: LocalDateTime,
+    @Schema(description = "종료 카운트다운 시작 원인. 종료 시작 전이면 null", nullable = true, example = "TIME_LIMIT_REACHED")
+    val endingReason: RealtimePartyEndingReason?,
+    @Schema(description = "파티 주최자 닉네임", example = "홍길동")
+    val hostNickname: String,
 ) {
     companion object {
         fun from(
             party: RealtimeParty,
             now: LocalDateTime,
+            endingInfo: RealtimePartyEndingInfo,
         ): RealtimePartyStateResult {
             val status = party.status(now)
             val endingStartedAt =
@@ -60,6 +80,8 @@ data class RealtimePartyStateResult(
                 liveStartAt = party.startedAt,
                 endingStartedAt = endingStartedAt,
                 endedAt = party.effectiveLiveEndedAt(),
+                endingReason = endingInfo.endingReason,
+                hostNickname = endingInfo.hostNickname,
             )
         }
     }

--- a/src/main/kotlin/com/team2/server/party/application/dto/RealtimePartyEndScheduleData.kt
+++ b/src/main/kotlin/com/team2/server/party/application/dto/RealtimePartyEndScheduleData.kt
@@ -1,6 +1,7 @@
 package com.team2.server.party.application.dto
 
 import com.team2.server.party.domain.entity.RealtimeParty
+import com.team2.server.party.domain.entity.RealtimePartyEndingReason
 import java.time.LocalDateTime
 
 data class RealtimePartyEndStartResult(
@@ -12,6 +13,8 @@ data class RealtimeEndingScheduleTarget(
     val partyId: Long,
     val endingStartedAt: LocalDateTime,
     val endedAt: LocalDateTime,
+    val endingReason: RealtimePartyEndingReason,
+    val hostNickname: String,
     val startedNow: Boolean = false,
 )
 

--- a/src/main/kotlin/com/team2/server/party/application/event/RealtimePartyEndingEventPublisher.kt
+++ b/src/main/kotlin/com/team2/server/party/application/event/RealtimePartyEndingEventPublisher.kt
@@ -1,6 +1,8 @@
 package com.team2.server.party.application.event
 
+import com.team2.server.party.application.dto.RealtimeEndingScheduleTarget
 import com.team2.server.party.application.dto.RealtimePartyEndResult
+import com.team2.server.party.domain.entity.RealtimePartyEndingReason
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
 import java.time.LocalDateTime
@@ -14,19 +16,35 @@ class RealtimePartyEndingEventPublisher(
             partyId = result.partyId,
             endingStartedAt = result.endingStartedAt,
             endedAt = result.endedAt,
+            endingReason = result.endingReason,
+            hostNickname = result.hostNickname,
         )
     }
 
-    fun publish(
+    fun publish(target: RealtimeEndingScheduleTarget) {
+        publish(
+            partyId = target.partyId,
+            endingStartedAt = target.endingStartedAt,
+            endedAt = target.endedAt,
+            endingReason = target.endingReason,
+            hostNickname = target.hostNickname,
+        )
+    }
+
+    private fun publish(
         partyId: Long,
         endingStartedAt: LocalDateTime,
         endedAt: LocalDateTime,
+        endingReason: RealtimePartyEndingReason,
+        hostNickname: String,
     ) {
         applicationEventPublisher.publishEvent(
             RealtimePartyEndingStartedEvent(
                 partyId = partyId,
                 endingStartedAt = endingStartedAt,
                 endedAt = endedAt,
+                endingReason = endingReason,
+                hostNickname = hostNickname,
             ),
         )
     }

--- a/src/main/kotlin/com/team2/server/party/application/event/RealtimePartyEvents.kt
+++ b/src/main/kotlin/com/team2/server/party/application/event/RealtimePartyEvents.kt
@@ -1,5 +1,6 @@
 package com.team2.server.party.application.event
 
+import com.team2.server.party.domain.entity.RealtimePartyEndingReason
 import java.time.LocalDateTime
 
 data class RealtimePartyCreatedEvent(
@@ -16,6 +17,8 @@ data class RealtimePartyEndingStartedEvent(
     val partyId: Long,
     val endingStartedAt: LocalDateTime,
     val endedAt: LocalDateTime,
+    val endingReason: RealtimePartyEndingReason,
+    val hostNickname: String,
 )
 
 data class RealtimePartyBurstGameStartedEvent(

--- a/src/main/kotlin/com/team2/server/party/application/port/RealtimePartyEndingInfoPort.kt
+++ b/src/main/kotlin/com/team2/server/party/application/port/RealtimePartyEndingInfoPort.kt
@@ -1,0 +1,14 @@
+package com.team2.server.party.application.port
+
+import com.team2.server.party.application.dto.RealtimePartyEndingInfo
+import com.team2.server.party.domain.entity.RealtimeParty
+import java.time.LocalDateTime
+
+interface RealtimePartyEndingInfoPort {
+    fun get(party: RealtimeParty): RealtimePartyEndingInfo
+
+    fun get(
+        party: RealtimeParty,
+        now: LocalDateTime,
+    ): RealtimePartyEndingInfo
+}

--- a/src/main/kotlin/com/team2/server/party/application/port/RealtimePartyEventBroadcaster.kt
+++ b/src/main/kotlin/com/team2/server/party/application/port/RealtimePartyEventBroadcaster.kt
@@ -1,5 +1,6 @@
 package com.team2.server.party.application.port
 
+import com.team2.server.party.domain.entity.RealtimePartyEndingReason
 import com.team2.server.party.domain.vo.PartyPhase
 import java.time.LocalDateTime
 
@@ -8,11 +9,14 @@ interface RealtimePartyEventBroadcaster {
         partyId: Long,
         endingStartedAt: LocalDateTime,
         endedAt: LocalDateTime,
+        endingReason: RealtimePartyEndingReason,
+        hostNickname: String,
     )
 
     fun broadcastPartyEnded(
         partyId: Long,
         endedAt: LocalDateTime,
+        hostNickname: String,
     )
 
     fun completeParty(partyId: Long)

--- a/src/main/kotlin/com/team2/server/party/application/service/RealtimePartyEndService.kt
+++ b/src/main/kotlin/com/team2/server/party/application/service/RealtimePartyEndService.kt
@@ -6,6 +6,7 @@ import com.team2.server.party.application.dto.RealtimeAutomaticEndSchedule
 import com.team2.server.party.application.dto.RealtimeEndingScheduleTarget
 import com.team2.server.party.application.dto.RealtimePartyEndRecoverySchedules
 import com.team2.server.party.application.dto.RealtimePartyEndStartResult
+import com.team2.server.party.application.support.RealtimePartyEndingInfoResolver
 import com.team2.server.party.domain.entity.Party
 import com.team2.server.party.domain.entity.PartyOption
 import com.team2.server.party.domain.entity.RealtimeParty
@@ -17,6 +18,7 @@ import java.time.LocalDateTime
 @Service
 class RealtimePartyEndService(
     private val partyRepository: PartyRepository,
+    private val endingInfoResolver: RealtimePartyEndingInfoResolver,
 ) {
     fun startIfNotStarted(
         partyId: Long,
@@ -37,10 +39,13 @@ class RealtimePartyEndService(
         val affected = partyRepository.startRealtimeEndingIfNotStarted(partyId, endingStartedAt)
         val party = findRealtimeParty(partyId)
         val actualEndingStartedAt = party.liveEndingStartedAt ?: return null
+        val endingInfo = endingInfoResolver.get(party)
         return RealtimeEndingScheduleTarget(
             partyId = party.id,
             endingStartedAt = actualEndingStartedAt,
             endedAt = requireNotNull(party.liveEndedAt()),
+            endingReason = requireNotNull(endingInfo.endingReason),
+            hostNickname = endingInfo.hostNickname,
             startedNow = affected == 1,
         )
     }
@@ -73,10 +78,13 @@ class RealtimePartyEndService(
         partyRepository
             .findRealtimePartiesWithEndingStarted(now.minusDays(Party.ENDED_AFTER_DAYS))
             .map { party ->
+                val endingInfo = endingInfoResolver.get(party)
                 RealtimeEndingScheduleTarget(
                     partyId = party.id,
                     endingStartedAt = requireNotNull(party.liveEndingStartedAt),
                     endedAt = requireNotNull(party.liveEndedAt()),
+                    endingReason = requireNotNull(endingInfo.endingReason),
+                    hostNickname = endingInfo.hostNickname,
                     startedNow = false,
                 )
             }

--- a/src/main/kotlin/com/team2/server/party/application/service/RealtimePartyEndService.kt
+++ b/src/main/kotlin/com/team2/server/party/application/service/RealtimePartyEndService.kt
@@ -6,7 +6,7 @@ import com.team2.server.party.application.dto.RealtimeAutomaticEndSchedule
 import com.team2.server.party.application.dto.RealtimeEndingScheduleTarget
 import com.team2.server.party.application.dto.RealtimePartyEndRecoverySchedules
 import com.team2.server.party.application.dto.RealtimePartyEndStartResult
-import com.team2.server.party.application.support.RealtimePartyEndingInfoResolver
+import com.team2.server.party.application.port.RealtimePartyEndingInfoPort
 import com.team2.server.party.domain.entity.Party
 import com.team2.server.party.domain.entity.PartyOption
 import com.team2.server.party.domain.entity.RealtimeParty
@@ -18,7 +18,7 @@ import java.time.LocalDateTime
 @Service
 class RealtimePartyEndService(
     private val partyRepository: PartyRepository,
-    private val endingInfoResolver: RealtimePartyEndingInfoResolver,
+    private val endingInfoPort: RealtimePartyEndingInfoPort,
 ) {
     fun startIfNotStarted(
         partyId: Long,
@@ -39,7 +39,7 @@ class RealtimePartyEndService(
         val affected = partyRepository.startRealtimeEndingIfNotStarted(partyId, endingStartedAt)
         val party = findRealtimeParty(partyId)
         val actualEndingStartedAt = party.liveEndingStartedAt ?: return null
-        val endingInfo = endingInfoResolver.get(party)
+        val endingInfo = endingInfoPort.get(party)
         return RealtimeEndingScheduleTarget(
             partyId = party.id,
             endingStartedAt = actualEndingStartedAt,
@@ -78,7 +78,7 @@ class RealtimePartyEndService(
         partyRepository
             .findRealtimePartiesWithEndingStarted(now.minusDays(Party.ENDED_AFTER_DAYS))
             .map { party ->
-                val endingInfo = endingInfoResolver.get(party)
+                val endingInfo = endingInfoPort.get(party)
                 RealtimeEndingScheduleTarget(
                     partyId = party.id,
                     endingStartedAt = requireNotNull(party.liveEndingStartedAt),

--- a/src/main/kotlin/com/team2/server/party/application/support/RealtimePartyEndingInfoResolver.kt
+++ b/src/main/kotlin/com/team2/server/party/application/support/RealtimePartyEndingInfoResolver.kt
@@ -1,0 +1,33 @@
+package com.team2.server.party.application.support
+
+import com.team2.server.party.application.dto.RealtimePartyEndingInfo
+import com.team2.server.party.domain.entity.RealtimeParty
+import com.team2.server.party.domain.entity.RealtimePartyEndingReason
+import com.team2.server.party.infrastructure.persistence.RealtimeParticipantProfileRepository
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+
+@Component
+class RealtimePartyEndingInfoResolver(
+    private val profileRepository: RealtimeParticipantProfileRepository,
+) {
+    fun get(party: RealtimeParty): RealtimePartyEndingInfo = get(party, party.endingReason())
+
+    fun get(
+        party: RealtimeParty,
+        now: LocalDateTime,
+    ): RealtimePartyEndingInfo = get(party, party.endingReason(now))
+
+    private fun get(
+        party: RealtimeParty,
+        endingReason: RealtimePartyEndingReason?,
+    ): RealtimePartyEndingInfo {
+        val hostProfile =
+            profileRepository.findByParticipantPartyIdAndParticipantIsCelebrantTrue(party.id)
+                ?: error("Realtime party host profile not found. partyId=${party.id}")
+        return RealtimePartyEndingInfo(
+            endingReason = endingReason,
+            hostNickname = hostProfile.nickname,
+        )
+    }
+}

--- a/src/main/kotlin/com/team2/server/party/application/usecase/GetRealtimePartyStateUseCase.kt
+++ b/src/main/kotlin/com/team2/server/party/application/usecase/GetRealtimePartyStateUseCase.kt
@@ -3,6 +3,7 @@ package com.team2.server.party.application.usecase
 import com.team2.server.party.application.dto.RealtimePartyStateResult
 import com.team2.server.party.application.service.ParticipantService
 import com.team2.server.party.application.service.PartyService
+import com.team2.server.party.application.support.RealtimePartyEndingInfoResolver
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Clock
@@ -12,6 +13,7 @@ import java.time.LocalDateTime
 class GetRealtimePartyStateUseCase(
     private val partyService: PartyService,
     private val participantService: ParticipantService,
+    private val endingInfoResolver: RealtimePartyEndingInfoResolver,
     private val clock: Clock,
 ) {
     @Transactional(readOnly = true)
@@ -23,6 +25,6 @@ class GetRealtimePartyStateUseCase(
         val now = LocalDateTime.now(clock)
         val party = partyService.requireRealtimeParty(partyId)
         participantService.validatePartyMember(party, userId, participantToken)
-        return RealtimePartyStateResult.from(party, now)
+        return RealtimePartyStateResult.from(party, now, endingInfoResolver.get(party, now))
     }
 }

--- a/src/main/kotlin/com/team2/server/party/application/usecase/GetRealtimePartyStateUseCase.kt
+++ b/src/main/kotlin/com/team2/server/party/application/usecase/GetRealtimePartyStateUseCase.kt
@@ -1,9 +1,9 @@
 package com.team2.server.party.application.usecase
 
 import com.team2.server.party.application.dto.RealtimePartyStateResult
+import com.team2.server.party.application.port.RealtimePartyEndingInfoPort
 import com.team2.server.party.application.service.ParticipantService
 import com.team2.server.party.application.service.PartyService
-import com.team2.server.party.application.support.RealtimePartyEndingInfoResolver
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Clock
@@ -13,7 +13,7 @@ import java.time.LocalDateTime
 class GetRealtimePartyStateUseCase(
     private val partyService: PartyService,
     private val participantService: ParticipantService,
-    private val endingInfoResolver: RealtimePartyEndingInfoResolver,
+    private val endingInfoPort: RealtimePartyEndingInfoPort,
     private val clock: Clock,
 ) {
     @Transactional(readOnly = true)
@@ -25,6 +25,6 @@ class GetRealtimePartyStateUseCase(
         val now = LocalDateTime.now(clock)
         val party = partyService.requireRealtimeParty(partyId)
         participantService.validatePartyMember(party, userId, participantToken)
-        return RealtimePartyStateResult.from(party, now, endingInfoResolver.get(party, now))
+        return RealtimePartyStateResult.from(party, now, endingInfoPort.get(party, now))
     }
 }

--- a/src/main/kotlin/com/team2/server/party/application/usecase/ResolveRealtimePartyEndingInfoUseCase.kt
+++ b/src/main/kotlin/com/team2/server/party/application/usecase/ResolveRealtimePartyEndingInfoUseCase.kt
@@ -1,0 +1,19 @@
+package com.team2.server.party.application.usecase
+
+import com.team2.server.party.application.dto.RealtimePartyEndingInfo
+import com.team2.server.party.application.port.RealtimePartyEndingInfoPort
+import com.team2.server.party.domain.entity.RealtimeParty
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service
+class ResolveRealtimePartyEndingInfoUseCase(
+    private val endingInfoPort: RealtimePartyEndingInfoPort,
+) {
+    @Transactional(readOnly = true)
+    operator fun invoke(
+        party: RealtimeParty,
+        now: LocalDateTime,
+    ): RealtimePartyEndingInfo = endingInfoPort.get(party, now)
+}

--- a/src/main/kotlin/com/team2/server/party/application/usecase/StartAutomaticRealtimePartyEndUseCase.kt
+++ b/src/main/kotlin/com/team2/server/party/application/usecase/StartAutomaticRealtimePartyEndUseCase.kt
@@ -19,7 +19,7 @@ class StartAutomaticRealtimePartyEndUseCase(
     ): RealtimeEndingScheduleTarget? {
         val target = realtimePartyEndService.startIfNotStartedOrNull(partyId, endingStartedAt) ?: return null
         if (target.startedNow) {
-            realtimePartyEndingEventPublisher.publish(target.partyId, target.endingStartedAt, target.endedAt)
+            realtimePartyEndingEventPublisher.publish(target)
         }
         return target
     }

--- a/src/main/kotlin/com/team2/server/party/application/usecase/StartRealtimePartyEndUseCase.kt
+++ b/src/main/kotlin/com/team2/server/party/application/usecase/StartRealtimePartyEndUseCase.kt
@@ -6,6 +6,7 @@ import com.team2.server.party.application.dto.RealtimePartyEndStartResult
 import com.team2.server.party.application.event.RealtimePartyEndingEventPublisher
 import com.team2.server.party.application.service.PartyService
 import com.team2.server.party.application.service.RealtimePartyEndService
+import com.team2.server.party.application.support.RealtimePartyEndingInfoResolver
 import com.team2.server.party.domain.entity.RealtimePartyStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -16,6 +17,7 @@ import java.time.LocalDateTime
 class StartRealtimePartyEndUseCase(
     private val partyService: PartyService,
     private val realtimePartyEndService: RealtimePartyEndService,
+    private val endingInfoResolver: RealtimePartyEndingInfoResolver,
     private val realtimePartyEndingEventPublisher: RealtimePartyEndingEventPublisher,
     private val clock: Clock,
 ) {
@@ -43,7 +45,7 @@ class StartRealtimePartyEndUseCase(
     }
 
     private fun toResultAndPublish(startResult: RealtimePartyEndStartResult): RealtimePartyEndResult =
-        RealtimePartyEndResult.from(startResult.party).also {
+        RealtimePartyEndResult.from(startResult.party, endingInfoResolver.get(startResult.party)).also {
             if (startResult.affected == 1) realtimePartyEndingEventPublisher.publish(it)
         }
 }

--- a/src/main/kotlin/com/team2/server/party/application/usecase/StartRealtimePartyEndUseCase.kt
+++ b/src/main/kotlin/com/team2/server/party/application/usecase/StartRealtimePartyEndUseCase.kt
@@ -4,9 +4,9 @@ import com.team2.server.common.exception.ErrorCode
 import com.team2.server.party.application.dto.RealtimePartyEndResult
 import com.team2.server.party.application.dto.RealtimePartyEndStartResult
 import com.team2.server.party.application.event.RealtimePartyEndingEventPublisher
+import com.team2.server.party.application.port.RealtimePartyEndingInfoPort
 import com.team2.server.party.application.service.PartyService
 import com.team2.server.party.application.service.RealtimePartyEndService
-import com.team2.server.party.application.support.RealtimePartyEndingInfoResolver
 import com.team2.server.party.domain.entity.RealtimePartyStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -17,7 +17,7 @@ import java.time.LocalDateTime
 class StartRealtimePartyEndUseCase(
     private val partyService: PartyService,
     private val realtimePartyEndService: RealtimePartyEndService,
-    private val endingInfoResolver: RealtimePartyEndingInfoResolver,
+    private val endingInfoPort: RealtimePartyEndingInfoPort,
     private val realtimePartyEndingEventPublisher: RealtimePartyEndingEventPublisher,
     private val clock: Clock,
 ) {
@@ -45,7 +45,7 @@ class StartRealtimePartyEndUseCase(
     }
 
     private fun toResultAndPublish(startResult: RealtimePartyEndStartResult): RealtimePartyEndResult =
-        RealtimePartyEndResult.from(startResult.party, endingInfoResolver.get(startResult.party)).also {
+        RealtimePartyEndResult.from(startResult.party, endingInfoPort.get(startResult.party)).also {
             if (startResult.affected == 1) realtimePartyEndingEventPublisher.publish(it)
         }
 }

--- a/src/main/kotlin/com/team2/server/party/domain/entity/RealtimeParty.kt
+++ b/src/main/kotlin/com/team2/server/party/domain/entity/RealtimeParty.kt
@@ -32,6 +32,23 @@ class RealtimeParty(
 
     fun liveEndedAt(): LocalDateTime? = liveEndingStartedAt?.plusSeconds(LIVE_END_COUNTDOWN_SECONDS)
 
+    fun endingReason(): RealtimePartyEndingReason? =
+        liveEndingStartedAt?.let {
+            if (it.isBefore(automaticEndingStartedAt())) {
+                RealtimePartyEndingReason.HOST_REQUEST
+            } else {
+                RealtimePartyEndingReason.TIME_LIMIT_REACHED
+            }
+        }
+
+    fun endingReason(now: LocalDateTime): RealtimePartyEndingReason? =
+        endingReason()
+            ?: if (!now.isBefore(automaticEndingStartedAt())) {
+                RealtimePartyEndingReason.TIME_LIMIT_REACHED
+            } else {
+                null
+            }
+
     fun isLiveOpen(now: LocalDateTime = LocalDateTime.now()): Boolean =
         !now.isBefore(startedAt) && now.isBefore(effectiveEndingStartedAt())
 
@@ -58,4 +75,9 @@ enum class RealtimePartyStatus {
     LIVE_ENDING,
     LIVE_CLOSED,
     ROLLING_PAPER_CLOSED,
+}
+
+enum class RealtimePartyEndingReason {
+    HOST_REQUEST,
+    TIME_LIMIT_REACHED,
 }

--- a/src/main/kotlin/com/team2/server/party/infrastructure/persistence/RealtimeParticipantProfileRepository.kt
+++ b/src/main/kotlin/com/team2/server/party/infrastructure/persistence/RealtimeParticipantProfileRepository.kt
@@ -10,6 +10,8 @@ import org.springframework.data.jpa.repository.Query
 interface RealtimeParticipantProfileRepository : JpaRepository<RealtimeParticipantProfile, Long> {
     fun findByParticipant(participant: Participant): RealtimeParticipantProfile?
 
+    fun findByParticipantPartyIdAndParticipantIsCelebrantTrue(partyId: Long): RealtimeParticipantProfile?
+
     @EntityGraph(attributePaths = ["participant", "participant.party"])
     fun findByParticipantToken(participantToken: String): RealtimeParticipantProfile?
 

--- a/src/main/kotlin/com/team2/server/party/infrastructure/persistence/RealtimePartyEndingInfoAdapter.kt
+++ b/src/main/kotlin/com/team2/server/party/infrastructure/persistence/RealtimePartyEndingInfoAdapter.kt
@@ -1,19 +1,19 @@
-package com.team2.server.party.application.support
+package com.team2.server.party.infrastructure.persistence
 
 import com.team2.server.party.application.dto.RealtimePartyEndingInfo
+import com.team2.server.party.application.port.RealtimePartyEndingInfoPort
 import com.team2.server.party.domain.entity.RealtimeParty
 import com.team2.server.party.domain.entity.RealtimePartyEndingReason
-import com.team2.server.party.infrastructure.persistence.RealtimeParticipantProfileRepository
 import org.springframework.stereotype.Component
 import java.time.LocalDateTime
 
 @Component
-class RealtimePartyEndingInfoResolver(
+class RealtimePartyEndingInfoAdapter(
     private val profileRepository: RealtimeParticipantProfileRepository,
-) {
-    fun get(party: RealtimeParty): RealtimePartyEndingInfo = get(party, party.endingReason())
+) : RealtimePartyEndingInfoPort {
+    override fun get(party: RealtimeParty): RealtimePartyEndingInfo = get(party, party.endingReason())
 
-    fun get(
+    override fun get(
         party: RealtimeParty,
         now: LocalDateTime,
     ): RealtimePartyEndingInfo = get(party, party.endingReason(now))
@@ -24,7 +24,7 @@ class RealtimePartyEndingInfoResolver(
     ): RealtimePartyEndingInfo {
         val hostProfile =
             profileRepository.findByParticipantPartyIdAndParticipantIsCelebrantTrue(party.id)
-                ?: error("Realtime party host profile not found. partyId=${party.id}")
+                ?: throw IllegalStateException("Realtime party host profile not found. partyId=${party.id}")
         return RealtimePartyEndingInfo(
             endingReason = endingReason,
             hostNickname = hostProfile.nickname,

--- a/src/main/kotlin/com/team2/server/party/infrastructure/sse/PartyEndScheduler.kt
+++ b/src/main/kotlin/com/team2/server/party/infrastructure/sse/PartyEndScheduler.kt
@@ -86,6 +86,8 @@ class PartyEndScheduler(
                 partyId = event.partyId,
                 endingStartedAt = event.endingStartedAt,
                 endedAt = event.endedAt,
+                endingReason = event.endingReason,
+                hostNickname = event.hostNickname,
             ),
             emitEnding = true,
         )
@@ -174,6 +176,8 @@ class PartyEndScheduler(
             partyId = target.partyId,
             endingStartedAt = target.endingStartedAt,
             endedAt = target.endedAt,
+            endingReason = target.endingReason,
+            hostNickname = target.hostNickname,
         )
     }
 
@@ -192,7 +196,7 @@ class PartyEndScheduler(
                 }
             }
         if (!shouldSend) return
-        realtimePartyEventBroadcaster.broadcastPartyEnded(target.partyId, target.endedAt)
+        realtimePartyEventBroadcaster.broadcastPartyEnded(target.partyId, target.endedAt, target.hostNickname)
         taskScheduler.schedule(
             {
                 realtimePartyEventBroadcaster.completeParty(target.partyId)

--- a/src/test/kotlin/com/team2/server/chat/controller/ChatControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/chat/controller/ChatControllerTest.kt
@@ -319,6 +319,8 @@ class ChatControllerTest
                         startedAt = startedAt,
                     ),
                 )
+            val host = participantRepository.save(Participant(party = party, user = owner, isCelebrant = true))
+            profileRepository.save(RealtimeParticipantProfile(participant = host, nickname = "주최자"))
             val invite =
                 partyInviteRepository.save(
                     PartyInvite(

--- a/src/test/kotlin/com/team2/server/chat/infrastructure/sse/ChatRealtimePartyEventBroadcasterTest.kt
+++ b/src/test/kotlin/com/team2/server/chat/infrastructure/sse/ChatRealtimePartyEventBroadcasterTest.kt
@@ -1,5 +1,6 @@
 package com.team2.server.chat.infrastructure.sse
 
+import com.team2.server.party.domain.entity.RealtimePartyEndingReason
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
@@ -18,8 +19,14 @@ class ChatRealtimePartyEventBroadcasterTest {
 
     @Test
     fun `broadcasts realtime party events through chat SSE registry`() {
-        broadcaster.broadcastPartyEnding(partyId = 1L, endingStartedAt = now, endedAt = now.plusSeconds(60))
-        broadcaster.broadcastPartyEnded(partyId = 1L, endedAt = now.plusSeconds(60))
+        broadcaster.broadcastPartyEnding(
+            partyId = 1L,
+            endingStartedAt = now,
+            endedAt = now.plusSeconds(60),
+            endingReason = RealtimePartyEndingReason.TIME_LIMIT_REACHED,
+            hostNickname = "주최자",
+        )
+        broadcaster.broadcastPartyEnded(partyId = 1L, endedAt = now.plusSeconds(60), hostNickname = "주최자")
         broadcaster.completeParty(partyId = 1L)
 
         val eventCaptor = argumentCaptor<Set<ResponseBodyEmitter.DataWithMediaType>>()

--- a/src/test/kotlin/com/team2/server/chat/infrastructure/sse/ChatRealtimePartyEventBroadcasterTest.kt
+++ b/src/test/kotlin/com/team2/server/chat/infrastructure/sse/ChatRealtimePartyEventBroadcasterTest.kt
@@ -33,6 +33,24 @@ class ChatRealtimePartyEventBroadcasterTest {
         verify(sseEmitterRegistry, times(2)).broadcast(eq(1L), eventCaptor.capture(), anyOrNull())
         verify(sseEmitterRegistry).completeAll(1L)
         assertEquals(listOf("party-ending", "party-ended"), eventCaptor.allValues.map(::eventName))
+        assertEquals(
+            ChatRealtimePartyEventBroadcaster.PartyEndingPayload(
+                partyId = 1L,
+                endingStartedAt = now,
+                endedAt = now.plusSeconds(60),
+                endingReason = RealtimePartyEndingReason.TIME_LIMIT_REACHED,
+                hostNickname = "주최자",
+            ),
+            payload(eventCaptor.firstValue),
+        )
+        assertEquals(
+            ChatRealtimePartyEventBroadcaster.PartyEndedPayload(
+                partyId = 1L,
+                endedAt = now.plusSeconds(60),
+                hostNickname = "주최자",
+            ),
+            payload(eventCaptor.secondValue),
+        )
     }
 
     private fun eventName(event: Set<ResponseBodyEmitter.DataWithMediaType>): String {
@@ -43,4 +61,7 @@ class ChatRealtimePartyEventBroadcasterTest {
             else -> error("Unexpected SSE event: $rawEvent")
         }
     }
+
+    private inline fun <reified T> payload(event: Set<ResponseBodyEmitter.DataWithMediaType>): T =
+        event.map { it.data }.filterIsInstance<T>().single()
 }

--- a/src/test/kotlin/com/team2/server/chat/usecase/EnterAndSubscribeChatUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/chat/usecase/EnterAndSubscribeChatUseCaseTest.kt
@@ -1,5 +1,6 @@
 package com.team2.server.chat.usecase
 
+import com.team2.server.chat.application.dto.EnterRealtimePartyResult
 import com.team2.server.chat.dto.EnterRealtimePartyRequest
 import com.team2.server.chat.entity.ChatMessage
 import com.team2.server.chat.infrastructure.sse.ChatSseGateway
@@ -40,7 +41,7 @@ class EnterAndSubscribeChatUseCaseTest {
     private fun enterResult(
         partyId: Long = 1L,
         isCelebrant: Boolean = false,
-    ) = EnterRealtimePartyUseCase.EnterResult(
+    ) = EnterRealtimePartyResult(
         participantToken = "abc12345",
         partyId = partyId,
         startedAt = LocalDateTime.now().minusMinutes(5),
@@ -54,6 +55,8 @@ class EnterAndSubscribeChatUseCaseTest {
                 liveStartAt = LocalDateTime.now().minusMinutes(5),
                 endingStartedAt = null,
                 endedAt = LocalDateTime.now().plusMinutes(5).plusSeconds(60),
+                endingReason = null,
+                hostNickname = "주최자",
             ),
     )
 

--- a/src/test/kotlin/com/team2/server/chat/usecase/EnterRealtimePartyUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/chat/usecase/EnterRealtimePartyUseCaseTest.kt
@@ -8,8 +8,8 @@ import com.team2.server.common.exception.BusinessException
 import com.team2.server.common.exception.ErrorCode
 import com.team2.server.party.application.dto.RealtimePartyEndingInfo
 import com.team2.server.party.application.service.PartyInviteService
-import com.team2.server.party.application.support.RealtimePartyEndingInfoResolver
 import com.team2.server.party.application.usecase.MarkRealtimePartyHostEnteredUseCase
+import com.team2.server.party.application.usecase.ResolveRealtimePartyEndingInfoUseCase
 import com.team2.server.party.domain.entity.PaperOnlyParty
 import com.team2.server.party.domain.entity.PartyInvite
 import com.team2.server.party.domain.entity.RealtimeParty
@@ -39,7 +39,7 @@ class EnterRealtimePartyUseCaseTest {
 
     @Mock lateinit var markRealtimePartyHostEnteredUseCase: MarkRealtimePartyHostEnteredUseCase
 
-    @Mock lateinit var endingInfoResolver: RealtimePartyEndingInfoResolver
+    @Mock lateinit var resolveRealtimePartyEndingInfoUseCase: ResolveRealtimePartyEndingInfoUseCase
 
     lateinit var useCase: EnterRealtimePartyUseCase
 
@@ -55,12 +55,12 @@ class EnterRealtimePartyUseCaseTest {
                 partyInviteService = partyInviteService,
                 profileResolver = RealtimePartyEntryProfileResolver(entryProfilePort),
                 markRealtimePartyHostEnteredUseCase = markRealtimePartyHostEnteredUseCase,
-                endingInfoResolver = endingInfoResolver,
+                resolveRealtimePartyEndingInfoUseCase = resolveRealtimePartyEndingInfoUseCase,
                 clock = clock,
             )
         Mockito
             .lenient()
-            .`when`(endingInfoResolver.get(any(), any()))
+            .`when`(resolveRealtimePartyEndingInfoUseCase(any(), any()))
             .thenReturn(RealtimePartyEndingInfo(null, "주최자"))
     }
 

--- a/src/test/kotlin/com/team2/server/chat/usecase/EnterRealtimePartyUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/chat/usecase/EnterRealtimePartyUseCaseTest.kt
@@ -6,7 +6,9 @@ import com.team2.server.chat.application.support.RealtimePartyEntryProfileResolv
 import com.team2.server.chat.dto.EnterRealtimePartyRequest
 import com.team2.server.common.exception.BusinessException
 import com.team2.server.common.exception.ErrorCode
+import com.team2.server.party.application.dto.RealtimePartyEndingInfo
 import com.team2.server.party.application.service.PartyInviteService
+import com.team2.server.party.application.support.RealtimePartyEndingInfoResolver
 import com.team2.server.party.application.usecase.MarkRealtimePartyHostEnteredUseCase
 import com.team2.server.party.domain.entity.PaperOnlyParty
 import com.team2.server.party.domain.entity.PartyInvite
@@ -16,6 +18,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
+import org.mockito.Mockito
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
@@ -36,6 +39,8 @@ class EnterRealtimePartyUseCaseTest {
 
     @Mock lateinit var markRealtimePartyHostEnteredUseCase: MarkRealtimePartyHostEnteredUseCase
 
+    @Mock lateinit var endingInfoResolver: RealtimePartyEndingInfoResolver
+
     lateinit var useCase: EnterRealtimePartyUseCase
 
     private val request = EnterRealtimePartyRequest(nickname = "토끼왕", characterId = 1L)
@@ -50,8 +55,13 @@ class EnterRealtimePartyUseCaseTest {
                 partyInviteService = partyInviteService,
                 profileResolver = RealtimePartyEntryProfileResolver(entryProfilePort),
                 markRealtimePartyHostEnteredUseCase = markRealtimePartyHostEnteredUseCase,
+                endingInfoResolver = endingInfoResolver,
                 clock = clock,
             )
+        Mockito
+            .lenient()
+            .`when`(endingInfoResolver.get(any(), any()))
+            .thenReturn(RealtimePartyEndingInfo(null, "주최자"))
     }
 
     @Test

--- a/src/test/kotlin/com/team2/server/party/api/PartyControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/party/api/PartyControllerTest.kt
@@ -233,6 +233,8 @@ class PartyControllerTest
                     jsonPath("$.data.partyId") { value(party.id.toInt()) }
                     jsonPath("$.data.endingStartedAt") { exists() }
                     jsonPath("$.data.endedAt") { exists() }
+                    jsonPath("$.data.endingReason") { value("HOST_REQUEST") }
+                    jsonPath("$.data.hostNickname") { value("주최자") }
                 }
         }
 
@@ -259,6 +261,8 @@ class PartyControllerTest
                     status { isOk() }
                     jsonPath("$.data.partyId") { value(party.id.toInt()) }
                     jsonPath("$.data.status") { value("LIVE_OPEN") }
+                    jsonPath("$.data.endingReason") { doesNotExist() }
+                    jsonPath("$.data.hostNickname") { value("주최자") }
                 }
 
             mockMvc
@@ -271,6 +275,22 @@ class PartyControllerTest
                 }
 
             assertEquals(party.id, memberParticipant.party.id)
+        }
+
+        @Test
+        fun `자동 종료 카운트다운 상태는 종료 원인과 주최자 닉네임을 조회할 수 있다`() {
+            val owner = saveUser("kakao-realtime-state-ending", "state-ending@kakao.local")
+            val party = saveRealtimeParty(owner, LocalDateTime.now().minusMinutes(10).minusSeconds(10))
+
+            mockMvc
+                .get("/api/v1/parties/${party.id}/realtime-state") {
+                    header("Authorization", "Bearer ${tokenProvider.issue(owner)}")
+                }.andExpect {
+                    status { isOk() }
+                    jsonPath("$.data.status") { value("LIVE_ENDING") }
+                    jsonPath("$.data.endingReason") { value("TIME_LIMIT_REACHED") }
+                    jsonPath("$.data.hostNickname") { value("주최자") }
+                }
         }
 
         @Test
@@ -343,6 +363,13 @@ class PartyControllerTest
             startedAt: LocalDateTime,
         ): RealtimeParty {
             val party = partyRepository.save(RealtimeParty(ownerId = owner.id, startedAt = startedAt))
+            val host = participantRepository.save(Participant(party = party, user = owner, isCelebrant = true))
+            realtimeParticipantProfileRepository.save(
+                RealtimeParticipantProfile(
+                    participant = host,
+                    nickname = "주최자",
+                ),
+            )
             partyInviteRepository.save(
                 PartyInvite(
                     party = party,

--- a/src/test/kotlin/com/team2/server/party/application/event/RealtimePartyEndingEventPublisherTest.kt
+++ b/src/test/kotlin/com/team2/server/party/application/event/RealtimePartyEndingEventPublisherTest.kt
@@ -1,0 +1,60 @@
+package com.team2.server.party.application.event
+
+import com.team2.server.party.application.dto.RealtimeEndingScheduleTarget
+import com.team2.server.party.application.dto.RealtimePartyEndResult
+import com.team2.server.party.domain.entity.RealtimePartyEndingReason
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.springframework.context.ApplicationEventPublisher
+import java.time.LocalDateTime
+import kotlin.test.assertEquals
+
+class RealtimePartyEndingEventPublisherTest {
+    private val applicationEventPublisher: ApplicationEventPublisher = mock()
+    private val publisher = RealtimePartyEndingEventPublisher(applicationEventPublisher)
+    private val endingStartedAt = LocalDateTime.of(2026, 6, 7, 10, 0)
+    private val endedAt = endingStartedAt.plusSeconds(60)
+
+    @Test
+    fun `publishes ending result display info`() {
+        publisher.publish(
+            RealtimePartyEndResult(
+                partyId = 1L,
+                endingStartedAt = endingStartedAt,
+                endedAt = endedAt,
+                endingReason = RealtimePartyEndingReason.HOST_REQUEST,
+                hostNickname = "주최자",
+            ),
+        )
+
+        assertPublishedEvent(RealtimePartyEndingReason.HOST_REQUEST)
+    }
+
+    @Test
+    fun `publishes schedule target display info`() {
+        publisher.publish(
+            RealtimeEndingScheduleTarget(
+                partyId = 1L,
+                endingStartedAt = endingStartedAt,
+                endedAt = endedAt,
+                endingReason = RealtimePartyEndingReason.TIME_LIMIT_REACHED,
+                hostNickname = "주최자",
+                startedNow = true,
+            ),
+        )
+
+        assertPublishedEvent(RealtimePartyEndingReason.TIME_LIMIT_REACHED)
+    }
+
+    private fun assertPublishedEvent(endingReason: RealtimePartyEndingReason) {
+        val captor = argumentCaptor<RealtimePartyEndingStartedEvent>()
+        verify(applicationEventPublisher).publishEvent(captor.capture())
+        assertEquals(1L, captor.firstValue.partyId)
+        assertEquals(endingStartedAt, captor.firstValue.endingStartedAt)
+        assertEquals(endedAt, captor.firstValue.endedAt)
+        assertEquals(endingReason, captor.firstValue.endingReason)
+        assertEquals("주최자", captor.firstValue.hostNickname)
+    }
+}

--- a/src/test/kotlin/com/team2/server/party/application/service/RealtimePartyEndServiceTest.kt
+++ b/src/test/kotlin/com/team2/server/party/application/service/RealtimePartyEndServiceTest.kt
@@ -2,6 +2,8 @@ package com.team2.server.party.application.service
 
 import com.team2.server.common.exception.BusinessException
 import com.team2.server.common.exception.ErrorCode
+import com.team2.server.party.application.dto.RealtimePartyEndingInfo
+import com.team2.server.party.application.support.RealtimePartyEndingInfoResolver
 import com.team2.server.party.domain.entity.PaperOnlyParty
 import com.team2.server.party.domain.entity.Party
 import com.team2.server.party.domain.entity.RealtimeParty
@@ -20,7 +22,8 @@ import kotlin.test.assertSame
 
 class RealtimePartyEndServiceTest {
     private val partyRepository: PartyRepository = mock()
-    private val service = RealtimePartyEndService(partyRepository)
+    private val endingInfoResolver: RealtimePartyEndingInfoResolver = mock()
+    private val service = RealtimePartyEndService(partyRepository, endingInfoResolver)
     private val startedAt = LocalDateTime.of(2026, 5, 23, 10, 0)
 
     @Test
@@ -28,6 +31,10 @@ class RealtimePartyEndServiceTest {
         val party = realtimeParty(id = 1L, liveEndingStartedAt = startedAt.plusMinutes(5))
         whenever(partyRepository.startRealtimeEndingIfNotStarted(eq(1L), any())).thenReturn(1)
         whenever(partyRepository.findPartyById(1L)).thenReturn(party)
+        whenever(endingInfoResolver.get(party))
+            .thenReturn(RealtimePartyEndingInfo(party.endingReason(), "주최자"))
+        whenever(endingInfoResolver.get(party))
+            .thenReturn(RealtimePartyEndingInfo(party.endingReason(), "주최자"))
 
         val result = service.startIfNotStarted(1L, startedAt.plusMinutes(5))
 
@@ -52,6 +59,8 @@ class RealtimePartyEndServiceTest {
         val party = realtimeParty(id = 1L, liveEndingStartedAt = endingStartedAt)
         whenever(partyRepository.startRealtimeEndingIfNotStarted(eq(1L), any())).thenReturn(1)
         whenever(partyRepository.findPartyById(1L)).thenReturn(party)
+        whenever(endingInfoResolver.get(party))
+            .thenReturn(RealtimePartyEndingInfo(party.endingReason(), "주최자"))
 
         val result = service.startIfNotStartedOrNull(1L, endingStartedAt)
 
@@ -91,6 +100,8 @@ class RealtimePartyEndServiceTest {
         val endingStartedAt = startedAt.plusMinutes(4)
         val party = realtimeParty(id = 3L, liveEndingStartedAt = endingStartedAt)
         whenever(partyRepository.findRealtimePartiesWithEndingStarted(any())).thenReturn(listOf(party))
+        whenever(endingInfoResolver.get(party))
+            .thenReturn(RealtimePartyEndingInfo(party.endingReason(), "주최자"))
 
         val result = service.findEndingTargets(startedAt.plusDays(1))
 

--- a/src/test/kotlin/com/team2/server/party/application/service/RealtimePartyEndServiceTest.kt
+++ b/src/test/kotlin/com/team2/server/party/application/service/RealtimePartyEndServiceTest.kt
@@ -7,6 +7,7 @@ import com.team2.server.party.application.port.RealtimePartyEndingInfoPort
 import com.team2.server.party.domain.entity.PaperOnlyParty
 import com.team2.server.party.domain.entity.Party
 import com.team2.server.party.domain.entity.RealtimeParty
+import com.team2.server.party.domain.entity.RealtimePartyEndingReason
 import com.team2.server.party.infrastructure.persistence.PartyRepository
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -65,6 +66,8 @@ class RealtimePartyEndServiceTest {
         assertEquals(1L, result?.partyId)
         assertEquals(endingStartedAt, result?.endingStartedAt)
         assertEquals(endingStartedAt.plusSeconds(RealtimeParty.LIVE_END_COUNTDOWN_SECONDS), result?.endedAt)
+        assertEquals(RealtimePartyEndingReason.HOST_REQUEST, result?.endingReason)
+        assertEquals("주최자", result?.hostNickname)
         assertEquals(true, result?.startedNow)
     }
 
@@ -106,6 +109,8 @@ class RealtimePartyEndServiceTest {
         assertEquals(3L, result.single().partyId)
         assertEquals(endingStartedAt, result.single().endingStartedAt)
         assertEquals(endingStartedAt.plusSeconds(RealtimeParty.LIVE_END_COUNTDOWN_SECONDS), result.single().endedAt)
+        assertEquals(RealtimePartyEndingReason.HOST_REQUEST, result.single().endingReason)
+        assertEquals("주최자", result.single().hostNickname)
         assertEquals(false, result.single().startedNow)
     }
 

--- a/src/test/kotlin/com/team2/server/party/application/service/RealtimePartyEndServiceTest.kt
+++ b/src/test/kotlin/com/team2/server/party/application/service/RealtimePartyEndServiceTest.kt
@@ -3,7 +3,7 @@ package com.team2.server.party.application.service
 import com.team2.server.common.exception.BusinessException
 import com.team2.server.common.exception.ErrorCode
 import com.team2.server.party.application.dto.RealtimePartyEndingInfo
-import com.team2.server.party.application.support.RealtimePartyEndingInfoResolver
+import com.team2.server.party.application.port.RealtimePartyEndingInfoPort
 import com.team2.server.party.domain.entity.PaperOnlyParty
 import com.team2.server.party.domain.entity.Party
 import com.team2.server.party.domain.entity.RealtimeParty
@@ -22,8 +22,8 @@ import kotlin.test.assertSame
 
 class RealtimePartyEndServiceTest {
     private val partyRepository: PartyRepository = mock()
-    private val endingInfoResolver: RealtimePartyEndingInfoResolver = mock()
-    private val service = RealtimePartyEndService(partyRepository, endingInfoResolver)
+    private val endingInfoPort: RealtimePartyEndingInfoPort = mock()
+    private val service = RealtimePartyEndService(partyRepository, endingInfoPort)
     private val startedAt = LocalDateTime.of(2026, 5, 23, 10, 0)
 
     @Test
@@ -31,9 +31,7 @@ class RealtimePartyEndServiceTest {
         val party = realtimeParty(id = 1L, liveEndingStartedAt = startedAt.plusMinutes(5))
         whenever(partyRepository.startRealtimeEndingIfNotStarted(eq(1L), any())).thenReturn(1)
         whenever(partyRepository.findPartyById(1L)).thenReturn(party)
-        whenever(endingInfoResolver.get(party))
-            .thenReturn(RealtimePartyEndingInfo(party.endingReason(), "주최자"))
-        whenever(endingInfoResolver.get(party))
+        whenever(endingInfoPort.get(party))
             .thenReturn(RealtimePartyEndingInfo(party.endingReason(), "주최자"))
 
         val result = service.startIfNotStarted(1L, startedAt.plusMinutes(5))
@@ -59,7 +57,7 @@ class RealtimePartyEndServiceTest {
         val party = realtimeParty(id = 1L, liveEndingStartedAt = endingStartedAt)
         whenever(partyRepository.startRealtimeEndingIfNotStarted(eq(1L), any())).thenReturn(1)
         whenever(partyRepository.findPartyById(1L)).thenReturn(party)
-        whenever(endingInfoResolver.get(party))
+        whenever(endingInfoPort.get(party))
             .thenReturn(RealtimePartyEndingInfo(party.endingReason(), "주최자"))
 
         val result = service.startIfNotStartedOrNull(1L, endingStartedAt)
@@ -100,7 +98,7 @@ class RealtimePartyEndServiceTest {
         val endingStartedAt = startedAt.plusMinutes(4)
         val party = realtimeParty(id = 3L, liveEndingStartedAt = endingStartedAt)
         whenever(partyRepository.findRealtimePartiesWithEndingStarted(any())).thenReturn(listOf(party))
-        whenever(endingInfoResolver.get(party))
+        whenever(endingInfoPort.get(party))
             .thenReturn(RealtimePartyEndingInfo(party.endingReason(), "주최자"))
 
         val result = service.findEndingTargets(startedAt.plusDays(1))

--- a/src/test/kotlin/com/team2/server/party/application/support/RealtimePartyEndingInfoResolverTest.kt
+++ b/src/test/kotlin/com/team2/server/party/application/support/RealtimePartyEndingInfoResolverTest.kt
@@ -1,0 +1,56 @@
+package com.team2.server.party.application.support
+
+import com.team2.server.party.domain.entity.Participant
+import com.team2.server.party.domain.entity.RealtimeParticipantProfile
+import com.team2.server.party.domain.entity.RealtimeParty
+import com.team2.server.party.domain.entity.RealtimePartyEndingReason
+import com.team2.server.party.infrastructure.persistence.RealtimeParticipantProfileRepository
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.time.LocalDateTime
+import kotlin.test.assertEquals
+
+class RealtimePartyEndingInfoResolverTest {
+    private val profileRepository: RealtimeParticipantProfileRepository = mock()
+    private val resolver = RealtimePartyEndingInfoResolver(profileRepository)
+    private val startedAt = LocalDateTime.of(2026, 6, 6, 10, 0)
+
+    @Test
+    fun `returns ending reason and host profile nickname`() {
+        val party = realtimeParty(1L).apply { liveEndingStartedAt = startedAt.plusMinutes(5) }
+        val profile = RealtimeParticipantProfile(Participant(party = party, isCelebrant = true), "주최자")
+        whenever(profileRepository.findByParticipantPartyIdAndParticipantIsCelebrantTrue(1L)).thenReturn(profile)
+
+        val result = resolver.get(party)
+
+        assertEquals(RealtimePartyEndingReason.HOST_REQUEST, result.endingReason)
+        assertEquals("주최자", result.hostNickname)
+    }
+
+    @Test
+    fun `throws when host profile is missing`() {
+        val party = realtimeParty(1L)
+        whenever(profileRepository.findByParticipantPartyIdAndParticipantIsCelebrantTrue(1L)).thenReturn(null)
+
+        assertThrows<IllegalStateException> { resolver.get(party) }
+    }
+
+    private fun realtimeParty(id: Long): RealtimeParty {
+        val party = RealtimeParty(ownerId = 1L, startedAt = startedAt)
+        var type: Class<*>? = party.javaClass
+        while (type != null) {
+            try {
+                type.getDeclaredField("id").also { field ->
+                    field.isAccessible = true
+                    field.set(party, id)
+                }
+                return party
+            } catch (_: NoSuchFieldException) {
+                type = type.superclass
+            }
+        }
+        error("Could not set party id")
+    }
+}

--- a/src/test/kotlin/com/team2/server/party/application/usecase/RecoverRealtimePartyEndScheduleUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/party/application/usecase/RecoverRealtimePartyEndScheduleUseCaseTest.kt
@@ -4,6 +4,7 @@ import com.team2.server.party.application.dto.RealtimeAutomaticEndSchedule
 import com.team2.server.party.application.dto.RealtimeEndingScheduleTarget
 import com.team2.server.party.application.dto.RealtimePartyEndRecoverySchedules
 import com.team2.server.party.application.service.RealtimePartyEndService
+import com.team2.server.party.domain.entity.RealtimePartyEndingReason
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -29,7 +30,18 @@ class RecoverRealtimePartyEndScheduleUseCaseTest {
                 ),
             )
         whenever(realtimePartyEndService.findEndingTargets(now))
-            .thenReturn(listOf(RealtimeEndingScheduleTarget(2L, now.minusMinutes(1), now, startedNow = true)))
+            .thenReturn(
+                listOf(
+                    RealtimeEndingScheduleTarget(
+                        partyId = 2L,
+                        endingStartedAt = now.minusMinutes(1),
+                        endedAt = now,
+                        endingReason = RealtimePartyEndingReason.HOST_REQUEST,
+                        hostNickname = "주최자",
+                        startedNow = true,
+                    ),
+                ),
+            )
 
         val result = useCase()
 

--- a/src/test/kotlin/com/team2/server/party/application/usecase/StartAutomaticRealtimePartyEndUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/party/application/usecase/StartAutomaticRealtimePartyEndUseCaseTest.kt
@@ -1,0 +1,61 @@
+package com.team2.server.party.application.usecase
+
+import com.team2.server.party.application.dto.RealtimeEndingScheduleTarget
+import com.team2.server.party.application.event.RealtimePartyEndingEventPublisher
+import com.team2.server.party.application.service.RealtimePartyEndService
+import com.team2.server.party.domain.entity.RealtimePartyEndingReason
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.LocalDateTime
+import kotlin.test.assertSame
+
+class StartAutomaticRealtimePartyEndUseCaseTest {
+    private val realtimePartyEndService: RealtimePartyEndService = mock()
+    private val eventPublisher: RealtimePartyEndingEventPublisher = mock()
+    private val useCase = StartAutomaticRealtimePartyEndUseCase(realtimePartyEndService, eventPublisher)
+    private val endingStartedAt = LocalDateTime.of(2026, 6, 7, 10, 0)
+
+    @Test
+    fun `returns null without publishing when ending target is absent`() {
+        whenever(realtimePartyEndService.startIfNotStartedOrNull(1L, endingStartedAt)).thenReturn(null)
+
+        useCase(1L, endingStartedAt)
+
+        verify(eventPublisher, never()).publish(org.mockito.kotlin.any<RealtimeEndingScheduleTarget>())
+    }
+
+    @Test
+    fun `publishes when automatic ending starts now`() {
+        val target = target(startedNow = true)
+        whenever(realtimePartyEndService.startIfNotStartedOrNull(1L, endingStartedAt)).thenReturn(target)
+
+        val result = useCase(1L, endingStartedAt)
+
+        assertSame(target, result)
+        verify(eventPublisher).publish(target)
+    }
+
+    @Test
+    fun `does not publish when automatic ending already started`() {
+        val target = target(startedNow = false)
+        whenever(realtimePartyEndService.startIfNotStartedOrNull(1L, endingStartedAt)).thenReturn(target)
+
+        val result = useCase(1L, endingStartedAt)
+
+        assertSame(target, result)
+        verify(eventPublisher, never()).publish(target)
+    }
+
+    private fun target(startedNow: Boolean) =
+        RealtimeEndingScheduleTarget(
+            partyId = 1L,
+            endingStartedAt = endingStartedAt,
+            endedAt = endingStartedAt.plusSeconds(60),
+            endingReason = RealtimePartyEndingReason.TIME_LIMIT_REACHED,
+            hostNickname = "주최자",
+            startedNow = startedNow,
+        )
+}

--- a/src/test/kotlin/com/team2/server/party/application/usecase/StartAutomaticRealtimePartyEndUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/party/application/usecase/StartAutomaticRealtimePartyEndUseCaseTest.kt
@@ -10,6 +10,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.time.LocalDateTime
+import kotlin.test.assertNull
 import kotlin.test.assertSame
 
 class StartAutomaticRealtimePartyEndUseCaseTest {
@@ -22,8 +23,9 @@ class StartAutomaticRealtimePartyEndUseCaseTest {
     fun `returns null without publishing when ending target is absent`() {
         whenever(realtimePartyEndService.startIfNotStartedOrNull(1L, endingStartedAt)).thenReturn(null)
 
-        useCase(1L, endingStartedAt)
+        val result = useCase(1L, endingStartedAt)
 
+        assertNull(result)
         verify(eventPublisher, never()).publish(org.mockito.kotlin.any<RealtimeEndingScheduleTarget>())
     }
 

--- a/src/test/kotlin/com/team2/server/party/application/usecase/StartRealtimePartyEndUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/party/application/usecase/StartRealtimePartyEndUseCaseTest.kt
@@ -5,9 +5,9 @@ import com.team2.server.common.exception.ErrorCode
 import com.team2.server.party.application.dto.RealtimePartyEndStartResult
 import com.team2.server.party.application.dto.RealtimePartyEndingInfo
 import com.team2.server.party.application.event.RealtimePartyEndingEventPublisher
+import com.team2.server.party.application.port.RealtimePartyEndingInfoPort
 import com.team2.server.party.application.service.PartyService
 import com.team2.server.party.application.service.RealtimePartyEndService
-import com.team2.server.party.application.support.RealtimePartyEndingInfoResolver
 import com.team2.server.party.domain.entity.Party
 import com.team2.server.party.domain.entity.RealtimeParty
 import org.junit.jupiter.api.Test
@@ -24,7 +24,7 @@ import kotlin.test.assertEquals
 class StartRealtimePartyEndUseCaseTest {
     private val partyService: PartyService = mock()
     private val realtimePartyEndService: RealtimePartyEndService = mock()
-    private val endingInfoResolver: RealtimePartyEndingInfoResolver = mock()
+    private val endingInfoPort: RealtimePartyEndingInfoPort = mock()
     private val eventPublisher: RealtimePartyEndingEventPublisher = mock()
     private val zone = ZoneId.of("Asia/Seoul")
     private val now = LocalDateTime.of(2026, 5, 23, 10, 0)
@@ -33,7 +33,7 @@ class StartRealtimePartyEndUseCaseTest {
         StartRealtimePartyEndUseCase(
             partyService,
             realtimePartyEndService,
-            endingInfoResolver,
+            endingInfoPort,
             eventPublisher,
             clock,
         )
@@ -76,7 +76,7 @@ class StartRealtimePartyEndUseCaseTest {
         whenever(partyService.requireRealtimeParty(1L)).thenReturn(party)
         whenever(realtimePartyEndService.startIfNotStarted(1L, endingStartedAt))
             .thenReturn(RealtimePartyEndStartResult(affected = 1, party = endedParty))
-        whenever(endingInfoResolver.get(endedParty))
+        whenever(endingInfoPort.get(endedParty))
             .thenReturn(RealtimePartyEndingInfo(endedParty.endingReason(), "주최자"))
 
         val result = useCase(1L, userId = 1L)
@@ -92,7 +92,7 @@ class StartRealtimePartyEndUseCaseTest {
         whenever(partyService.requireRealtimeParty(1L)).thenReturn(party)
         whenever(realtimePartyEndService.startIfNotStarted(1L, endingStartedAt))
             .thenReturn(RealtimePartyEndStartResult(affected = 0, party = party))
-        whenever(endingInfoResolver.get(party))
+        whenever(endingInfoPort.get(party))
             .thenReturn(RealtimePartyEndingInfo(party.endingReason(), "주최자"))
 
         val result = useCase(1L, userId = 1L)
@@ -115,7 +115,7 @@ class StartRealtimePartyEndUseCaseTest {
         whenever(partyService.requireRealtimeParty(1L)).thenReturn(party)
         whenever(realtimePartyEndService.startIfNotStarted(1L, party.automaticEndingStartedAt()))
             .thenReturn(RealtimePartyEndStartResult(affected = 0, party = endedParty))
-        whenever(endingInfoResolver.get(endedParty))
+        whenever(endingInfoPort.get(endedParty))
             .thenReturn(RealtimePartyEndingInfo(endedParty.endingReason(), "주최자"))
 
         val result = useCase(1L, userId = 1L)

--- a/src/test/kotlin/com/team2/server/party/application/usecase/StartRealtimePartyEndUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/party/application/usecase/StartRealtimePartyEndUseCaseTest.kt
@@ -3,9 +3,11 @@ package com.team2.server.party.application.usecase
 import com.team2.server.common.exception.BusinessException
 import com.team2.server.common.exception.ErrorCode
 import com.team2.server.party.application.dto.RealtimePartyEndStartResult
+import com.team2.server.party.application.dto.RealtimePartyEndingInfo
 import com.team2.server.party.application.event.RealtimePartyEndingEventPublisher
 import com.team2.server.party.application.service.PartyService
 import com.team2.server.party.application.service.RealtimePartyEndService
+import com.team2.server.party.application.support.RealtimePartyEndingInfoResolver
 import com.team2.server.party.domain.entity.Party
 import com.team2.server.party.domain.entity.RealtimeParty
 import org.junit.jupiter.api.Test
@@ -22,6 +24,7 @@ import kotlin.test.assertEquals
 class StartRealtimePartyEndUseCaseTest {
     private val partyService: PartyService = mock()
     private val realtimePartyEndService: RealtimePartyEndService = mock()
+    private val endingInfoResolver: RealtimePartyEndingInfoResolver = mock()
     private val eventPublisher: RealtimePartyEndingEventPublisher = mock()
     private val zone = ZoneId.of("Asia/Seoul")
     private val now = LocalDateTime.of(2026, 5, 23, 10, 0)
@@ -30,6 +33,7 @@ class StartRealtimePartyEndUseCaseTest {
         StartRealtimePartyEndUseCase(
             partyService,
             realtimePartyEndService,
+            endingInfoResolver,
             eventPublisher,
             clock,
         )
@@ -72,6 +76,8 @@ class StartRealtimePartyEndUseCaseTest {
         whenever(partyService.requireRealtimeParty(1L)).thenReturn(party)
         whenever(realtimePartyEndService.startIfNotStarted(1L, endingStartedAt))
             .thenReturn(RealtimePartyEndStartResult(affected = 1, party = endedParty))
+        whenever(endingInfoResolver.get(endedParty))
+            .thenReturn(RealtimePartyEndingInfo(endedParty.endingReason(), "주최자"))
 
         val result = useCase(1L, userId = 1L)
 
@@ -86,6 +92,8 @@ class StartRealtimePartyEndUseCaseTest {
         whenever(partyService.requireRealtimeParty(1L)).thenReturn(party)
         whenever(realtimePartyEndService.startIfNotStarted(1L, endingStartedAt))
             .thenReturn(RealtimePartyEndStartResult(affected = 0, party = party))
+        whenever(endingInfoResolver.get(party))
+            .thenReturn(RealtimePartyEndingInfo(party.endingReason(), "주최자"))
 
         val result = useCase(1L, userId = 1L)
 
@@ -107,6 +115,8 @@ class StartRealtimePartyEndUseCaseTest {
         whenever(partyService.requireRealtimeParty(1L)).thenReturn(party)
         whenever(realtimePartyEndService.startIfNotStarted(1L, party.automaticEndingStartedAt()))
             .thenReturn(RealtimePartyEndStartResult(affected = 0, party = endedParty))
+        whenever(endingInfoResolver.get(endedParty))
+            .thenReturn(RealtimePartyEndingInfo(endedParty.endingReason(), "주최자"))
 
         val result = useCase(1L, userId = 1L)
 

--- a/src/test/kotlin/com/team2/server/party/domain/entity/PartyStatusTest.kt
+++ b/src/test/kotlin/com/team2/server/party/domain/entity/PartyStatusTest.kt
@@ -144,8 +144,23 @@ class PartyStatusTest {
         val endingStartedAt = liveStart.plusMinutes(6)
         val party = realtimeParty().apply { liveEndingStartedAt = endingStartedAt }
         assertEquals(endingStartedAt, party.hostViewableAt())
+        assertEquals(RealtimePartyEndingReason.HOST_REQUEST, party.endingReason())
         assertEquals(RealtimePartyStatus.LIVE_ENDING, party.status(endingStartedAt))
         assertEquals(RealtimePartyStatus.LIVE_CLOSED, party.status(endingStartedAt.plusSeconds(60)))
+    }
+
+    @Test
+    fun `RealtimeParty - 자동 종료 시각부터는 TIME_LIMIT_REACHED`() {
+        val party = realtimeParty().apply { liveEndingStartedAt = automaticEndingStartedAt() }
+
+        assertEquals(RealtimePartyEndingReason.TIME_LIMIT_REACHED, party.endingReason())
+    }
+
+    @Test
+    fun `RealtimeParty - 자동 종료 시각이 지나면 저장 전에도 TIME_LIMIT_REACHED`() {
+        val party = realtimeParty()
+
+        assertEquals(RealtimePartyEndingReason.TIME_LIMIT_REACHED, party.endingReason(party.automaticEndingStartedAt()))
     }
 
     @Test

--- a/src/test/kotlin/com/team2/server/party/infrastructure/persistence/RealtimePartyEndingInfoAdapterTest.kt
+++ b/src/test/kotlin/com/team2/server/party/infrastructure/persistence/RealtimePartyEndingInfoAdapterTest.kt
@@ -1,10 +1,9 @@
-package com.team2.server.party.application.support
+package com.team2.server.party.infrastructure.persistence
 
 import com.team2.server.party.domain.entity.Participant
 import com.team2.server.party.domain.entity.RealtimeParticipantProfile
 import com.team2.server.party.domain.entity.RealtimeParty
 import com.team2.server.party.domain.entity.RealtimePartyEndingReason
-import com.team2.server.party.infrastructure.persistence.RealtimeParticipantProfileRepository
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.mock
@@ -12,9 +11,9 @@ import org.mockito.kotlin.whenever
 import java.time.LocalDateTime
 import kotlin.test.assertEquals
 
-class RealtimePartyEndingInfoResolverTest {
+class RealtimePartyEndingInfoAdapterTest {
     private val profileRepository: RealtimeParticipantProfileRepository = mock()
-    private val resolver = RealtimePartyEndingInfoResolver(profileRepository)
+    private val adapter = RealtimePartyEndingInfoAdapter(profileRepository)
     private val startedAt = LocalDateTime.of(2026, 6, 6, 10, 0)
 
     @Test
@@ -23,7 +22,7 @@ class RealtimePartyEndingInfoResolverTest {
         val profile = RealtimeParticipantProfile(Participant(party = party, isCelebrant = true), "주최자")
         whenever(profileRepository.findByParticipantPartyIdAndParticipantIsCelebrantTrue(1L)).thenReturn(profile)
 
-        val result = resolver.get(party)
+        val result = adapter.get(party)
 
         assertEquals(RealtimePartyEndingReason.HOST_REQUEST, result.endingReason)
         assertEquals("주최자", result.hostNickname)
@@ -34,7 +33,7 @@ class RealtimePartyEndingInfoResolverTest {
         val party = realtimeParty(1L)
         whenever(profileRepository.findByParticipantPartyIdAndParticipantIsCelebrantTrue(1L)).thenReturn(null)
 
-        assertThrows<IllegalStateException> { resolver.get(party) }
+        assertThrows<IllegalStateException> { adapter.get(party) }
     }
 
     private fun realtimeParty(id: Long): RealtimeParty {

--- a/src/test/kotlin/com/team2/server/party/infrastructure/sse/PartyEndSchedulerTest.kt
+++ b/src/test/kotlin/com/team2/server/party/infrastructure/sse/PartyEndSchedulerTest.kt
@@ -9,6 +9,7 @@ import com.team2.server.party.application.port.PartyPhaseStore
 import com.team2.server.party.application.port.RealtimePartyEventBroadcaster
 import com.team2.server.party.application.usecase.RecoverRealtimePartyEndScheduleUseCase
 import com.team2.server.party.application.usecase.StartAutomaticRealtimePartyEndUseCase
+import com.team2.server.party.domain.entity.RealtimePartyEndingReason
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
@@ -66,6 +67,8 @@ class PartyEndSchedulerTest {
                 partyId = 1L,
                 endingStartedAt = endingStartedAt,
                 endedAt = endingStartedAt.plusSeconds(60),
+                endingReason = RealtimePartyEndingReason.TIME_LIMIT_REACHED,
+                hostNickname = "주최자",
                 startedNow = true,
             )
         whenever(startAutomaticRealtimePartyEndUseCase(1L, endingStartedAt)).thenReturn(target)
@@ -79,8 +82,10 @@ class PartyEndSchedulerTest {
             partyId = eq(1L),
             endingStartedAt = eq(endingStartedAt),
             endedAt = eq(endingStartedAt.plusSeconds(60)),
+            endingReason = eq(RealtimePartyEndingReason.TIME_LIMIT_REACHED),
+            hostNickname = eq("주최자"),
         )
-        verify(realtimePartyEventBroadcaster).broadcastPartyEnded(1L, endingStartedAt.plusSeconds(60))
+        verify(realtimePartyEventBroadcaster).broadcastPartyEnded(1L, endingStartedAt.plusSeconds(60), "주최자")
         verify(realtimePartyEventBroadcaster).completeParty(1L)
     }
 
@@ -94,7 +99,7 @@ class PartyEndSchedulerTest {
         scheduledTasks[0].run()
 
         assertEquals(1, scheduledTasks.size)
-        verify(realtimePartyEventBroadcaster, never()).broadcastPartyEnding(any(), any(), any())
+        verify(realtimePartyEventBroadcaster, never()).broadcastPartyEnding(any(), any(), any(), any(), any())
     }
 
     @Test
@@ -103,19 +108,26 @@ class PartyEndSchedulerTest {
         whenever(recoverRealtimePartyEndScheduleUseCase()).thenReturn(
             RealtimePartyEndRecoveryResult(
                 automaticEndSchedules = listOf(RealtimeAutomaticEndSchedule(1L, endingStartedAt)),
-                endingTargets = listOf(RealtimeEndingScheduleTarget(2L, now.minusSeconds(10), now.plusSeconds(50))),
+                endingTargets =
+                    listOf(
+                        target(
+                            partyId = 2L,
+                            endingStartedAt = now.minusSeconds(10),
+                            endedAt = now.plusSeconds(50),
+                        ),
+                    ),
             ),
         )
 
         scheduler.recoverSchedules()
 
         assertEquals(2, scheduledTasks.size)
-        verify(realtimePartyEventBroadcaster, never()).broadcastPartyEnding(eq(2L), any(), any())
+        verify(realtimePartyEventBroadcaster, never()).broadcastPartyEnding(eq(2L), any(), any(), any(), any())
     }
 
     @Test
     fun `late party-ending is skipped when party-ended was already sent`() {
-        val target = RealtimeEndingScheduleTarget(1L, now.minusSeconds(70), now.minusSeconds(10))
+        val target = target(1L, now.minusSeconds(70), now.minusSeconds(10))
         whenever(recoverRealtimePartyEndScheduleUseCase()).thenReturn(
             RealtimePartyEndRecoveryResult(
                 automaticEndSchedules = emptyList(),
@@ -130,10 +142,12 @@ class PartyEndSchedulerTest {
                 partyId = 1L,
                 endingStartedAt = target.endingStartedAt,
                 endedAt = target.endedAt,
+                endingReason = target.endingReason,
+                hostNickname = target.hostNickname,
             ),
         )
 
-        verify(realtimePartyEventBroadcaster, times(1)).broadcastPartyEnded(eq(1L), any())
+        verify(realtimePartyEventBroadcaster, times(1)).broadcastPartyEnded(eq(1L), any(), eq("주최자"))
     }
 
     @Test
@@ -144,6 +158,8 @@ class PartyEndSchedulerTest {
                 partyId = 1L,
                 endingStartedAt = now,
                 endedAt = now.plusSeconds(60),
+                endingReason = RealtimePartyEndingReason.HOST_REQUEST,
+                hostNickname = "주최자",
             ),
         )
 
@@ -151,4 +167,17 @@ class PartyEndSchedulerTest {
 
         scheduledFutures.forEach { verify(it).cancel(false) }
     }
+
+    private fun target(
+        partyId: Long,
+        endingStartedAt: LocalDateTime,
+        endedAt: LocalDateTime,
+    ): RealtimeEndingScheduleTarget =
+        RealtimeEndingScheduleTarget(
+            partyId = partyId,
+            endingStartedAt = endingStartedAt,
+            endedAt = endedAt,
+            endingReason = RealtimePartyEndingReason.HOST_REQUEST,
+            hostNickname = "주최자",
+        )
 }


### PR DESCRIPTION
## 🔗 Issue
- closes #206

## 💬 Context
실시간 파티 종료 카운트다운과 종료 안내에서 프론트가 종료 원인과 주최자 닉네임을 표시할 수 있도록 응답 계약을 확장합니다.

## 🛠 Changes
- 종료 원인을 `HOST_REQUEST`, `TIME_LIMIT_REACHED`로 구분
- 종료 API, 실시간 파티 상태, `party-ending` SSE에 `endingReason`, `hostNickname` 추가
- `party-ended` SSE에 `hostNickname` 추가
- 스케줄 복구 흐름에서도 종료 표시 정보 유지
- 종료 원인 경계값과 API/SSE/스케줄러 회귀 테스트 추가

## 👀 Review Focus
- 10분 도달 시 `TIME_LIMIT_REACHED`로 판정하는 경계값
- API 및 SSE별 `endingReason`, `hostNickname` 제공 범위
- 재시작 후 스케줄 복구 시 동일한 종료 표시 정보 전달 여부

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새 기능**
  * 실시간 파티 자동 종료 기능 추가 (시작 후 10분)
  * 주최자가 파티를 수동으로 종료할 수 있는 기능 개선
  * 파티 종료 사유 표시 (주최자 요청 vs 시간 제한)
  * 파티 상태 조회 시 주최자 정보 포함

* **개선 사항**
  * 실시간 파티 상태 복구 API에 종료 관련 정보 추가
  * 파티 종료 카운트다운 화면에서 종료 사유 명시
<!-- end of auto-generated comment: release notes by coderabbit.ai -->