### PR TITLE
fix: HTTP 요청 로그 개선

### DIFF
--- a/src/main/kotlin/com/team2/server/common/web/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/team2/server/common/web/GlobalExceptionHandler.kt
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.context.request.async.AsyncRequestNotUsableException
 import org.springframework.web.method.annotation.HandlerMethodValidationException
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+import org.springframework.web.servlet.resource.NoResourceFoundException
 import tools.jackson.databind.ObjectMapper
 
 @RestControllerAdvice
@@ -97,6 +98,19 @@ class GlobalExceptionHandler(
     @ExceptionHandler(AsyncRequestNotUsableException::class)
     fun handleAsyncRequestNotUsableException(e: AsyncRequestNotUsableException) {
         log.debug("Client disconnected during async request", e)
+    }
+
+    @ExceptionHandler(NoResourceFoundException::class)
+    fun handleNoResourceFoundException(
+        e: NoResourceFoundException,
+        response: HttpServletResponse,
+    ) {
+        log.warn("Resource not found. path={}", e.resourcePath)
+        writeErrorResponse(
+            response,
+            HttpStatus.NOT_FOUND.value(),
+            ErrorResponse.of(HttpStatus.NOT_FOUND, "NOT_FOUND", "요청한 리소스를 찾을 수 없습니다."),
+        )
     }
 
     @ExceptionHandler(Exception::class)

--- a/src/main/kotlin/com/team2/server/common/web/HttpExchangeLoggingFilter.kt
+++ b/src/main/kotlin/com/team2/server/common/web/HttpExchangeLoggingFilter.kt
@@ -33,7 +33,6 @@ class HttpExchangeLoggingFilter : OncePerRequestFilter() {
         val uri = request.requestURI
 
         return uri.startsWith("/actuator") ||
-            uri.contains("/stream") ||
             request.contentType?.startsWith(MediaType.MULTIPART_FORM_DATA_VALUE) == true
     }
 
@@ -43,6 +42,11 @@ class HttpExchangeLoggingFilter : OncePerRequestFilter() {
         filterChain: FilterChain,
     ) {
         val cachedRequest = ContentCachingRequestWrapper(request, MAX_LOG_BODY_LENGTH)
+        if (request.requestURI.contains("/stream")) {
+            doFilterStreamingRequest(cachedRequest, response, filterChain)
+            return
+        }
+
         val cachedResponse = ContentCachingResponseWrapper(response)
         val startedAt = System.currentTimeMillis()
 
@@ -55,6 +59,24 @@ class HttpExchangeLoggingFilter : OncePerRequestFilter() {
                 log.warn("HTTP exchange logging failed. uri={}", request.requestURI, ex)
             }
             cachedResponse.copyBodyToResponse()
+        }
+    }
+
+    private fun doFilterStreamingRequest(
+        request: ContentCachingRequestWrapper,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val startedAt = System.currentTimeMillis()
+
+        try {
+            filterChain.doFilter(request, response)
+        } finally {
+            runCatching {
+                logStreamingHttpExchange(request, response, System.currentTimeMillis() - startedAt)
+            }.onFailure { ex ->
+                log.warn("HTTP stream exchange logging failed. uri={}", request.requestURI, ex)
+            }
         }
     }
 
@@ -82,6 +104,29 @@ class HttpExchangeLoggingFilter : OncePerRequestFilter() {
                 body = response.contentAsByteArray,
                 contentType = response.contentType,
                 encoding = response.characterEncoding,
+            ),
+        )
+    }
+
+    private fun logStreamingHttpExchange(
+        request: ContentCachingRequestWrapper,
+        response: HttpServletResponse,
+        elapsedMillis: Long,
+    ) {
+        if (!log.isInfoEnabled) {
+            return
+        }
+
+        log.info(
+            "HTTP stream exchange method={} uri={} status={} elapsedMs={} requestJson={}",
+            request.method,
+            requestUri(request),
+            response.status,
+            elapsedMillis,
+            visibleBodyOrEmpty(
+                body = request.contentAsByteArray,
+                contentType = request.contentType,
+                encoding = request.characterEncoding,
             ),
         )
     }

