### PR TITLE
fix: 서버 시간대 KST 고정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -95,6 +95,12 @@ tasks.withType<Test> {
     finalizedBy(tasks.jacocoTestReport)
 }
 
+tasks.withType<org.springframework.boot.gradle.tasks.run.BootRun> {
+    systemProperty("user.timezone", "Asia/Seoul")
+    environment("TZ", "Asia/Seoul")
+    environment("APP_TIME_ZONE", System.getenv("APP_TIME_ZONE") ?: "Asia/Seoul")
+}
+
 tasks.jacocoTestReport {
     reports {
         xml.required = true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,6 +20,10 @@ FROM eclipse-temurin:25-jre
 
 WORKDIR /app
 
+ENV TZ=Asia/Seoul
+ENV APP_TIME_ZONE=Asia/Seoul
+ENV JAVA_TOOL_OPTIONS="-Duser.timezone=Asia/Seoul"
+
 # healthcheck용 curl 설치
 RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 

--- a/docker/docker-compose.app.yml
+++ b/docker/docker-compose.app.yml
@@ -8,6 +8,9 @@ services:
       - SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE:?SPRING_PROFILES_ACTIVE must be set}
       - SERVER_FORWARD_HEADERS_STRATEGY=framework
       - DB_HOST=db-${APP_ENV:?APP_ENV must be set}
+      - TZ=${TZ:-Asia/Seoul}
+      - APP_TIME_ZONE=${APP_TIME_ZONE:-Asia/Seoul}
+      - JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS:--Duser.timezone=Asia/Seoul}
     healthcheck:
       test: ["CMD-SHELL", "curl -f --max-time 5 http://localhost:8080/actuator/health || exit 1"]
       interval: 10s

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -24,4 +24,4 @@ loki:
 
 app:
   env: dev
-  time-zone: ${APP_TIME_ZONE:Asia/Shanghai}
+  time-zone: ${APP_TIME_ZONE:Asia/Seoul}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -11,4 +11,4 @@ management:
       application: ${spring.application.name}
 
 app:
-  time-zone: ${APP_TIME_ZONE:Asia/Shanghai}
+  time-zone: ${APP_TIME_ZONE:Asia/Seoul}


### PR DESCRIPTION
## 🔗 Issue
- closes #

## 💬 Context
<!-- 작업 배경, 맥락, 특이사항 등 자유롭게 -->
- dev/local 서버 시간이 KST와 맞지 않아 실시간 파티 활성 시간 판단이 어긋나는 문제를 수정합니다.
- app Clock뿐 아니라 Docker/JVM/로컬 bootRun 기본 시간대도 KST로 맞춰, LocalDateTime.now() 직접 사용 지점까지 같은 기준을 보도록 합니다.

## 🛠 Changes
<!-- 핵심 변경 사항 -->
- dev/local app.time-zone 기본값을 Asia/Seoul로 변경
- Docker 이미지와 app compose 환경변수에 TZ, APP_TIME_ZONE, user.timezone KST 기본값 추가
- Gradle bootRun 실행 시 user.timezone, TZ, APP_TIME_ZONE을 KST로 고정

## 👀 Review Focus
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분 -->
- dev/prod/local 서버 시간 기준이 모두 KST로 통일되는지
- 배포 환경에서 별도 APP_TIME_ZONE/JAVA_TOOL_OPTIONS override가 필요한지

## ✅ Check List
- [ ] Assignees 등록
- [ ] Label 등록
- [ ] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **설정 개선**
  * 애플리케이션 전체 시간대를 Asia/Seoul로 통일 설정
  * 개발 환경, 컨테이너 환경, 로컬 환경의 타임존 설정 일관성 확보
  * 시간 관련 처리의 신뢰성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->