### PR TITLE
[Fix] 실시간 파티 페이즈/참여자/채팅 버그 수정

### DIFF
--- a/src/main/kotlin/com/team2/server/chat/infrastructure/party/PartyRealtimePartyEntryProfileAdapter.kt
+++ b/src/main/kotlin/com/team2/server/chat/infrastructure/party/PartyRealtimePartyEntryProfileAdapter.kt
@@ -61,13 +61,14 @@ class PartyRealtimePartyEntryProfileAdapter(
         character: Character,
         now: LocalDateTime,
     ): RealtimeParticipantProfile {
-        val profile = realtimeParticipantProfileService.requireByParticipantToken(participantToken, party.id)
+        val profile = realtimeParticipantProfileService.requireForReentryByParticipantToken(participantToken, party.id)
         if (party.status(now) !in RECONNECTABLE_STATUSES) {
             throw BusinessException(ErrorCode.CHAT_NOT_ACTIVE)
         }
         if (profile.participant.isCelebrant && profile.nickname != nickname) {
             throw BusinessException(ErrorCode.PARTY_HOST_NICKNAME_NOT_EDITABLE)
         }
+        participantService.rejoin(profile.participant)
         profile.nickname = nickname
         profile.character = character
         return profile

--- a/src/main/kotlin/com/team2/server/chat/infrastructure/party/PartyRealtimePartyEntryProfileAdapter.kt
+++ b/src/main/kotlin/com/team2/server/chat/infrastructure/party/PartyRealtimePartyEntryProfileAdapter.kt
@@ -68,7 +68,6 @@ class PartyRealtimePartyEntryProfileAdapter(
         if (profile.participant.isCelebrant && profile.nickname != nickname) {
             throw BusinessException(ErrorCode.PARTY_HOST_NICKNAME_NOT_EDITABLE)
         }
-        participantService.rejoin(profile.participant)
         profile.nickname = nickname
         profile.character = character
         return profile

--- a/src/main/kotlin/com/team2/server/chat/usecase/EnterAndSubscribeChatUseCase.kt
+++ b/src/main/kotlin/com/team2/server/chat/usecase/EnterAndSubscribeChatUseCase.kt
@@ -37,7 +37,11 @@ class EnterAndSubscribeChatUseCase(
                 .filterNotNull()
                 .distinct()
         val imageUrlMap =
-            imageUrlReader.findFirstImageUrlByTargetIds(ImageTargetType.CHARACTER, characterIds)
+            imageUrlReader.findImageUrlByTargetIdsAndSortOrder(
+                ImageTargetType.CHARACTER,
+                characterIds,
+                CHARACTER_THUMBNAIL_SORT_ORDER,
+            )
         val messages =
             rawMessages.map {
                 ChatMessageResponse.from(
@@ -111,6 +115,7 @@ class EnterAndSubscribeChatUseCase(
     }
 
     companion object {
+        private const val CHARACTER_THUMBNAIL_SORT_ORDER = 1
         private const val SSE_GRACE_CLEANUP_SECONDS = 2L
         private const val EMITTER_TIMEOUT_MS =
             (

--- a/src/main/kotlin/com/team2/server/chat/usecase/LeaveChatUseCase.kt
+++ b/src/main/kotlin/com/team2/server/chat/usecase/LeaveChatUseCase.kt
@@ -3,6 +3,7 @@ package com.team2.server.chat.usecase
 import com.team2.server.chat.domain.vo.ParticipantRole
 import com.team2.server.chat.dto.UserLeftEventPayload
 import com.team2.server.chat.infrastructure.sse.ChatSseGateway
+import com.team2.server.party.application.service.ParticipantService
 import com.team2.server.party.application.usecase.ResolveRealtimeParticipantProfileUseCase
 import com.team2.server.party.application.usecase.ResolveRealtimePartyUseCase
 import org.springframework.stereotype.Service
@@ -13,6 +14,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 class LeaveChatUseCase(
     private val resolveRealtimePartyUseCase: ResolveRealtimePartyUseCase,
     private val resolveRealtimeParticipantProfileUseCase: ResolveRealtimeParticipantProfileUseCase,
+    private val participantService: ParticipantService,
     private val chatSseGateway: ChatSseGateway,
 ) {
     @Transactional
@@ -24,7 +26,7 @@ class LeaveChatUseCase(
         resolveRealtimePartyUseCase.invoke(partyId)
         val profile = resolveRealtimeParticipantProfileUseCase.invoke(partyId, userId, participantToken)
 
-        profile.participant.hasLeft = true
+        participantService.leave(profile.participant)
 
         val payload =
             UserLeftEventPayload(

--- a/src/main/kotlin/com/team2/server/chat/usecase/LeaveChatUseCase.kt
+++ b/src/main/kotlin/com/team2/server/chat/usecase/LeaveChatUseCase.kt
@@ -15,7 +15,7 @@ class LeaveChatUseCase(
     private val resolveRealtimeParticipantProfileUseCase: ResolveRealtimeParticipantProfileUseCase,
     private val chatSseGateway: ChatSseGateway,
 ) {
-    @Transactional(readOnly = true)
+    @Transactional
     fun leave(
         partyId: Long,
         userId: Long?,
@@ -23,6 +23,8 @@ class LeaveChatUseCase(
     ) {
         resolveRealtimePartyUseCase.invoke(partyId)
         val profile = resolveRealtimeParticipantProfileUseCase.invoke(partyId, userId, participantToken)
+
+        profile.participant.hasLeft = true
 
         val payload =
             UserLeftEventPayload(

--- a/src/main/kotlin/com/team2/server/chat/usecase/SendChatMessageUseCase.kt
+++ b/src/main/kotlin/com/team2/server/chat/usecase/SendChatMessageUseCase.kt
@@ -38,7 +38,11 @@ class SendChatMessageUseCase(
 
         val imageUrl =
             message.profile.character?.id?.let {
-                imageUrlReader.findFirstImageUrlByTargetIds(ImageTargetType.CHARACTER, listOf(it))[it]
+                imageUrlReader.findImageUrlByTargetIdsAndSortOrder(
+                    ImageTargetType.CHARACTER,
+                    listOf(it),
+                    CHARACTER_THUMBNAIL_SORT_ORDER,
+                )[it]
             }
         val response = ChatMessageResponse.from(message, message.profile.participant.isCelebrant, imageUrl)
         chatSseGateway.broadcastAfterCommit(
@@ -50,5 +54,9 @@ class SendChatMessageUseCase(
                 .build(),
         )
         return response
+    }
+
+    private companion object {
+        private const val CHARACTER_THUMBNAIL_SORT_ORDER = 1
     }
 }

--- a/src/main/kotlin/com/team2/server/common/image/application/port/ImageUrlPort.kt
+++ b/src/main/kotlin/com/team2/server/common/image/application/port/ImageUrlPort.kt
@@ -7,4 +7,10 @@ interface ImageUrlPort {
         targetType: ImageTargetType,
         targetIds: Collection<Long>,
     ): Map<Long, String>
+
+    fun findImageUrlByTargetIdsAndSortOrder(
+        targetType: ImageTargetType,
+        targetIds: Collection<Long>,
+        sortOrder: Int,
+    ): Map<Long, String>
 }

--- a/src/main/kotlin/com/team2/server/common/image/persistence/ImageUrlReader.kt
+++ b/src/main/kotlin/com/team2/server/common/image/persistence/ImageUrlReader.kt
@@ -21,4 +21,19 @@ class ImageUrlReader(
             .distinctBy { it.targetId }
             .associate { it.targetId to it.imageUrl }
     }
+
+    override fun findImageUrlByTargetIdsAndSortOrder(
+        targetType: ImageTargetType,
+        targetIds: Collection<Long>,
+        sortOrder: Int,
+    ): Map<Long, String> {
+        if (targetIds.isEmpty()) {
+            return emptyMap()
+        }
+
+        return imageRepository
+            .findAllByTargetTypeAndTargetIdsOrderByTargetIdAndSortOrder(targetType, targetIds.distinct())
+            .filter { it.sortOrder == sortOrder }
+            .associate { it.targetId to it.imageUrl }
+    }
 }

--- a/src/main/kotlin/com/team2/server/party/application/port/PartyPhaseStore.kt
+++ b/src/main/kotlin/com/team2/server/party/application/port/PartyPhaseStore.kt
@@ -14,6 +14,13 @@ interface PartyPhaseStore {
         now: LocalDateTime,
     ): Boolean
 
+    // 현재 페이즈에 관계없이 강제 설정 (파티 강제 종료 등)
+    fun forceSet(
+        partyId: Long,
+        phase: PartyPhase,
+        now: LocalDateTime,
+    )
+
     fun removeByPartyId(partyId: Long)
 
     fun clear()

--- a/src/main/kotlin/com/team2/server/party/application/service/ParticipantService.kt
+++ b/src/main/kotlin/com/team2/server/party/application/service/ParticipantService.kt
@@ -74,6 +74,16 @@ class ParticipantService(
         )
     }
 
+    fun leave(participant: Participant): Participant {
+        participant.leave()
+        return participant
+    }
+
+    fun rejoin(participant: Participant): Participant {
+        participant.rejoin()
+        return participant
+    }
+
     fun resolveUser(userId: Long?): User? {
         if (userId == null) return null
         return userRepository.findByIdOrNull(userId)

--- a/src/main/kotlin/com/team2/server/party/application/service/ParticipantService.kt
+++ b/src/main/kotlin/com/team2/server/party/application/service/ParticipantService.kt
@@ -94,6 +94,9 @@ class ParticipantService(
         val profile =
             realtimeParticipantProfileRepository.findByParticipantToken(participantToken)
                 ?: return null
+        if (profile.participant.hasLeft) {
+            throw BusinessException(ErrorCode.PARTY_FORBIDDEN)
+        }
         if (profile.participant.party.id != partyId) {
             throw BusinessException(ErrorCode.PARTY_FORBIDDEN)
         }

--- a/src/main/kotlin/com/team2/server/party/application/service/ParticipantService.kt
+++ b/src/main/kotlin/com/team2/server/party/application/service/ParticipantService.kt
@@ -28,13 +28,11 @@ class ParticipantService(
         participantRepository.findByPartyAndUser(party, user)
             ?: createMemberParticipant(party, user)
 
-    fun joinAnonymous(party: Party): Participant = participantRepository.save(Participant(party = party))
-
     fun joinAnonymousOrMember(
         party: Party,
         user: User?,
     ): Participant {
-        if (user == null) return joinAnonymous(party)
+        if (user == null) return participantRepository.save(Participant(party = party))
         return joinMember(party, user)
     }
 
@@ -76,11 +74,6 @@ class ParticipantService(
 
     fun leave(participant: Participant): Participant {
         participant.leave()
-        return participant
-    }
-
-    fun rejoin(participant: Participant): Participant {
-        participant.rejoin()
         return participant
     }
 

--- a/src/main/kotlin/com/team2/server/party/application/service/RealtimeParticipantProfileService.kt
+++ b/src/main/kotlin/com/team2/server/party/application/service/RealtimeParticipantProfileService.kt
@@ -77,12 +77,7 @@ class RealtimeParticipantProfileService(
         val profile =
             profileRepository.findByParticipantToken(participantToken)
                 ?: throw BusinessException(ErrorCode.UNAUTHORIZED)
-        if (profile.participant.hasLeft) {
-            throw BusinessException(ErrorCode.PARTY_FORBIDDEN)
-        }
-        if (profile.participant.party.id != partyId) {
-            throw BusinessException(ErrorCode.PARTY_FORBIDDEN)
-        }
+        validateActivePartyMember(profile, partyId)
         return profile
     }
 
@@ -96,6 +91,7 @@ class RealtimeParticipantProfileService(
         if (profile.participant.party.id != partyId) {
             throw BusinessException(ErrorCode.PARTY_FORBIDDEN)
         }
+        profile.participant.rejoin()
         return profile
     }
 
@@ -117,12 +113,19 @@ class RealtimeParticipantProfileService(
         val profile =
             profileRepository.findByParticipantToken(participantToken)
                 ?: throw BusinessException(ErrorCode.CHARACTER_REQUIRED)
+        validateActivePartyMember(profile, partyId)
+        return profile
+    }
+
+    private fun validateActivePartyMember(
+        profile: RealtimeParticipantProfile,
+        partyId: Long,
+    ) {
         if (profile.participant.hasLeft) {
             throw BusinessException(ErrorCode.PARTY_FORBIDDEN)
         }
         if (profile.participant.party.id != partyId) {
             throw BusinessException(ErrorCode.PARTY_FORBIDDEN)
         }
-        return profile
     }
 }

--- a/src/main/kotlin/com/team2/server/party/application/service/RealtimeParticipantProfileService.kt
+++ b/src/main/kotlin/com/team2/server/party/application/service/RealtimeParticipantProfileService.kt
@@ -26,6 +26,7 @@ class RealtimeParticipantProfileService(
         val existing = profileRepository.findByParticipant(participant)
         if (existing == null) {
             validateNicknameUnique(participant, nickname)
+            participant.rejoin()
             return profileRepository.save(
                 RealtimeParticipantProfile(
                     participant = participant,
@@ -40,6 +41,7 @@ class RealtimeParticipantProfileService(
             }
             validateNicknameUnique(participant, nickname)
         }
+        participant.rejoin()
         existing.nickname = nickname
         existing.character = character
         return existing

--- a/src/main/kotlin/com/team2/server/party/application/service/RealtimeParticipantProfileService.kt
+++ b/src/main/kotlin/com/team2/server/party/application/service/RealtimeParticipantProfileService.kt
@@ -86,6 +86,19 @@ class RealtimeParticipantProfileService(
         return profile
     }
 
+    fun requireForReentryByParticipantToken(
+        participantToken: String,
+        partyId: Long,
+    ): RealtimeParticipantProfile {
+        val profile =
+            profileRepository.findByParticipantToken(participantToken)
+                ?: throw BusinessException(ErrorCode.UNAUTHORIZED)
+        if (profile.participant.party.id != partyId) {
+            throw BusinessException(ErrorCode.PARTY_FORBIDDEN)
+        }
+        return profile
+    }
+
     private fun resolveByUserId(
         partyId: Long,
         userId: Long,

--- a/src/main/kotlin/com/team2/server/party/application/service/RealtimeParticipantProfileService.kt
+++ b/src/main/kotlin/com/team2/server/party/application/service/RealtimeParticipantProfileService.kt
@@ -77,6 +77,9 @@ class RealtimeParticipantProfileService(
         val profile =
             profileRepository.findByParticipantToken(participantToken)
                 ?: throw BusinessException(ErrorCode.UNAUTHORIZED)
+        if (profile.participant.hasLeft) {
+            throw BusinessException(ErrorCode.PARTY_FORBIDDEN)
+        }
         if (profile.participant.party.id != partyId) {
             throw BusinessException(ErrorCode.PARTY_FORBIDDEN)
         }
@@ -101,6 +104,9 @@ class RealtimeParticipantProfileService(
         val profile =
             profileRepository.findByParticipantToken(participantToken)
                 ?: throw BusinessException(ErrorCode.CHARACTER_REQUIRED)
+        if (profile.participant.hasLeft) {
+            throw BusinessException(ErrorCode.PARTY_FORBIDDEN)
+        }
         if (profile.participant.party.id != partyId) {
             throw BusinessException(ErrorCode.PARTY_FORBIDDEN)
         }

--- a/src/main/kotlin/com/team2/server/party/domain/entity/Participant.kt
+++ b/src/main/kotlin/com/team2/server/party/domain/entity/Participant.kt
@@ -31,4 +31,6 @@ class Participant(
     var isCelebrant: Boolean = false,
     @Column(name = "has_written_paper", nullable = false)
     var hasWrittenPaper: Boolean = false,
+    @Column(name = "has_left", nullable = false)
+    var hasLeft: Boolean = false,
 ) : BaseEntity()

--- a/src/main/kotlin/com/team2/server/party/domain/entity/Participant.kt
+++ b/src/main/kotlin/com/team2/server/party/domain/entity/Participant.kt
@@ -31,6 +31,17 @@ class Participant(
     var isCelebrant: Boolean = false,
     @Column(name = "has_written_paper", nullable = false)
     var hasWrittenPaper: Boolean = false,
+    hasLeft: Boolean = false,
+) : BaseEntity() {
     @Column(name = "has_left", nullable = false)
-    var hasLeft: Boolean = false,
-) : BaseEntity()
+    final var hasLeft: Boolean = hasLeft
+        private set
+
+    fun leave() {
+        hasLeft = true
+    }
+
+    fun rejoin() {
+        hasLeft = false
+    }
+}

--- a/src/main/kotlin/com/team2/server/party/infrastructure/memory/InMemoryPartyPhaseStore.kt
+++ b/src/main/kotlin/com/team2/server/party/infrastructure/memory/InMemoryPartyPhaseStore.kt
@@ -28,6 +28,16 @@ class InMemoryPartyPhaseStore : PartyPhaseStore {
         }
     }
 
+    override fun forceSet(
+        partyId: Long,
+        phase: PartyPhase,
+        now: LocalDateTime,
+    ) {
+        synchronized(lockFor(partyId)) {
+            entries[partyId] = PartyPhaseStore.PhaseEntry(phase = phase, startedAt = now)
+        }
+    }
+
     override fun removeByPartyId(partyId: Long) {
         synchronized(lockFor(partyId)) {
             entries.remove(partyId)

--- a/src/main/kotlin/com/team2/server/party/infrastructure/persistence/RealtimeParticipantProfileRepository.kt
+++ b/src/main/kotlin/com/team2/server/party/infrastructure/persistence/RealtimeParticipantProfileRepository.kt
@@ -52,6 +52,7 @@ interface RealtimeParticipantProfileRepository : JpaRepository<RealtimeParticipa
         LEFT JOIN FETCH participant.user
         LEFT JOIN FETCH rpp.character
         WHERE participant.party.id = :partyId
+          AND participant.hasLeft = false
         ORDER BY participant.id ASC
         """,
     )

--- a/src/main/kotlin/com/team2/server/party/infrastructure/sse/PartyEndScheduler.kt
+++ b/src/main/kotlin/com/team2/server/party/infrastructure/sse/PartyEndScheduler.kt
@@ -89,7 +89,7 @@ class PartyEndScheduler(
             ),
             emitEnding = true,
         )
-        phaseStore.advance(event.partyId, PartyPhase.CLOSEABLE, PartyPhase.END, event.endingStartedAt)
+        phaseStore.forceSet(event.partyId, PartyPhase.END, event.endingStartedAt)
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)

--- a/src/main/kotlin/com/team2/server/rollingpaper/usecase/CreateRollingPaperUseCase.kt
+++ b/src/main/kotlin/com/team2/server/rollingpaper/usecase/CreateRollingPaperUseCase.kt
@@ -77,7 +77,7 @@ class CreateRollingPaperUseCase(
         userId: Long?,
     ): Participant {
         if (userId == null) {
-            return participantService.joinAnonymous(party)
+            return participantService.joinAnonymousOrMember(party, null)
         }
 
         val user =

--- a/src/main/resources/db/migration/V7__add_participant_has_left.sql
+++ b/src/main/resources/db/migration/V7__add_participant_has_left.sql
@@ -1,0 +1,1 @@
+alter table participant add column has_left bit not null default 0;

--- a/src/test/kotlin/com/team2/server/chat/infrastructure/party/PartyRealtimePartyEntryProfileAdapterTest.kt
+++ b/src/test/kotlin/com/team2/server/chat/infrastructure/party/PartyRealtimePartyEntryProfileAdapterTest.kt
@@ -106,43 +106,6 @@ class PartyRealtimePartyEntryProfileAdapterTest {
         assertEquals("existing-token", result.participantToken)
         assertEquals("새닉네임", profile.nickname)
         assertEquals(character, profile.character)
-        verify(participantService).rejoin(participant)
-    }
-
-    @Test
-    fun `participantToken 재입장은 퇴장 플래그를 해제한다`() {
-        val party = RealtimeParty(ownerId = 1L, startedAt = now.minusMinutes(1))
-        val character = Character(name = "토끼")
-        val participant = Participant(party = party, hasLeft = true)
-        val profile =
-            RealtimeParticipantProfile(
-                participant = participant,
-                nickname = "기존닉네임",
-                character = null,
-                participantToken = "existing-token",
-            )
-        val reenterRequest =
-            EnterRealtimePartyRequest(
-                nickname = "새닉네임",
-                characterId = 1L,
-                participantToken = "existing-token",
-            )
-
-        whenever(characterService.requireCharacter(1L)).thenReturn(character)
-        whenever(
-            realtimeParticipantProfileService.requireForReentryByParticipantToken(
-                participantToken = "existing-token",
-                partyId = party.id,
-            ),
-        ).thenReturn(profile)
-        whenever(participantService.rejoin(participant)).thenAnswer {
-            participant.rejoin()
-            participant
-        }
-
-        adapter.resolve(party = party, userId = 99L, request = reenterRequest, now = now)
-
-        assertEquals(false, participant.hasLeft)
     }
 
     @Test

--- a/src/test/kotlin/com/team2/server/chat/infrastructure/party/PartyRealtimePartyEntryProfileAdapterTest.kt
+++ b/src/test/kotlin/com/team2/server/chat/infrastructure/party/PartyRealtimePartyEntryProfileAdapterTest.kt
@@ -95,7 +95,7 @@ class PartyRealtimePartyEntryProfileAdapterTest {
 
         whenever(characterService.requireCharacter(1L)).thenReturn(character)
         whenever(
-            realtimeParticipantProfileService.requireByParticipantToken(
+            realtimeParticipantProfileService.requireForReentryByParticipantToken(
                 participantToken = "existing-token",
                 partyId = party.id,
             ),
@@ -106,6 +106,43 @@ class PartyRealtimePartyEntryProfileAdapterTest {
         assertEquals("existing-token", result.participantToken)
         assertEquals("새닉네임", profile.nickname)
         assertEquals(character, profile.character)
+        verify(participantService).rejoin(participant)
+    }
+
+    @Test
+    fun `participantToken 재입장은 퇴장 플래그를 해제한다`() {
+        val party = RealtimeParty(ownerId = 1L, startedAt = now.minusMinutes(1))
+        val character = Character(name = "토끼")
+        val participant = Participant(party = party, hasLeft = true)
+        val profile =
+            RealtimeParticipantProfile(
+                participant = participant,
+                nickname = "기존닉네임",
+                character = null,
+                participantToken = "existing-token",
+            )
+        val reenterRequest =
+            EnterRealtimePartyRequest(
+                nickname = "새닉네임",
+                characterId = 1L,
+                participantToken = "existing-token",
+            )
+
+        whenever(characterService.requireCharacter(1L)).thenReturn(character)
+        whenever(
+            realtimeParticipantProfileService.requireForReentryByParticipantToken(
+                participantToken = "existing-token",
+                partyId = party.id,
+            ),
+        ).thenReturn(profile)
+        whenever(participantService.rejoin(participant)).thenAnswer {
+            participant.rejoin()
+            participant
+        }
+
+        adapter.resolve(party = party, userId = 99L, request = reenterRequest, now = now)
+
+        assertEquals(false, participant.hasLeft)
     }
 
     @Test
@@ -129,7 +166,7 @@ class PartyRealtimePartyEntryProfileAdapterTest {
 
         whenever(characterService.requireCharacter(1L)).thenReturn(character)
         whenever(
-            realtimeParticipantProfileService.requireByParticipantToken(
+            realtimeParticipantProfileService.requireForReentryByParticipantToken(
                 participantToken = "existing-token",
                 partyId = party.id,
             ),

--- a/src/test/kotlin/com/team2/server/chat/usecase/EnterAndSubscribeChatUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/chat/usecase/EnterAndSubscribeChatUseCaseTest.kt
@@ -68,7 +68,7 @@ class EnterAndSubscribeChatUseCaseTest {
         whenever(enterRealtimePartyUseCase.enter("tok", null, request)).thenReturn(enterResult)
         whenever(chatMessageRepository.findAllByPartyIdWithProfileOrderByCreatedAtAsc(1L))
             .thenReturn(listOf(msg))
-        whenever(imageUrlReader.findFirstImageUrlByTargetIds(any(), any())).thenReturn(emptyMap())
+        whenever(imageUrlReader.findImageUrlByTargetIdsAndSortOrder(any(), any(), any())).thenReturn(emptyMap())
 
         val emitter = useCase.enterAndSubscribe("tok", null, request)
 
@@ -83,7 +83,7 @@ class EnterAndSubscribeChatUseCaseTest {
         whenever(enterRealtimePartyUseCase.enter("tok", null, request)).thenReturn(enterResult)
         whenever(chatMessageRepository.findAllByPartyIdWithProfileOrderByCreatedAtAsc(1L))
             .thenReturn(emptyList())
-        whenever(imageUrlReader.findFirstImageUrlByTargetIds(any(), any())).thenReturn(emptyMap())
+        whenever(imageUrlReader.findImageUrlByTargetIdsAndSortOrder(any(), any(), any())).thenReturn(emptyMap())
 
         val emitter = useCase.enterAndSubscribe("tok", null, request)
 
@@ -98,7 +98,7 @@ class EnterAndSubscribeChatUseCaseTest {
         whenever(enterRealtimePartyUseCase.enter("tok", null, request)).thenReturn(enterResult)
         whenever(chatMessageRepository.findAllByPartyIdWithProfileOrderByCreatedAtAsc(1L))
             .thenReturn(emptyList())
-        whenever(imageUrlReader.findFirstImageUrlByTargetIds(any(), any()))
+        whenever(imageUrlReader.findImageUrlByTargetIdsAndSortOrder(any(), any(), any()))
             .thenReturn(mapOf(1L to "https://example.com/rabbit.png"))
 
         useCase.enterAndSubscribe("tok", null, request)

--- a/src/test/kotlin/com/team2/server/chat/usecase/EnterAndSubscribeChatUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/chat/usecase/EnterAndSubscribeChatUseCaseTest.kt
@@ -68,7 +68,7 @@ class EnterAndSubscribeChatUseCaseTest {
         whenever(enterRealtimePartyUseCase.enter("tok", null, request)).thenReturn(enterResult)
         whenever(chatMessageRepository.findAllByPartyIdWithProfileOrderByCreatedAtAsc(1L))
             .thenReturn(listOf(msg))
-        whenever(imageUrlReader.findImageUrlByTargetIdsAndSortOrder(any(), any(), any())).thenReturn(emptyMap())
+        whenever(imageUrlReader.findImageUrlByTargetIdsAndSortOrder(any(), any(), eq(1))).thenReturn(emptyMap())
 
         val emitter = useCase.enterAndSubscribe("tok", null, request)
 
@@ -83,7 +83,7 @@ class EnterAndSubscribeChatUseCaseTest {
         whenever(enterRealtimePartyUseCase.enter("tok", null, request)).thenReturn(enterResult)
         whenever(chatMessageRepository.findAllByPartyIdWithProfileOrderByCreatedAtAsc(1L))
             .thenReturn(emptyList())
-        whenever(imageUrlReader.findImageUrlByTargetIdsAndSortOrder(any(), any(), any())).thenReturn(emptyMap())
+        whenever(imageUrlReader.findImageUrlByTargetIdsAndSortOrder(any(), any(), eq(1))).thenReturn(emptyMap())
 
         val emitter = useCase.enterAndSubscribe("tok", null, request)
 
@@ -98,7 +98,7 @@ class EnterAndSubscribeChatUseCaseTest {
         whenever(enterRealtimePartyUseCase.enter("tok", null, request)).thenReturn(enterResult)
         whenever(chatMessageRepository.findAllByPartyIdWithProfileOrderByCreatedAtAsc(1L))
             .thenReturn(emptyList())
-        whenever(imageUrlReader.findImageUrlByTargetIdsAndSortOrder(any(), any(), any()))
+        whenever(imageUrlReader.findImageUrlByTargetIdsAndSortOrder(any(), any(), eq(1)))
             .thenReturn(mapOf(1L to "https://example.com/rabbit.png"))
 
         useCase.enterAndSubscribe("tok", null, request)

--- a/src/test/kotlin/com/team2/server/chat/usecase/LeaveChatUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/chat/usecase/LeaveChatUseCaseTest.kt
@@ -3,6 +3,7 @@ package com.team2.server.chat.usecase
 import com.team2.server.chat.infrastructure.sse.ChatSseGateway
 import com.team2.server.common.exception.BusinessException
 import com.team2.server.common.exception.ErrorCode
+import com.team2.server.party.application.service.ParticipantService
 import com.team2.server.party.application.usecase.ResolveRealtimeParticipantProfileUseCase
 import com.team2.server.party.application.usecase.ResolveRealtimePartyUseCase
 import com.team2.server.party.domain.entity.Participant
@@ -26,6 +27,8 @@ class LeaveChatUseCaseTest {
     @Mock lateinit var resolveRealtimePartyUseCase: ResolveRealtimePartyUseCase
 
     @Mock lateinit var resolveRealtimeParticipantProfileUseCase: ResolveRealtimeParticipantProfileUseCase
+
+    @Mock lateinit var participantService: ParticipantService
 
     @Mock lateinit var chatSseGateway: ChatSseGateway
 
@@ -71,6 +74,7 @@ class LeaveChatUseCaseTest {
 
         useCase.leave(party.id, null, "tok")
 
+        verify(participantService).leave(participant)
         verify(chatSseGateway).leave("tok")
         verify(chatSseGateway).broadcastAfterCommit(any(), any(), anyOrNull())
     }

--- a/src/test/kotlin/com/team2/server/chat/usecase/SendChatMessageUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/chat/usecase/SendChatMessageUseCaseTest.kt
@@ -119,7 +119,7 @@ class SendChatMessageUseCaseTest {
         whenever(resolveLiveOpenRealtimePartyUseCase.invoke(1L)).thenReturn(party)
         whenever(resolveRealtimeParticipantProfileUseCase.invoke(1L, 10L, null)).thenReturn(profile)
         whenever(chatMessageRepository.save(any())).thenReturn(savedMessage)
-        whenever(imageUrlReader.findFirstImageUrlByTargetIds(ImageTargetType.CHARACTER, listOf(character.id)))
+        whenever(imageUrlReader.findImageUrlByTargetIdsAndSortOrder(ImageTargetType.CHARACTER, listOf(character.id), 1))
             .thenReturn(mapOf(character.id to "https://example.com/rabbit.png"))
 
         val response = useCase.send(partyId = 1L, userId = 10L, participantToken = null, request)

--- a/src/test/kotlin/com/team2/server/party/application/service/ParticipantServiceTest.kt
+++ b/src/test/kotlin/com/team2/server/party/application/service/ParticipantServiceTest.kt
@@ -143,7 +143,7 @@ class ParticipantServiceTest {
         val ex =
             assertFailsWith<BusinessException> {
                 service.requireCallerParticipant(partyId = 1L, userId = null, participantToken = "tok")
-        }
+            }
         assertEquals(ErrorCode.PARTY_FORBIDDEN, ex.errorCode)
     }
 

--- a/src/test/kotlin/com/team2/server/party/application/service/ParticipantServiceTest.kt
+++ b/src/test/kotlin/com/team2/server/party/application/service/ParticipantServiceTest.kt
@@ -143,6 +143,20 @@ class ParticipantServiceTest {
         val ex =
             assertFailsWith<BusinessException> {
                 service.requireCallerParticipant(partyId = 1L, userId = null, participantToken = "tok")
+        }
+        assertEquals(ErrorCode.PARTY_FORBIDDEN, ex.errorCode)
+    }
+
+    @Test
+    fun `requireCallerParticipant throws PARTY_FORBIDDEN when token participant has left`() {
+        val party = makeRealtimeParty()
+        val participant = Participant(party = party, user = null, hasLeft = true)
+        val profile = RealtimeParticipantProfile(participant = participant, nickname = "익명")
+        whenever(realtimeParticipantProfileRepository.findByParticipantToken("tok")).thenReturn(profile)
+
+        val ex =
+            assertFailsWith<BusinessException> {
+                service.requireCallerParticipant(party.id, userId = null, participantToken = "tok")
             }
         assertEquals(ErrorCode.PARTY_FORBIDDEN, ex.errorCode)
     }

--- a/src/test/kotlin/com/team2/server/party/application/service/RealtimeParticipantProfileServiceTest.kt
+++ b/src/test/kotlin/com/team2/server/party/application/service/RealtimeParticipantProfileServiceTest.kt
@@ -94,6 +94,25 @@ class RealtimeParticipantProfileServiceTest {
     }
 
     @Test
+    fun `기존 프로필 갱신 시 퇴장 상태를 해제한다`() {
+        val participant = Participant(party = party, hasLeft = true)
+        val existing =
+            RealtimeParticipantProfile(participant = participant, nickname = "old", character = character)
+        whenever(profileRepository.findByParticipant(participant)).thenReturn(existing)
+        whenever(
+            profileRepository.existsByPartyIdAndNicknameIgnoreCaseExcludingParticipant(
+                partyId = eq(party.id),
+                nickname = eq("new"),
+                excludingParticipantId = eq(participant.id),
+            ),
+        ).thenReturn(false)
+
+        service.upsert(participant, "new", anotherCharacter, isHostNicknameLocked = false)
+
+        assertEquals(false, participant.hasLeft)
+    }
+
+    @Test
     fun `locked = true이고 nickname이 같으면 character만 갱신한다`() {
         val participant = newParticipant(isCelebrant = true)
         val existing =

--- a/src/test/kotlin/com/team2/server/party/application/service/RealtimeParticipantProfileServiceTest.kt
+++ b/src/test/kotlin/com/team2/server/party/application/service/RealtimeParticipantProfileServiceTest.kt
@@ -183,6 +183,23 @@ class RealtimeParticipantProfileServiceTest {
     }
 
     @Test
+    fun `requireForReentryByParticipantToken clears left flag`() {
+        val participant = Participant(party = party, hasLeft = true)
+        val profile =
+            RealtimeParticipantProfile(
+                participant = participant,
+                nickname = "guest",
+                participantToken = "tok",
+            )
+        whenever(profileRepository.findByParticipantToken("tok")).thenReturn(profile)
+
+        val result = service.requireForReentryByParticipantToken("tok", party.id)
+
+        assertSame(profile, result)
+        assertEquals(false, participant.hasLeft)
+    }
+
+    @Test
     fun `resolveProfile by user returns profile`() {
         val participant = newParticipant(isCelebrant = false)
         val profile = RealtimeParticipantProfile(participant = participant, nickname = "guest")

--- a/src/test/kotlin/com/team2/server/party/application/service/RealtimeParticipantProfileServiceTest.kt
+++ b/src/test/kotlin/com/team2/server/party/application/service/RealtimeParticipantProfileServiceTest.kt
@@ -167,6 +167,22 @@ class RealtimeParticipantProfileServiceTest {
     }
 
     @Test
+    fun `requireByParticipantToken throws PARTY_FORBIDDEN when token participant has left`() {
+        val participant = Participant(party = party, hasLeft = true)
+        val profile =
+            RealtimeParticipantProfile(
+                participant = participant,
+                nickname = "guest",
+                participantToken = "tok",
+            )
+        whenever(profileRepository.findByParticipantToken("tok")).thenReturn(profile)
+
+        val ex = assertThrows<BusinessException> { service.requireByParticipantToken("tok", party.id) }
+
+        assertEquals(ErrorCode.PARTY_FORBIDDEN, ex.errorCode)
+    }
+
+    @Test
     fun `resolveProfile by user returns profile`() {
         val participant = newParticipant(isCelebrant = false)
         val profile = RealtimeParticipantProfile(participant = participant, nickname = "guest")
@@ -197,6 +213,20 @@ class RealtimeParticipantProfileServiceTest {
         val result = service.resolveProfile(party.id, userId = null, participantToken = "tok")
 
         assertSame(profile, result)
+    }
+
+    @Test
+    fun `resolveProfile by token throws PARTY_FORBIDDEN when token participant has left`() {
+        val participant = Participant(party = party, hasLeft = true)
+        val profile = RealtimeParticipantProfile(participant = participant, nickname = "guest")
+        whenever(profileRepository.findByParticipantToken("tok")).thenReturn(profile)
+
+        val ex =
+            assertThrows<BusinessException> {
+                service.resolveProfile(party.id, userId = null, participantToken = "tok")
+            }
+
+        assertEquals(ErrorCode.PARTY_FORBIDDEN, ex.errorCode)
     }
 
     @Test


### PR DESCRIPTION
## 🔗 Issue
- closes #208

## 💬 Context
실시간 파티 플로우 테스트 중 발견된 세 가지 버그를 수정합니다.

1. 주최자가 파티 중간(예: CANDLE 단계)에 X버튼으로 강제 종료했을 때, 다른 참여자가 `/phase`를 조회하면 여전히 CANDLE이 반환되는 문제가 있었습니다. `PartyPhaseStore`의 `advance`가 CAS 방식이라 `CLOSEABLE→END` 전환만 시도했고, 실제 페이즈가 CANDLE인 경우 전환에 실패했습니다.

2. 퇴장 API(`POST /chat/leave`) 호출 후에도 `/participants` 목록에 해당 참여자가 계속 노출되는 문제가 있었습니다.

3. 채팅 메시지의 `senderCharacterImageUrl`이 원본 이미지(`/images/characters/...`)를 반환하고 있어 썸네일(`/images/character-thumbnails/...`)로 변경이 필요했습니다.

## 🛠 Changes
- `PartyPhaseStore`에 `forceSet` 메서드 추가 — 현재 페이즈에 관계없이 강제 설정
- `PartyEndScheduler.onRealtimePartyEndingStarted`에서 `advance` 대신 `forceSet(END)` 사용
- `Participant` 엔티티에 `hasLeft` 필드 추가
- `LeaveChatUseCase`에서 퇴장 시 `hasLeft = true` 마킹 (`@Transactional` readOnly 제거)
- `RealtimeParticipantProfileRepository` 참여자 목록 쿼리에 `hasLeft = false` 필터 추가
- `ImageUrlPort` / `ImageUrlReader`에 `findImageUrlByTargetIdsAndSortOrder` 메서드 추가
- `SendChatMessageUseCase`, `EnterAndSubscribeChatUseCase`에서 썸네일(sortOrder=1) URL 사용

## 👀 Review Focus
- `PartyPhaseStore.forceSet` 도입 — CAS 방식의 `advance`와 달리 락 내부에서 무조건 덮어씁니다. 의도적 설계이나 남용 방지를 위해 사용처가 종료 이벤트로 한정되어 있는지 확인 부탁드립니다.
- `LeaveChatUseCase`의 `@Transactional` readOnly → readWrite 변경 — `hasLeft` 필드를 dirty checking으로 저장하기 위한 변경입니다.
- 참여자 목록 쿼리 필터(`hasLeft = false`) — 이미 퇴장한 사용자가 재입장하는 케이스가 생길 경우 `hasLeft` 초기화 로직이 필요한지 검토 필요합니다.

## ⚠️ Side Effects
- **DB 마이그레이션**: `V7__add_participant_has_left.sql` — `participant` 테이블에 `has_left bit not null default 0` 컬럼 추가. 기존 데이터는 default 0으로 채워지므로 롤백 가능(컬럼 drop).
- **API 변경(Breaking)**: `senderCharacterImageUrl` 응답값이 원본 이미지 → 썸네일 이미지 경로로 변경됩니다. 프론트엔드 확인 필요.
- **환경변수/설정**: 없음
- **의존성 변경**: 없음
- **외부 시스템 영향**: 채팅 `senderCharacterImageUrl` 변경으로 프론트 이미지 렌더링 확인 필요
- **운영 작업**: 없음

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 파티 위상을 강제로 설정할 수 있는 기능이 추가되었습니다.

* **개선 사항**
  * 실시간 채팅의 참가자 퇴장·재입장 흐름이 강화되어, 퇴장된 사용자는 자동 제외되고 재입장 시 상태가 복구됩니다.
  * 캐릭터 썸네일 조회가 정렬 기준을 사용하도록 개선되어 이미지 선택 정확도가 향상되었습니다.
  * 퇴장 시 관련 이벤트와 내부 상태 갱신이 일관되게 처리됩니다.

* **데이터베이스**
  * 참가자의 퇴장 여부를 저장하는 필드가 추가되었습니다.

* **테스트**
  * 퇴장/재입장 및 이미지 조회 관련 테스트가 보강되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->