--- a/src/main/kotlin/com/team2/server/party/application/usecase/ResolveLiveOpenRealtimePartyUseCase.kt
+++ b/src/main/kotlin/com/team2/server/party/application/usecase/ResolveLiveOpenRealtimePartyUseCase.kt
@@ -23,9 +23,9 @@ class ResolveLiveOpenRealtimePartyUseCase(
         val party = partyService.requireRealtimeParty(partyId)
         val now = LocalDateTime.now(clock)
         val status = party.status(now)
-        if (status != RealtimePartyStatus.LIVE_OPEN) {
+        if (status !in ACTIVE_STATUSES) {
             log.warn(
-                "Realtime party is not live-open. partyId={} status={} " +
+                "Realtime party is not active. partyId={} status={} " +
                     "startedAt={} liveEndingStartedAt={} now={} clockZone={}",
                 partyId,
                 status,
@@ -37,5 +37,13 @@ class ResolveLiveOpenRealtimePartyUseCase(
             throw BusinessException(ErrorCode.CHAT_NOT_ACTIVE)
         }
         return party
+    }
+
+    private companion object {
+        private val ACTIVE_STATUSES =
+            setOf(
+                RealtimePartyStatus.LIVE_OPEN,
+                RealtimePartyStatus.LIVE_ENDING,
+            )
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,5 +39,17 @@ spring:
 support:
   chat-url: "https://open.kakao.com/o/placeholder"
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus, metrics
+  endpoint:
+    health:
+      show-details: always
+  metrics:
+    tags:
+      application: ${spring.application.name}
+
 candle-blow:
   duration-seconds: 300

--- a/src/test/kotlin/com/team2/server/chat/usecase/SendChatMessageUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/chat/usecase/SendChatMessageUseCaseTest.kt
@@ -70,7 +70,7 @@ class SendChatMessageUseCaseTest {
     }
 
     @Test
-    fun `LIVE_OPEN이 아니면 CHAT_NOT_ACTIVE`() {
+    fun `활성 상태가 아니면 CHAT_NOT_ACTIVE`() {
         whenever(resolveLiveOpenRealtimePartyUseCase.invoke(1L))
             .thenThrow(BusinessException(ErrorCode.CHAT_NOT_ACTIVE))
 

--- a/src/test/kotlin/com/team2/server/common/web/HttpExchangeLoggingFilterTest.kt
+++ b/src/test/kotlin/com/team2/server/common/web/HttpExchangeLoggingFilterTest.kt
@@ -50,6 +50,45 @@ class HttpExchangeLoggingFilterTest {
         }
     }
 
+    @Test
+    fun `stream 요청은 응답을 캐싱하지 않고 요청 body를 로깅한다`() {
+        val appender = ListAppender<ILoggingEvent>().apply { start() }
+        val logger = LoggerFactory.getLogger(HttpExchangeLoggingFilter::class.java) as Logger
+        val originalLevel = logger.level
+        logger.level = Level.INFO
+        logger.addAppender(appender)
+
+        try {
+            val request =
+                MockHttpServletRequest("POST", "/api/v1/party-invites/invite-code/realtime-participants/stream").apply {
+                    contentType = MediaType.APPLICATION_JSON_VALUE
+                    characterEncoding = Charsets.UTF_8.name()
+                    setContent("""{"nickname":"토끼왕","characterId":1}""".toByteArray())
+                }
+            val response =
+                MockHttpServletResponse().apply {
+                    characterEncoding = Charsets.UTF_8.name()
+                }
+            val chain =
+                FilterChain { servletRequest, servletResponse ->
+                    servletRequest.inputStream.readAllBytes()
+                    servletResponse.contentType = MediaType.APPLICATION_JSON_VALUE
+                    servletResponse.writer.write("""{"status":400,"error":{"code":"CHAT_NOT_ACTIVE"}}""")
+                }
+
+            filter.doFilter(request, response, chain)
+
+            assertEquals("""{"status":400,"error":{"code":"CHAT_NOT_ACTIVE"}}""", response.contentAsString)
+            val logMessage = appender.list.single().formattedMessage
+            assertContains(logMessage, "HTTP stream exchange")
+            assertContains(logMessage, "uri=/api/v1/party-invites/invite-code/realtime-participants/stream")
+            assertContains(logMessage, """requestJson={"nickname":"토끼왕","characterId":1}""")
+        } finally {
+            logger.detachAppender(appender)
+            logger.level = originalLevel
+        }
+    }
+
     private fun jsonRequest(): MockHttpServletRequest =
         MockHttpServletRequest("POST", "/api/v1/parties/1/participants").apply {
             contentType = MediaType.APPLICATION_JSON_VALUE

--- a/src/test/kotlin/com/team2/server/party/application/usecase/ResolveLiveOpenRealtimePartyUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/party/application/usecase/ResolveLiveOpenRealtimePartyUseCaseTest.kt
@@ -1,0 +1,74 @@
+package com.team2.server.party.application.usecase
+
+import com.team2.server.common.exception.BusinessException
+import com.team2.server.common.exception.ErrorCode
+import com.team2.server.party.application.service.PartyService
+import com.team2.server.party.domain.entity.RealtimeParty
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+@ExtendWith(MockitoExtension::class)
+class ResolveLiveOpenRealtimePartyUseCaseTest {
+    @Mock lateinit var partyService: PartyService
+
+    private val clock = Clock.fixed(Instant.parse("2026-06-08T11:00:30Z"), ZoneId.of("Asia/Seoul"))
+    private lateinit var useCase: ResolveLiveOpenRealtimePartyUseCase
+
+    @BeforeEach
+    fun setUp() {
+        useCase = ResolveLiveOpenRealtimePartyUseCase(partyService, clock)
+    }
+
+    @Test
+    fun `LIVE_OPEN이면 실시간 기능 사용 가능 파티를 반환한다`() {
+        val party = RealtimeParty(ownerId = 1L, startedAt = now().minusMinutes(1))
+        whenever(partyService.requireRealtimeParty(1L)).thenReturn(party)
+
+        val result = useCase.invoke(1L)
+
+        assertSame(party, result)
+    }
+
+    @Test
+    fun `LIVE_ENDING이면 실시간 기능 사용 가능 파티를 반환한다`() {
+        val party =
+            RealtimeParty(
+                ownerId = 1L,
+                startedAt = now().minusMinutes(1),
+                liveEndingStartedAt = now().minusSeconds(10),
+            )
+        whenever(partyService.requireRealtimeParty(1L)).thenReturn(party)
+
+        val result = useCase.invoke(1L)
+
+        assertSame(party, result)
+    }
+
+    @Test
+    fun `LIVE_CLOSED이면 CHAT_NOT_ACTIVE`() {
+        val party =
+            RealtimeParty(
+                ownerId = 1L,
+                startedAt = now().minusMinutes(1),
+                liveEndingStartedAt = now().minusSeconds(61),
+            )
+        whenever(partyService.requireRealtimeParty(1L)).thenReturn(party)
+
+        val ex = assertThrows<BusinessException> { useCase.invoke(1L) }
+
+        assertEquals(ErrorCode.CHAT_NOT_ACTIVE, ex.errorCode)
+    }
+
+    private fun now(): LocalDateTime = LocalDateTime.now(clock)
+}


### PR DESCRIPTION
## 🔗 Issue
- closes #

## 💬 Context
- dev 환경에서 `/actuator/prometheus` 요청이 actuator endpoint로 처리되지 못할 때 `NoResourceFoundException`이 `Unexpected error`로 크게 찍혀 로그 확인이 어려웠습니다.
- SSE stream 입장 요청은 기존 HTTP exchange logging 대상에서 제외되어 `CHAT_NOT_ACTIVE` 같은 실패 상황의 요청 body를 확인하기 어려웠습니다.
- 주최자 강제 종료 후 60초 종료 카운트다운(`LIVE_ENDING`) 동안 채팅/fireworks/burst 입력이 `CHAT_NOT_ACTIVE`로 막히는 문제가 있었습니다.

## 🛠 Changes
- 공통 `application.yml`에 actuator prometheus/metrics 노출 설정을 추가했습니다.
- `NoResourceFoundException`을 404 응답으로 별도 처리해 불필요한 ERROR stack trace를 줄였습니다.
- 일반 JSON API는 요청/응답 JSON을 계속 로깅하고, `/stream` 요청은 SSE 응답을 캐싱하지 않으면서 요청 JSON과 status를 로깅하도록 분기했습니다.
- stream 요청 로깅 동작을 테스트로 추가했습니다.
- 실시간 기능 공통 파티 조회 기준을 `LIVE_OPEN`뿐 아니라 `LIVE_ENDING`도 허용하도록 확장했습니다.

## 👀 Review Focus
- `/stream` 요청에서 응답 캐싱 없이 요청 body만 로깅하는 방식이 SSE 동작에 영향 없는지 확인 부탁드립니다.
- actuator prometheus 노출 설정을 공통 설정으로 올린 것이 dev/prod 프로필과 충돌 없는지 확인 부탁드립니다.
- 종료 카운트다운 60초 동안 채팅/fireworks/burst 입력을 허용하는 정책이 의도와 맞는지 확인 부탁드립니다.

## ✅ Check List
- [ ] Assignees 등록
- [ ] Label 등록
- [ ] CI 통과 확인

검증:
- `./gradlew ktlintCheck --quiet`
- `./gradlew compileKotlin --quiet`
- `./gradlew test --tests 'com.team2.server.common.web.HttpExchangeLoggingFilterTest' --quiet`
- `./gradlew test --tests 'com.team2.server.party.application.usecase.ResolveLiveOpenRealtimePartyUseCaseTest' --tests 'com.team2.server.chat.usecase.SendChatMessageUseCaseTest' --tests 'com.team2.server.fireworks.application.usecase.TriggerFireworksUseCaseTest' --quiet`

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * 리소스를 찾을 수 없을 때 명확한 오류 메시지 처리 추가
  * 스트리밍 요청의 로깅 성능 개선

* **New Features**
  * 라이브 파티 종료 중에도 채팅 기능 사용 가능
  * 시스템 모니터링 및 헬스 체크 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->