### PR TITLE
[Feat] 실시간 파티 주최자 종료 사유 분기

### DIFF
--- a/docs/superpowers/specs/2026-05-19-realtime-party-end-design.md
+++ b/docs/superpowers/specs/2026-05-19-realtime-party-end-design.md
@@ -10,9 +10,23 @@
 
 - 주최자만 수동 종료 가능
 - 수동 종료 가능 조건: `LIVE_OPEN` 상태의 주최자는 언제든 종료 가능
+- 주최자 수동 종료 원인은 종료 요청 시점에 `hostEnteredAt + 4분`이 지났거나 박터뜨리기가 종료됐으면 `HOST_REQUEST`, 그 전이면 `HOST_LEFT`
+- `hostEnteredAt + 4분`은 파티 예약 시작 시각이 아니라 주최자가 실시간 파티에 처음 입장한 시각을 기준으로 계산
+- 종료 요청 시점이 정확히 `hostEnteredAt + 4분`이면 `HOST_REQUEST`
+- 박터뜨리기 종료 시각은 영속화하며, 서버 재시작 후 `hostEnteredAt + 4분` 전 종료 요청도 박터뜨리기가 이미 종료됐다면 `HOST_REQUEST`
+- `burstGameEndedAt`은 박터뜨리기 최초 종료 시각만 조건부 저장하며 중복 종료 이벤트로 변경하지 않음
+- 종료 요청과 박터뜨리기 종료가 경합하면 저장된 사건 시각을 비교한다. `burstGameEndedAt <= 종료 요청 시각`이면 `HOST_REQUEST`, 아니면 `HOST_LEFT`
+- 종료 시작 원인은 종료 요청 시점에 확정하며 이후 발생한 사건으로 변경하지 않음
+- 종료 요청 시점이 정확히 `startedAt + 10분`이거나 그 이후면 자동 종료 저장 여부와 관계없이 `TIME_LIMIT_REACHED`
+- 방어적으로 `hostEnteredAt == null` 상태에서 수동 종료 요청이 처리되면 `HOST_LEFT`
+- `hostFarewellAvailable`은 현재 주최자 종료 인사하기 버튼을 사용할 수 있는지 나타낸다. `LIVE_OPEN`이고 `now >= hostEnteredAt + 4분` 또는 `burstGameEndedAt <= now`이면 `true`
+- `hostEnteredAt == null`이면 `hostFarewellAvailable`은 `false`
+- 상태 복구 조회는 `hostFarewellAvailable`과 프론트 타이머 기준인 `hostFarewellAvailableAt = hostEnteredAt + 4분`을 제공
+- 프론트는 서버 시각 기준으로 `hostFarewellAvailableAt` 도달을 계산하고, 박터뜨리기 종료는 기존 `burst-game-ended` SSE로 감지
+- 조기 종료 확인 팝업과 버튼 노출 UI는 프론트 책임이며, 백엔드는 종료 요청 시 권한 검증과 종료 원인 판정을 담당
 - 자동 종료 트리거: `startedAt + 10분`
 - 종료 트리거부터 60초 카운트다운 진행
-- 종료 카운트다운 화면은 `HOST_REQUEST`, `TIME_LIMIT_REACHED` 두 종료 시작 원인을 구분해 표시
+- 종료 카운트다운 화면은 `HOST_REQUEST`, `HOST_LEFT`, `TIME_LIMIT_REACHED` 세 종료 시작 원인을 구분해 표시
 - `party-ending` 전송 후 60초 뒤 `party-ended` 전송
 - `party-ended` 전송 후 짧은 grace time 뒤 남은 SSE emitter 정리
 - 실시간 세션 종료 후 재오픈, 신규 입장, 채팅 전송 불가
@@ -32,23 +46,43 @@ RealtimeParty.LIVE_END_COUNTDOWN_SECONDS = 60
 | 컬럼 | 타입 | nullable | 설명 |
 |---|---|---:|---|
 | `live_ending_started_at` | DATETIME | O | 60초 종료 카운트다운 시작 시각 |
+| `live_ending_reason` | VARCHAR | O | 종료 카운트다운 시작 원인. 종료 시작과 함께 원자적으로 저장 |
+| `burst_game_ended_at` | DATETIME | O | 박터뜨리기 종료 시각. 수동 종료 원인 판정과 재시작 복구에 사용 |
+
+박터뜨리기 종료 시각 저장:
+
+```sql
+UPDATE realtime_party
+SET burst_game_ended_at = :endedAt
+WHERE id = :partyId
+  AND burst_game_ended_at IS NULL
+```
 
 종료 완료 시각은 `live_ending_started_at + 60초`로 계산한다.
-종료 시작 원인은 저장된 `live_ending_started_at`과 자동 종료 기준 시각으로 계산한다.
+종료 시작 원인은 종료 카운트다운 시작 시 확정해 `live_ending_reason`에 저장한다.
+종료 시작 전에는 두 값이 모두 `null`이고, 종료 시작 후에는 `live_ending_started_at`, `live_ending_reason`이 모두 non-null이어야 한다.
+마이그레이션 시 기존 종료 데이터는 판단 가능한 기존 규칙으로 백필한다.
+
+- `live_ending_started_at < started_at + 10분`: `HOST_REQUEST`
+- `live_ending_started_at >= started_at + 10분`: `TIME_LIMIT_REACHED`
+- 기존 데이터에는 조기 종료 판단 정보가 없으므로 `HOST_LEFT`로 백필하지 않음
 
 ```kotlin
 enum class RealtimePartyEndingReason {
     HOST_REQUEST,
+    HOST_LEFT,
     TIME_LIMIT_REACHED,
 }
 ```
 
 | 종료 시작 원인 | 조건 | 의미 | `hostNickname` |
 |---|---|---|---|
-| `HOST_REQUEST` | `liveEndingStartedAt < automaticEndingStartedAt` | 주최자가 제한 시간 전에 종료 요청 | 종료를 요청한 주최자의 닉네임 |
-| `TIME_LIMIT_REACHED` | `liveEndingStartedAt >= automaticEndingStartedAt` | 10분 제한 시간 도달 | 파티 주최자의 닉네임 |
+| `HOST_REQUEST` | 수동 종료 요청 시 `now >= hostEnteredAt + 4분` 또는 `burstGameEndedAt <= now` | 파티가 충분히 진행된 뒤 주최자가 종료 | 종료를 요청한 주최자의 닉네임 |
+| `HOST_LEFT` | 수동 종료 요청 시 `hostEnteredAt == null`이거나 `now < hostEnteredAt + 4분`이고 박터뜨리기가 아직 종료되지 않음 | 파티 진행 초기에 주최자가 종료 | 종료를 요청한 주최자의 닉네임 |
+| `TIME_LIMIT_REACHED` | 종료 요청 시점이 `startedAt + 10분` 이상이거나 자동 종료 트리거 실행 | 10분 제한 시간 도달 | 파티 주최자의 닉네임 |
 
-주최자가 정확히 `startedAt + 10분`에 종료 요청한 경우에도 사용자 관점의 원인을 우선해 `TIME_LIMIT_REACHED`로 계산한다.
+수동 종료 요청과 자동 종료 스케줄러가 경합해도 종료 요청 시점이 `startedAt + 10분` 이상이면 `TIME_LIMIT_REACHED`를 저장한다.
+스케줄러 실행이 지연된 상태에서 주최자가 먼저 종료 API를 호출해도 동일하다.
 `hostNickname`은 파티 주최자의 표시 닉네임이며 종료 원인과 관계없이 항상 제공한다.
 값은 주최자의 `RealtimeParticipantProfile.nickname`을 사용한다. 실시간 파티 생성 시 주최자 프로필이 함께 생성되고 프로필 닉네임은 필수 값이므로, `hostNickname`은 non-null 계약으로 제공한다.
 주최자 프로필은 `Participant.isCelebrant = true`인 참가자의 `RealtimeParticipantProfile`로 식별한다. 실시간 파티에는 주최자 프로필이 한 개 존재한다.
@@ -96,6 +130,9 @@ POST /api/v1/parties/{partyId}/realtime-end
 Authorization: Bearer {accessToken}
 ```
 
+종료 인사하기와 조기 종료는 동일한 API를 사용하며 클라이언트는 종료 원인을 전달하지 않는다.
+서버는 종료 요청 시점의 `hostFarewellAvailable`을 기준으로 `HOST_REQUEST` 또는 `HOST_LEFT`를 판정한다.
+
 ```json
 {
   "partyId": 1,
@@ -121,7 +158,8 @@ Authorization: Bearer {accessToken}
 
 ```sql
 UPDATE realtime_party
-SET live_ending_started_at = :now
+SET live_ending_started_at = :now,
+    live_ending_reason = :endingReason
 WHERE id = :partyId
   AND live_ending_started_at IS NULL
 ```
@@ -147,12 +185,22 @@ Authorization: Bearer {accessToken} 또는 X-Participant-Token: {participantToke
   "endingStartedAt": "2026-05-19T20:10:00",
   "endedAt": "2026-05-19T20:11:00",
   "endingReason": "TIME_LIMIT_REACHED",
-  "hostNickname": "홍길동"
+  "hostNickname": "홍길동",
+  "hostFarewellAvailable": false,
+  "hostFarewellAvailableAt": "2026-05-19T20:04:00",
+  "serverNow": "2026-05-19T20:10:00"
 }
 ```
 
 `endingReason`은 `LIVE_ENDING`, `LIVE_CLOSED`에서만 제공하고, 종료 카운트다운 시작 전에는 `null`이다.
 `hostNickname`은 종료 원인과 상태에 관계없이 항상 제공한다. 따라서 종료 시작 전 상태 응답은 `endingReason = null`, `hostNickname = 주최자 닉네임`으로 내려준다.
+`hostFarewellAvailable`은 응답 시점의 파티 상태 스냅샷이며 현재 조회자가 주최자인지와 관계없이 동일하게 제공한다.
+`hostFarewellAvailable`, `hostFarewellAvailableAt`, `serverNow`는 `realtime-state`와 SSE 연결 직후 전송하는 `party-state`에 포함한다. 종료 요청 응답과 phase API에는 포함하지 않는다.
+`LIVE_ENDING`, `LIVE_CLOSED`, `ROLLING_PAPER_OPEN`, `ROLLING_PAPER_CLOSED`에서는 `false`다.
+`hostEnteredAt == null`이면 `hostFarewellAvailableAt`은 `null`이다.
+프론트는 `serverNow`를 기준으로 `hostFarewellAvailableAt`까지 남은 시간을 계산하고, 도달 시 로컬 상태를 `true`로 전환한다.
+박터뜨리기 종료 시에는 기존 `burst-game-ended` SSE를 받아 로컬 상태를 즉시 `true`로 전환한다.
+프론트는 `isHost && 로컬 hostFarewellAvailable`일 때 주최자 종료 인사하기 버튼을 노출한다.
 
 | 응답 또는 이벤트 | `endingReason` | `hostNickname` |
 |---|---|---|
@@ -160,6 +208,11 @@ Authorization: Bearer {accessToken} 또는 X-Participant-Token: {participantToke
 | `realtime-state`, `party-state` | nullable | non-null |
 | `party-ending` | non-null | non-null |
 | `party-ended` | 미포함 | non-null |
+
+| 응답 또는 이벤트 | `hostFarewellAvailable` | `hostFarewellAvailableAt` | `serverNow` |
+|---|---|---|---|
+| `realtime-state`, `party-state` | non-null | nullable | non-null |
+| 주최자 종료 요청 API, phase API, `party-ending`, `party-ended` | 미포함 | 미포함 | 미포함 |
 
 ### 3-3. 종료 후 다음 행동 조회
 
@@ -206,7 +259,7 @@ SSE 연결 직후 항상 현재 상태를 1회 전송한다.
 
 ```text
 event: party-state
-data: {"partyId":1,"status":"LIVE_ENDING","liveStartAt":"2026-05-19T20:00:00","endingStartedAt":"2026-05-19T20:10:00","endedAt":"2026-05-19T20:11:00","endingReason":"TIME_LIMIT_REACHED","hostNickname":"홍길동"}
+data: {"partyId":1,"status":"LIVE_ENDING","liveStartAt":"2026-05-19T20:00:00","endingStartedAt":"2026-05-19T20:10:00","endedAt":"2026-05-19T20:11:00","endingReason":"TIME_LIMIT_REACHED","hostNickname":"홍길동","hostFarewellAvailable":false,"hostFarewellAvailableAt":"2026-05-19T20:04:00","serverNow":"2026-05-19T20:10:00"}
 ```
 
 ### party-ending
@@ -319,20 +372,15 @@ REALTIME_PARTY_ALREADY_ENDED(HttpStatus.CONFLICT, "이미 종료된 실시간 �
 
 ## 8. 구현 체크리스트
 
-1. `RealtimeParty.liveEndingStartedAt` 추가
-2. Flyway migration 추가
-3. `RealtimePartyStatus.LIVE_ENDING` 추가
-4. `RealtimeParty.hostViewableAt()` 수정
-5. 주최자 종료 요청 API 추가
-6. 실시간 상태 복구 API 추가
-7. 종료 후 다음 행동 조회 API 추가
-8. `party-state`, `party-ending`, `party-ended` SSE에 종료 표시 정보 제공
-9. `PartyEndScheduler`를 startup recovery + event 기반 예약 구조로 변경
-10. 종료 시작 조건부 update 구현
-11. `party-ended` 후 grace cleanup 적용
-12. 신규 입장/채팅 검증에서 `LIVE_OPEN` 허용
-13. 참가자 `LIVE_ENDING` SSE 재연결 허용
-14. `HOST_REQUEST`, `TIME_LIMIT_REACHED` 경계 및 응답 필드 테스트 추가
+1. `realtime_party.live_ending_reason`, `burst_game_ended_at` Flyway migration 및 기존 종료 사유 백필
+2. `RealtimePartyEndingReason.HOST_LEFT` 추가
+3. 종료 시작 조건부 update에서 `live_ending_started_at`, `live_ending_reason` 원자적 저장
+4. 박터뜨리기 최초 종료 시각 조건부 저장
+5. 수동 종료 요청 시 `TIME_LIMIT_REACHED → HOST_REQUEST → HOST_LEFT` 우선순위 판정
+6. 자동 종료와 스케줄 복구에서 저장된 `live_ending_reason` 사용
+7. `realtime-state`, `party-state`에 `hostFarewellAvailable`, `hostFarewellAvailableAt`, `serverNow` 제공
+8. 기존 `burst-game-ended` SSE를 프론트 종료 인사하기 버튼 활성화 트리거로 문서화
+9. 마이그레이션 백필, 4분 경계, 박터뜨리기 경합, 10분 스케줄러 지연, 서버 재시작 복구 테스트 추가
 
 ## 9. 참가자 next action 계산 기준
 

--- a/src/main/kotlin/com/team2/server/party/application/dto/RealtimePartyEndResults.kt
+++ b/src/main/kotlin/com/team2/server/party/application/dto/RealtimePartyEndResults.kt
@@ -59,6 +59,12 @@ data class RealtimePartyStateResult(
     val endingReason: RealtimePartyEndingReason?,
     @Schema(description = "파티 주최자 닉네임", example = "홍길동")
     val hostNickname: String,
+    @Schema(description = "현재 주최자 종료 인사하기 버튼 사용 가능 여부", example = "false")
+    val hostFarewellAvailable: Boolean,
+    @Schema(description = "주최자 입장 기준 종료 인사하기 버튼 활성화 시각", nullable = true)
+    val hostFarewellAvailableAt: LocalDateTime?,
+    @Schema(description = "응답 생성 서버 시각")
+    val serverNow: LocalDateTime,
 ) {
     companion object {
         fun from(
@@ -82,6 +88,9 @@ data class RealtimePartyStateResult(
                 endedAt = party.effectiveLiveEndedAt(),
                 endingReason = endingInfo.endingReason,
                 hostNickname = endingInfo.hostNickname,
+                hostFarewellAvailable = party.isHostFarewellAvailable(now),
+                hostFarewellAvailableAt = party.hostFarewellAvailableAt,
+                serverNow = now,
             )
         }
     }

--- a/src/main/kotlin/com/team2/server/party/application/port/RealtimePartyBurstGameEndRecorder.kt
+++ b/src/main/kotlin/com/team2/server/party/application/port/RealtimePartyBurstGameEndRecorder.kt
@@ -1,0 +1,10 @@
+package com.team2.server.party.application.port
+
+import java.time.LocalDateTime
+
+interface RealtimePartyBurstGameEndRecorder {
+    fun recordFirst(
+        partyId: Long,
+        endedAt: LocalDateTime,
+    ): Boolean
+}

--- a/src/main/kotlin/com/team2/server/party/application/service/RealtimePartyEndService.kt
+++ b/src/main/kotlin/com/team2/server/party/application/service/RealtimePartyEndService.kt
@@ -62,6 +62,7 @@ class RealtimePartyEndService(
             now = now,
             liveDurationMinutes = RealtimeParty.LIVE_DURATION_MINUTES,
             partyEndedAfterDays = Party.ENDED_AFTER_DAYS,
+            endingReason = RealtimePartyEndingReason.TIME_LIMIT_REACHED.name,
         )
     }
 

--- a/src/main/kotlin/com/team2/server/party/application/service/RealtimePartyEndService.kt
+++ b/src/main/kotlin/com/team2/server/party/application/service/RealtimePartyEndService.kt
@@ -10,6 +10,7 @@ import com.team2.server.party.application.port.RealtimePartyEndingInfoPort
 import com.team2.server.party.domain.entity.Party
 import com.team2.server.party.domain.entity.PartyOption
 import com.team2.server.party.domain.entity.RealtimeParty
+import com.team2.server.party.domain.entity.RealtimePartyEndingReason
 import com.team2.server.party.infrastructure.persistence.PartyRepository
 import org.hibernate.Hibernate
 import org.springframework.stereotype.Service
@@ -23,8 +24,9 @@ class RealtimePartyEndService(
     fun startIfNotStarted(
         partyId: Long,
         endingStartedAt: LocalDateTime,
+        endingReason: RealtimePartyEndingReason,
     ): RealtimePartyEndStartResult {
-        val affected = partyRepository.startRealtimeEndingIfNotStarted(partyId, endingStartedAt)
+        val affected = partyRepository.startRealtimeEndingIfNotStarted(partyId, endingStartedAt, endingReason)
         val party = findRealtimeParty(partyId)
         return RealtimePartyEndStartResult(
             affected = affected,
@@ -36,7 +38,12 @@ class RealtimePartyEndService(
         partyId: Long,
         endingStartedAt: LocalDateTime,
     ): RealtimeEndingScheduleTarget? {
-        val affected = partyRepository.startRealtimeEndingIfNotStarted(partyId, endingStartedAt)
+        val affected =
+            partyRepository.startRealtimeEndingIfNotStarted(
+                partyId,
+                endingStartedAt,
+                RealtimePartyEndingReason.TIME_LIMIT_REACHED,
+            )
         val party = findRealtimeParty(partyId)
         val actualEndingStartedAt = party.liveEndingStartedAt ?: return null
         val endingInfo = endingInfoPort.get(party)

--- a/src/main/kotlin/com/team2/server/party/application/usecase/MarkRealtimePartyBurstGameEndedUseCase.kt
+++ b/src/main/kotlin/com/team2/server/party/application/usecase/MarkRealtimePartyBurstGameEndedUseCase.kt
@@ -1,0 +1,19 @@
+package com.team2.server.party.application.usecase
+
+import com.team2.server.party.application.port.RealtimePartyBurstGameEndRecorder
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service
+class MarkRealtimePartyBurstGameEndedUseCase(
+    private val recorder: RealtimePartyBurstGameEndRecorder,
+) {
+    @Transactional
+    operator fun invoke(
+        partyId: Long,
+        endedAt: LocalDateTime,
+    ) {
+        recorder.recordFirst(partyId, endedAt)
+    }
+}

--- a/src/main/kotlin/com/team2/server/party/application/usecase/StartRealtimePartyEndUseCase.kt
+++ b/src/main/kotlin/com/team2/server/party/application/usecase/StartRealtimePartyEndUseCase.kt
@@ -34,10 +34,17 @@ class StartRealtimePartyEndUseCase(
                     realtimePartyEndService.startIfNotStarted(
                         party.id,
                         party.liveEndingStartedAt ?: party.automaticEndingStartedAt(),
+                        party.endingReason(now) ?: party.endingReasonForManualRequest(now),
                     ),
                 )
             RealtimePartyStatus.LIVE_OPEN ->
-                toResultAndPublish(realtimePartyEndService.startIfNotStarted(party.id, now))
+                toResultAndPublish(
+                    realtimePartyEndService.startIfNotStarted(
+                        party.id,
+                        now,
+                        party.endingReasonForManualRequest(now),
+                    ),
+                )
             else -> throwPartyBusiness(ErrorCode.REALTIME_PARTY_INVALID_STATE)
         }
     }

--- a/src/main/kotlin/com/team2/server/party/domain/entity/RealtimeParty.kt
+++ b/src/main/kotlin/com/team2/server/party/domain/entity/RealtimeParty.kt
@@ -3,6 +3,8 @@ package com.team2.server.party.domain.entity
 import jakarta.persistence.Column
 import jakarta.persistence.DiscriminatorValue
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.Table
 import java.time.LocalDateTime
 
@@ -17,8 +19,13 @@ class RealtimeParty(
     startedAt: LocalDateTime,
     @Column(name = "live_ending_started_at")
     var liveEndingStartedAt: LocalDateTime? = null,
+    @Column(name = "live_ending_reason")
+    @Enumerated(EnumType.STRING)
+    var liveEndingReason: RealtimePartyEndingReason? = null,
     @Column(name = "host_entered_at")
     var hostEnteredAt: LocalDateTime? = null,
+    @Column(name = "burst_game_ended_at")
+    var burstGameEndedAt: LocalDateTime? = null,
 ) : Party(ownerId, name, celebrantNickname, startedAt, purpose) {
     override val partyOption: PartyOption get() = PartyOption.REALTIME
 
@@ -33,13 +40,14 @@ class RealtimeParty(
     fun liveEndedAt(): LocalDateTime? = liveEndingStartedAt?.plusSeconds(LIVE_END_COUNTDOWN_SECONDS)
 
     fun endingReason(): RealtimePartyEndingReason? =
-        liveEndingStartedAt?.let {
-            if (it.isBefore(automaticEndingStartedAt())) {
-                RealtimePartyEndingReason.HOST_REQUEST
-            } else {
-                RealtimePartyEndingReason.TIME_LIMIT_REACHED
+        liveEndingReason
+            ?: liveEndingStartedAt?.let {
+                if (it.isBefore(automaticEndingStartedAt())) {
+                    RealtimePartyEndingReason.HOST_REQUEST
+                } else {
+                    RealtimePartyEndingReason.TIME_LIMIT_REACHED
+                }
             }
-        }
 
     fun endingReason(now: LocalDateTime): RealtimePartyEndingReason? =
         endingReason()
@@ -48,6 +56,25 @@ class RealtimeParty(
             } else {
                 null
             }
+
+    fun endingReasonForManualRequest(now: LocalDateTime): RealtimePartyEndingReason =
+        when {
+            !now.isBefore(automaticEndingStartedAt()) -> RealtimePartyEndingReason.TIME_LIMIT_REACHED
+            hostFarewellAvailableAt?.let { !now.isBefore(it) } == true ->
+                RealtimePartyEndingReason.HOST_REQUEST
+            burstGameEndedAt?.let { !it.isAfter(now) } == true -> RealtimePartyEndingReason.HOST_REQUEST
+            else -> RealtimePartyEndingReason.HOST_LEFT
+        }
+
+    val hostFarewellAvailableAt: LocalDateTime?
+        get() = hostEnteredAt?.plusMinutes(HOST_FAREWELL_AVAILABLE_AFTER_MINUTES)
+
+    fun isHostFarewellAvailable(now: LocalDateTime): Boolean =
+        isLiveOpen(now) &&
+            (
+                hostFarewellAvailableAt?.let { !now.isBefore(it) } == true ||
+                    burstGameEndedAt?.let { !it.isAfter(now) } == true
+            )
 
     fun isLiveOpen(now: LocalDateTime = LocalDateTime.now()): Boolean =
         !now.isBefore(startedAt) && now.isBefore(effectiveEndingStartedAt())
@@ -64,6 +91,7 @@ class RealtimeParty(
     companion object {
         const val LIVE_DURATION_MINUTES: Long = 10
         const val LIVE_END_COUNTDOWN_SECONDS: Long = 60
+        const val HOST_FAREWELL_AVAILABLE_AFTER_MINUTES: Long = 4
         const val ENTERABLE_BEFORE_MINUTES: Long = 5
         const val MAX_PARTICIPANTS: Int = 14
     }
@@ -79,5 +107,6 @@ enum class RealtimePartyStatus {
 
 enum class RealtimePartyEndingReason {
     HOST_REQUEST,
+    HOST_LEFT,
     TIME_LIMIT_REACHED,
 }

--- a/src/main/kotlin/com/team2/server/party/infrastructure/event/RealtimePartyBurstGameEndedListener.kt
+++ b/src/main/kotlin/com/team2/server/party/infrastructure/event/RealtimePartyBurstGameEndedListener.kt
@@ -1,0 +1,17 @@
+package com.team2.server.party.infrastructure.event
+
+import com.team2.server.party.application.event.RealtimePartyBurstGameEndedEvent
+import com.team2.server.party.application.usecase.MarkRealtimePartyBurstGameEndedUseCase
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Component
+class RealtimePartyBurstGameEndedListener(
+    private val markRealtimePartyBurstGameEndedUseCase: MarkRealtimePartyBurstGameEndedUseCase,
+) {
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    fun onBurstGameEnded(event: RealtimePartyBurstGameEndedEvent) {
+        markRealtimePartyBurstGameEndedUseCase(event.partyId, event.endedAt)
+    }
+}

--- a/src/main/kotlin/com/team2/server/party/infrastructure/persistence/PartyRepository.kt
+++ b/src/main/kotlin/com/team2/server/party/infrastructure/persistence/PartyRepository.kt
@@ -71,7 +71,7 @@ interface PartyRepository : JpaRepository<Party, Long> {
                 party.started_at,
                 INTERVAL :liveDurationMinutes MINUTE
             ),
-                realtime_party.live_ending_reason = 'TIME_LIMIT_REACHED'
+                realtime_party.live_ending_reason = :endingReason
             WHERE realtime_party.live_ending_started_at IS NULL
               AND DATE_ADD(party.started_at, INTERVAL :liveDurationMinutes MINUTE) <= :now
               AND DATE_ADD(party.started_at, INTERVAL :partyEndedAfterDays DAY) > :now
@@ -82,6 +82,7 @@ interface PartyRepository : JpaRepository<Party, Long> {
         now: LocalDateTime,
         liveDurationMinutes: Long,
         partyEndedAfterDays: Long,
+        endingReason: String,
     ): Int
 
     @Query(

--- a/src/main/kotlin/com/team2/server/party/infrastructure/persistence/PartyRepository.kt
+++ b/src/main/kotlin/com/team2/server/party/infrastructure/persistence/PartyRepository.kt
@@ -2,6 +2,7 @@ package com.team2.server.party.infrastructure.persistence
 
 import com.team2.server.party.domain.entity.Party
 import com.team2.server.party.domain.entity.RealtimeParty
+import com.team2.server.party.domain.entity.RealtimePartyEndingReason
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
@@ -20,7 +21,8 @@ interface PartyRepository : JpaRepository<Party, Long> {
     @Query(
         """
         UPDATE RealtimeParty party
-        SET party.liveEndingStartedAt = :endingStartedAt
+        SET party.liveEndingStartedAt = :endingStartedAt,
+            party.liveEndingReason = :endingReason
         WHERE party.id = :partyId
           AND party.liveEndingStartedAt IS NULL
         """,
@@ -28,6 +30,7 @@ interface PartyRepository : JpaRepository<Party, Long> {
     fun startRealtimeEndingIfNotStarted(
         partyId: Long,
         endingStartedAt: LocalDateTime,
+        endingReason: RealtimePartyEndingReason,
     ): Int
 
     @Modifying(flushAutomatically = true)
@@ -46,6 +49,20 @@ interface PartyRepository : JpaRepository<Party, Long> {
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(
+        """
+        UPDATE RealtimeParty party
+        SET party.burstGameEndedAt = :endedAt
+        WHERE party.id = :partyId
+          AND party.burstGameEndedAt IS NULL
+        """,
+    )
+    fun markBurstGameEndedIfAbsent(
+        partyId: Long,
+        endedAt: LocalDateTime,
+    ): Int
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
         value =
             """
             UPDATE realtime_party realtime_party
@@ -53,7 +70,8 @@ interface PartyRepository : JpaRepository<Party, Long> {
             SET realtime_party.live_ending_started_at = DATE_ADD(
                 party.started_at,
                 INTERVAL :liveDurationMinutes MINUTE
-            )
+            ),
+                realtime_party.live_ending_reason = 'TIME_LIMIT_REACHED'
             WHERE realtime_party.live_ending_started_at IS NULL
               AND DATE_ADD(party.started_at, INTERVAL :liveDurationMinutes MINUTE) <= :now
               AND DATE_ADD(party.started_at, INTERVAL :partyEndedAfterDays DAY) > :now

--- a/src/main/kotlin/com/team2/server/party/infrastructure/persistence/RealtimePartyBurstGameEndRecorderAdapter.kt
+++ b/src/main/kotlin/com/team2/server/party/infrastructure/persistence/RealtimePartyBurstGameEndRecorderAdapter.kt
@@ -1,0 +1,15 @@
+package com.team2.server.party.infrastructure.persistence
+
+import com.team2.server.party.application.port.RealtimePartyBurstGameEndRecorder
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+
+@Component
+class RealtimePartyBurstGameEndRecorderAdapter(
+    private val partyRepository: PartyRepository,
+) : RealtimePartyBurstGameEndRecorder {
+    override fun recordFirst(
+        partyId: Long,
+        endedAt: LocalDateTime,
+    ): Boolean = partyRepository.markBurstGameEndedIfAbsent(partyId, endedAt) == 1
+}

--- a/src/main/resources/db/migration/V8__add_realtime_party_end_reason_and_burst_game_ended_at.sql
+++ b/src/main/resources/db/migration/V8__add_realtime_party_end_reason_and_burst_game_ended_at.sql
@@ -1,0 +1,14 @@
+ALTER TABLE realtime_party
+    ADD COLUMN live_ending_reason VARCHAR(50) NULL,
+    ADD COLUMN burst_game_ended_at DATETIME(6) NULL;
+
+UPDATE realtime_party realtime_party
+JOIN party party ON party.id = realtime_party.id
+SET realtime_party.live_ending_reason =
+    CASE
+        WHEN realtime_party.live_ending_started_at < DATE_ADD(party.started_at, INTERVAL 10 MINUTE)
+            THEN 'HOST_REQUEST'
+        ELSE 'TIME_LIMIT_REACHED'
+    END
+WHERE realtime_party.live_ending_started_at IS NOT NULL
+  AND realtime_party.live_ending_reason IS NULL;

--- a/src/test/kotlin/com/team2/server/chat/usecase/EnterAndSubscribeChatUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/chat/usecase/EnterAndSubscribeChatUseCaseTest.kt
@@ -41,27 +41,30 @@ class EnterAndSubscribeChatUseCaseTest {
     private fun enterResult(
         partyId: Long = 1L,
         isCelebrant: Boolean = false,
-    ) = EnterRealtimePartyResult(
-        participantToken = "abc12345",
-        partyId = partyId,
-        startedAt = LocalDateTime.now().minusMinutes(5),
-        isCelebrant = isCelebrant,
-        nickname = "토끼왕",
-        characterId = 1L,
-        partyState =
-            RealtimePartyStateResult(
-                partyId = partyId,
-                status = RealtimePartyStatus.LIVE_OPEN,
-                liveStartAt = LocalDateTime.now().minusMinutes(5),
-                endingStartedAt = null,
-                endedAt = LocalDateTime.now().plusMinutes(5).plusSeconds(60),
-                endingReason = null,
-                hostNickname = "주최자",
-                hostFarewellAvailable = true,
-                hostFarewellAvailableAt = LocalDateTime.now().minusMinutes(1),
-                serverNow = LocalDateTime.now(),
-            ),
-    )
+    ): EnterRealtimePartyResult {
+        val now = LocalDateTime.now()
+        return EnterRealtimePartyResult(
+            participantToken = "abc12345",
+            partyId = partyId,
+            startedAt = now.minusMinutes(5),
+            isCelebrant = isCelebrant,
+            nickname = "토끼왕",
+            characterId = 1L,
+            partyState =
+                RealtimePartyStateResult(
+                    partyId = partyId,
+                    status = RealtimePartyStatus.LIVE_OPEN,
+                    liveStartAt = now.minusMinutes(5),
+                    endingStartedAt = null,
+                    endedAt = now.plusMinutes(5).plusSeconds(60),
+                    endingReason = null,
+                    hostNickname = "주최자",
+                    hostFarewellAvailable = true,
+                    hostFarewellAvailableAt = now.minusMinutes(1),
+                    serverNow = now,
+                ),
+        )
+    }
 
     @Test
     fun `입장 성공 - entered 이벤트와 함께 emitter 반환`() {

--- a/src/test/kotlin/com/team2/server/chat/usecase/EnterAndSubscribeChatUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/chat/usecase/EnterAndSubscribeChatUseCaseTest.kt
@@ -57,6 +57,9 @@ class EnterAndSubscribeChatUseCaseTest {
                 endedAt = LocalDateTime.now().plusMinutes(5).plusSeconds(60),
                 endingReason = null,
                 hostNickname = "주최자",
+                hostFarewellAvailable = true,
+                hostFarewellAvailableAt = LocalDateTime.now().minusMinutes(1),
+                serverNow = LocalDateTime.now(),
             ),
     )
 

--- a/src/test/kotlin/com/team2/server/chat/usecase/EnterAndSubscribeChatUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/chat/usecase/EnterAndSubscribeChatUseCaseTest.kt
@@ -38,12 +38,13 @@ class EnterAndSubscribeChatUseCaseTest {
 
     private val request = EnterRealtimePartyRequest(nickname = "토끼왕", characterId = 1L)
 
+    private val now = LocalDateTime.of(2026, 5, 23, 10, 0)
+
     private fun enterResult(
         partyId: Long = 1L,
         isCelebrant: Boolean = false,
-    ): EnterRealtimePartyResult {
-        val now = LocalDateTime.now()
-        return EnterRealtimePartyResult(
+    ): EnterRealtimePartyResult =
+        EnterRealtimePartyResult(
             participantToken = "abc12345",
             partyId = partyId,
             startedAt = now.minusMinutes(5),
@@ -64,11 +65,10 @@ class EnterAndSubscribeChatUseCaseTest {
                     serverNow = now,
                 ),
         )
-    }
 
     @Test
     fun `입장 성공 - entered 이벤트와 함께 emitter 반환`() {
-        val party = RealtimeParty(ownerId = 1L, startedAt = LocalDateTime.now().minusMinutes(5))
+        val party = RealtimeParty(ownerId = 1L, startedAt = now.minusMinutes(5))
         val participant = Participant(party = party)
         val profile = RealtimeParticipantProfile(participant = participant, nickname = "토끼왕")
         val msg = ChatMessage(content = "이전 메시지", party = party, profile = profile)

--- a/src/test/kotlin/com/team2/server/db/FlywayMigrationTest.kt
+++ b/src/test/kotlin/com/team2/server/db/FlywayMigrationTest.kt
@@ -9,6 +9,61 @@ import kotlin.test.assertEquals
 
 class FlywayMigrationTest {
     @Test
+    fun `Flyway migration backfills existing realtime party ending reasons`() {
+        val flywayToV7 =
+            Flyway
+                .configure()
+                .dataSource(MYSQL.jdbcUrl, MYSQL.username, MYSQL.password)
+                .locations("classpath:db/migration")
+                .target("7")
+                .cleanDisabled(false)
+                .load()
+        flywayToV7.clean()
+        flywayToV7.migrate()
+
+        DriverManager.getConnection(MYSQL.jdbcUrl, MYSQL.username, MYSQL.password).use { connection ->
+            connection.createStatement().use { statement ->
+                statement.executeUpdate(
+                    """
+                    insert into users (
+                        id, created_at, updated_at, name, birth_day, provider, provider_id, email
+                    ) values (
+                        1, '2026-06-08 19:00:00', '2026-06-08 19:00:00',
+                        'host', '01-01', 'KAKAO', 'provider-id', 'host@example.com'
+                    )
+                    """.trimIndent(),
+                )
+                statement.executeUpdate(
+                    """
+                    insert into party (
+                        id, party_option, created_at, updated_at, owner_id, started_at
+                    ) values
+                        (1, 'REALTIME', '2026-06-08 19:00:00', '2026-06-08 19:00:00', 1, '2026-06-08 20:00:00'),
+                        (2, 'REALTIME', '2026-06-08 19:00:00', '2026-06-08 19:00:00', 1, '2026-06-08 20:00:00')
+                    """.trimIndent(),
+                )
+                statement.executeUpdate(
+                    """
+                    insert into realtime_party (id, live_ending_started_at, host_entered_at) values
+                        (1, '2026-06-08 20:05:00', '2026-06-08 20:00:00'),
+                        (2, '2026-06-08 20:10:00', '2026-06-08 20:00:00')
+                    """.trimIndent(),
+                )
+            }
+
+            Flyway
+                .configure()
+                .dataSource(MYSQL.jdbcUrl, MYSQL.username, MYSQL.password)
+                .locations("classpath:db/migration")
+                .load()
+                .migrate()
+
+            assertEquals("HOST_REQUEST", connection.findEndingReason(1L))
+            assertEquals("TIME_LIMIT_REACHED", connection.findEndingReason(2L))
+        }
+    }
+
+    @Test
     fun `Flyway migration creates schema and seeds default assets`() {
         DriverManager.getConnection(MYSQL.jdbcUrl, MYSQL.username, MYSQL.password).use { connection ->
             Flyway
@@ -32,6 +87,14 @@ class FlywayMigrationTest {
                 ColumnDefinition(dataType = "datetime", datetimePrecision = 6, nullable = true),
                 connection.findColumn("realtime_party", "host_entered_at"),
             )
+            assertEquals(
+                ColumnDefinition(dataType = "varchar", datetimePrecision = 0, nullable = true),
+                connection.findColumn("realtime_party", "live_ending_reason"),
+            )
+            assertEquals(
+                ColumnDefinition(dataType = "datetime", datetimePrecision = 6, nullable = true),
+                connection.findColumn("realtime_party", "burst_game_ended_at"),
+            )
         }
     }
 
@@ -44,6 +107,15 @@ class FlywayMigrationTest {
             }
         }
     }
+
+    private fun java.sql.Connection.findEndingReason(partyId: Long): String =
+        prepareStatement("select live_ending_reason from realtime_party where id = ?").use { statement ->
+            statement.setLong(1, partyId)
+            statement.executeQuery().use { resultSet ->
+                resultSet.next()
+                resultSet.getString(1)
+            }
+        }
 
     private fun java.sql.Connection.countRollingPaperToppingsMissingImage(): Int =
         createStatement().use { statement ->

--- a/src/test/kotlin/com/team2/server/party/api/PartyControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/party/api/PartyControllerTest.kt
@@ -231,7 +231,7 @@ class PartyControllerTest
         }
 
         @Test
-        fun `주최자는 LIVE_OPEN이면 4분 전에도 실시간 파티 종료를 시작할 수 있다`() {
+        fun `주최자는 LIVE_OPEN이면 4분 전에도 HOST_LEFT로 실시간 파티 종료를 시작할 수 있다`() {
             val owner = saveUser("kakao-realtime-end-start", "end-start@kakao.local")
             val party = saveRealtimeParty(owner, LocalDateTime.now().minusMinutes(1))
 
@@ -243,7 +243,7 @@ class PartyControllerTest
                     jsonPath("$.data.partyId") { value(party.id.toInt()) }
                     jsonPath("$.data.endingStartedAt") { exists() }
                     jsonPath("$.data.endedAt") { exists() }
-                    jsonPath("$.data.endingReason") { value("HOST_REQUEST") }
+                    jsonPath("$.data.endingReason") { value("HOST_LEFT") }
                     jsonPath("$.data.hostNickname") { value("주최자") }
                 }
         }
@@ -285,6 +285,46 @@ class PartyControllerTest
                 }
 
             assertEquals(party.id, memberParticipant.party.id)
+        }
+
+        @Test
+        fun `실시간 파티 상태는 주최자 종료 인사 가능 여부와 기준 시각을 제공한다`() {
+            val owner = saveUser("kakao-realtime-state-farewell", "state-farewell@kakao.local")
+            val hostEnteredAt = LocalDateTime.now().minusMinutes(1)
+            val party =
+                saveRealtimeParty(owner, LocalDateTime.now().minusMinutes(1)).also {
+                    it.hostEnteredAt = hostEnteredAt
+                    partyRepository.save(it)
+                }
+
+            mockMvc
+                .get("/api/v1/parties/${party.id}/realtime-state") {
+                    header("Authorization", "Bearer ${tokenProvider.issue(owner)}")
+                }.andExpect {
+                    status { isOk() }
+                    jsonPath("$.data.hostFarewellAvailable") { value(false) }
+                    jsonPath("$.data.hostFarewellAvailableAt") { exists() }
+                    jsonPath("$.data.serverNow") { exists() }
+                }
+        }
+
+        @Test
+        fun `박터뜨리기가 종료된 파티 상태는 주최자 종료 인사 가능 상태를 복구한다`() {
+            val owner = saveUser("kakao-realtime-state-burst-ended", "state-burst-ended@kakao.local")
+            val party =
+                saveRealtimeParty(owner, LocalDateTime.now().minusMinutes(1)).also {
+                    it.hostEnteredAt = LocalDateTime.now().minusMinutes(1)
+                    it.burstGameEndedAt = LocalDateTime.now().minusSeconds(1)
+                    partyRepository.save(it)
+                }
+
+            mockMvc
+                .get("/api/v1/parties/${party.id}/realtime-state") {
+                    header("Authorization", "Bearer ${tokenProvider.issue(owner)}")
+                }.andExpect {
+                    status { isOk() }
+                    jsonPath("$.data.hostFarewellAvailable") { value(true) }
+                }
         }
 
         @Test

--- a/src/test/kotlin/com/team2/server/party/application/service/RealtimePartyEndServiceTest.kt
+++ b/src/test/kotlin/com/team2/server/party/application/service/RealtimePartyEndServiceTest.kt
@@ -86,6 +86,7 @@ class RealtimePartyEndServiceTest {
             now = now,
             liveDurationMinutes = RealtimeParty.LIVE_DURATION_MINUTES,
             partyEndedAfterDays = Party.ENDED_AFTER_DAYS,
+            endingReason = RealtimePartyEndingReason.TIME_LIMIT_REACHED.name,
         )
     }
 

--- a/src/test/kotlin/com/team2/server/party/application/service/RealtimePartyEndServiceTest.kt
+++ b/src/test/kotlin/com/team2/server/party/application/service/RealtimePartyEndServiceTest.kt
@@ -30,12 +30,17 @@ class RealtimePartyEndServiceTest {
     @Test
     fun `startIfNotStarted returns affected count and realtime party`() {
         val party = realtimeParty(id = 1L, liveEndingStartedAt = startedAt.plusMinutes(5))
-        whenever(partyRepository.startRealtimeEndingIfNotStarted(eq(1L), any())).thenReturn(1)
+        whenever(partyRepository.startRealtimeEndingIfNotStarted(eq(1L), any(), any())).thenReturn(1)
         whenever(partyRepository.findPartyById(1L)).thenReturn(party)
         whenever(endingInfoPort.get(party))
             .thenReturn(RealtimePartyEndingInfo(party.endingReason(), "주최자"))
 
-        val result = service.startIfNotStarted(1L, startedAt.plusMinutes(5))
+        val result =
+            service.startIfNotStarted(
+                1L,
+                startedAt.plusMinutes(5),
+                RealtimePartyEndingReason.HOST_REQUEST,
+            )
 
         assertEquals(1, result.affected)
         assertSame(party, result.party)
@@ -44,7 +49,7 @@ class RealtimePartyEndServiceTest {
     @Test
     fun `startIfNotStartedOrNull returns null when ending time is still absent`() {
         val party = realtimeParty(id = 1L)
-        whenever(partyRepository.startRealtimeEndingIfNotStarted(eq(1L), any())).thenReturn(0)
+        whenever(partyRepository.startRealtimeEndingIfNotStarted(eq(1L), any(), any())).thenReturn(0)
         whenever(partyRepository.findPartyById(1L)).thenReturn(party)
 
         val result = service.startIfNotStartedOrNull(1L, startedAt.plusMinutes(5))
@@ -56,7 +61,7 @@ class RealtimePartyEndServiceTest {
     fun `startIfNotStartedOrNull returns ending schedule`() {
         val endingStartedAt = startedAt.plusMinutes(5)
         val party = realtimeParty(id = 1L, liveEndingStartedAt = endingStartedAt)
-        whenever(partyRepository.startRealtimeEndingIfNotStarted(eq(1L), any())).thenReturn(1)
+        whenever(partyRepository.startRealtimeEndingIfNotStarted(eq(1L), any(), any())).thenReturn(1)
         whenever(partyRepository.findPartyById(1L)).thenReturn(party)
         whenever(endingInfoPort.get(party))
             .thenReturn(RealtimePartyEndingInfo(party.endingReason(), "주최자"))
@@ -116,10 +121,13 @@ class RealtimePartyEndServiceTest {
 
     @Test
     fun `missing party throws PARTY_NOT_FOUND`() {
-        whenever(partyRepository.startRealtimeEndingIfNotStarted(eq(1L), any())).thenReturn(0)
+        whenever(partyRepository.startRealtimeEndingIfNotStarted(eq(1L), any(), any())).thenReturn(0)
         whenever(partyRepository.findPartyById(1L)).thenReturn(null)
 
-        val ex = assertThrows<BusinessException> { service.startIfNotStarted(1L, startedAt) }
+        val ex =
+            assertThrows<BusinessException> {
+                service.startIfNotStarted(1L, startedAt, RealtimePartyEndingReason.HOST_REQUEST)
+            }
 
         assertEquals(ErrorCode.PARTY_NOT_FOUND, ex.errorCode)
     }
@@ -127,10 +135,13 @@ class RealtimePartyEndServiceTest {
     @Test
     fun `non realtime party throws PARTY_NOT_REALTIME`() {
         val party = PaperOnlyParty(ownerId = 1L, startedAt = startedAt)
-        whenever(partyRepository.startRealtimeEndingIfNotStarted(eq(1L), any())).thenReturn(0)
+        whenever(partyRepository.startRealtimeEndingIfNotStarted(eq(1L), any(), any())).thenReturn(0)
         whenever(partyRepository.findPartyById(1L)).thenReturn(party)
 
-        val ex = assertThrows<BusinessException> { service.startIfNotStarted(1L, startedAt) }
+        val ex =
+            assertThrows<BusinessException> {
+                service.startIfNotStarted(1L, startedAt, RealtimePartyEndingReason.HOST_REQUEST)
+            }
 
         assertEquals(ErrorCode.PARTY_NOT_REALTIME, ex.errorCode)
     }

--- a/src/test/kotlin/com/team2/server/party/application/usecase/MarkRealtimePartyBurstGameEndedUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/party/application/usecase/MarkRealtimePartyBurstGameEndedUseCaseTest.kt
@@ -1,0 +1,21 @@
+package com.team2.server.party.application.usecase
+
+import com.team2.server.party.application.port.RealtimePartyBurstGameEndRecorder
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import java.time.LocalDateTime
+
+class MarkRealtimePartyBurstGameEndedUseCaseTest {
+    private val recorder: RealtimePartyBurstGameEndRecorder = mock()
+    private val useCase = MarkRealtimePartyBurstGameEndedUseCase(recorder)
+
+    @Test
+    fun `박터뜨리기 종료 시각을 최초 한 번 저장한다`() {
+        val endedAt = LocalDateTime.of(2026, 6, 8, 20, 0)
+
+        useCase(partyId = 1L, endedAt = endedAt)
+
+        verify(recorder).recordFirst(partyId = 1L, endedAt = endedAt)
+    }
+}

--- a/src/test/kotlin/com/team2/server/party/application/usecase/StartRealtimePartyEndUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/party/application/usecase/StartRealtimePartyEndUseCaseTest.kt
@@ -106,7 +106,10 @@ class StartRealtimePartyEndUseCaseTest {
     @Test
     fun `LIVE_ENDING with existing ending returns result without publishing duplicate event`() {
         val endingStartedAt = now.minusSeconds(10)
-        val party = realtimeParty(id = 1L, ownerId = 1L, startedAt = now.minusMinutes(10), endingStartedAt)
+        val party =
+            realtimeParty(id = 1L, ownerId = 1L, startedAt = now.minusMinutes(10), endingStartedAt).apply {
+                hostEnteredAt = now.minusMinutes(5)
+            }
         whenever(partyService.requireRealtimeParty(1L)).thenReturn(party)
         whenever(
             realtimePartyEndService.startIfNotStarted(

--- a/src/test/kotlin/com/team2/server/party/application/usecase/StartRealtimePartyEndUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/party/application/usecase/StartRealtimePartyEndUseCaseTest.kt
@@ -12,6 +12,7 @@ import com.team2.server.party.application.service.RealtimePartyEndResultService
 import com.team2.server.party.application.service.RealtimePartyEndService
 import com.team2.server.party.domain.entity.Party
 import com.team2.server.party.domain.entity.RealtimeParty
+import com.team2.server.party.domain.entity.RealtimePartyEndingReason
 import com.team2.server.party.domain.vo.PartyPhase
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -74,12 +75,22 @@ class StartRealtimePartyEndUseCaseTest {
     }
 
     @Test
-    fun `LIVE_OPEN host starts ending and publishes event when newly persisted`() {
+    fun `LIVE_OPEN host before farewell availability starts HOST_LEFT ending`() {
         val endingStartedAt = now
-        val party = realtimeParty(id = 1L, ownerId = 1L, startedAt = now.minusMinutes(1))
-        val endedParty = realtimeParty(id = 1L, ownerId = 1L, startedAt = now.minusMinutes(1), endingStartedAt)
+        val party =
+            realtimeParty(id = 1L, ownerId = 1L, startedAt = now.minusMinutes(1)).apply {
+                hostEnteredAt = now.minusMinutes(1)
+            }
+        val endedParty =
+            realtimeParty(
+                id = 1L,
+                ownerId = 1L,
+                startedAt = now.minusMinutes(1),
+                liveEndingStartedAt = endingStartedAt,
+                liveEndingReason = RealtimePartyEndingReason.HOST_LEFT,
+            )
         whenever(partyService.requireRealtimeParty(1L)).thenReturn(party)
-        whenever(realtimePartyEndService.startIfNotStarted(1L, endingStartedAt))
+        whenever(realtimePartyEndService.startIfNotStarted(1L, endingStartedAt, RealtimePartyEndingReason.HOST_LEFT))
             .thenReturn(RealtimePartyEndStartResult(affected = 1, party = endedParty))
         whenever(endingInfoPort.get(endedParty))
             .thenReturn(RealtimePartyEndingInfo(endedParty.endingReason(), "주최자"))
@@ -87,6 +98,7 @@ class StartRealtimePartyEndUseCaseTest {
         val result = useCase(1L, userId = 1L)
 
         assertEquals(endingStartedAt, result.endingStartedAt)
+        assertEquals(RealtimePartyEndingReason.HOST_LEFT, result.endingReason)
         verify(phaseStore).forceSet(1L, PartyPhase.END, endingStartedAt)
         verify(eventPublisher).publish(result)
     }
@@ -96,15 +108,21 @@ class StartRealtimePartyEndUseCaseTest {
         val endingStartedAt = now.minusSeconds(10)
         val party = realtimeParty(id = 1L, ownerId = 1L, startedAt = now.minusMinutes(10), endingStartedAt)
         whenever(partyService.requireRealtimeParty(1L)).thenReturn(party)
-        whenever(realtimePartyEndService.startIfNotStarted(1L, endingStartedAt))
-            .thenReturn(RealtimePartyEndStartResult(affected = 0, party = party))
+        whenever(
+            realtimePartyEndService.startIfNotStarted(
+                1L,
+                endingStartedAt,
+                RealtimePartyEndingReason.HOST_REQUEST,
+            ),
+        ).thenReturn(RealtimePartyEndStartResult(affected = 0, party = party))
         whenever(endingInfoPort.get(party))
             .thenReturn(RealtimePartyEndingInfo(party.endingReason(), "주최자"))
 
         val result = useCase(1L, userId = 1L)
 
         assertEquals(endingStartedAt, result.endingStartedAt)
-        verify(realtimePartyEndService).startIfNotStarted(1L, endingStartedAt)
+        verify(realtimePartyEndService)
+            .startIfNotStarted(1L, endingStartedAt, RealtimePartyEndingReason.HOST_REQUEST)
         verify(phaseStore).forceSet(1L, PartyPhase.END, endingStartedAt)
         verifyNoInteractions(eventPublisher)
     }
@@ -120,8 +138,13 @@ class StartRealtimePartyEndUseCaseTest {
                 liveEndingStartedAt = party.automaticEndingStartedAt(),
             )
         whenever(partyService.requireRealtimeParty(1L)).thenReturn(party)
-        whenever(realtimePartyEndService.startIfNotStarted(1L, party.automaticEndingStartedAt()))
-            .thenReturn(RealtimePartyEndStartResult(affected = 0, party = endedParty))
+        whenever(
+            realtimePartyEndService.startIfNotStarted(
+                1L,
+                party.automaticEndingStartedAt(),
+                RealtimePartyEndingReason.TIME_LIMIT_REACHED,
+            ),
+        ).thenReturn(RealtimePartyEndStartResult(affected = 0, party = endedParty))
         whenever(endingInfoPort.get(endedParty))
             .thenReturn(RealtimePartyEndingInfo(endedParty.endingReason(), "주최자"))
 
@@ -137,9 +160,14 @@ class StartRealtimePartyEndUseCaseTest {
         ownerId: Long,
         startedAt: LocalDateTime,
         liveEndingStartedAt: LocalDateTime? = null,
+        liveEndingReason: RealtimePartyEndingReason? = null,
     ): RealtimeParty =
-        RealtimeParty(ownerId = ownerId, startedAt = startedAt, liveEndingStartedAt = liveEndingStartedAt)
-            .also { setId(it, id) }
+        RealtimeParty(
+            ownerId = ownerId,
+            startedAt = startedAt,
+            liveEndingStartedAt = liveEndingStartedAt,
+            liveEndingReason = liveEndingReason,
+        ).also { setId(it, id) }
 
     private fun setId(
         party: Party,

--- a/src/test/kotlin/com/team2/server/party/domain/entity/PartyStatusTest.kt
+++ b/src/test/kotlin/com/team2/server/party/domain/entity/PartyStatusTest.kt
@@ -164,6 +164,64 @@ class PartyStatusTest {
     }
 
     @Test
+    fun `RealtimeParty - 주최자 입장 4분 전 수동 종료는 HOST_LEFT`() {
+        val hostEnteredAt = liveStart.plusSeconds(10)
+        val party = realtimeParty().apply { this.hostEnteredAt = hostEnteredAt }
+
+        assertEquals(
+            RealtimePartyEndingReason.HOST_LEFT,
+            party.endingReasonForManualRequest(hostEnteredAt.plusMinutes(4).minusNanos(1)),
+        )
+    }
+
+    @Test
+    fun `RealtimeParty - 주최자 입장 정확히 4분 뒤 수동 종료는 HOST_REQUEST`() {
+        val hostEnteredAt = liveStart.plusSeconds(10)
+        val party = realtimeParty().apply { this.hostEnteredAt = hostEnteredAt }
+
+        assertEquals(
+            RealtimePartyEndingReason.HOST_REQUEST,
+            party.endingReasonForManualRequest(hostEnteredAt.plusMinutes(4)),
+        )
+    }
+
+    @Test
+    fun `RealtimeParty - 정확히 10분 시점 수동 종료는 TIME_LIMIT_REACHED`() {
+        val party = realtimeParty().apply { hostEnteredAt = liveStart }
+
+        assertEquals(
+            RealtimePartyEndingReason.TIME_LIMIT_REACHED,
+            party.endingReasonForManualRequest(party.automaticEndingStartedAt()),
+        )
+    }
+
+    @Test
+    fun `RealtimeParty - 주최자 입장 4분 전이어도 박터뜨리기가 끝났으면 HOST_REQUEST`() {
+        val hostEnteredAt = liveStart
+        val requestAt = hostEnteredAt.plusMinutes(2)
+        val party =
+            realtimeParty().apply {
+                this.hostEnteredAt = hostEnteredAt
+                burstGameEndedAt = requestAt.minusNanos(1)
+            }
+
+        assertEquals(RealtimePartyEndingReason.HOST_REQUEST, party.endingReasonForManualRequest(requestAt))
+    }
+
+    @Test
+    fun `RealtimeParty - 종료 카운트다운 중에는 종료 인사하기를 사용할 수 없다`() {
+        val endingStartedAt = liveStart.plusMinutes(5)
+        val party =
+            realtimeParty().apply {
+                hostEnteredAt = liveStart
+                liveEndingStartedAt = endingStartedAt
+                liveEndingReason = RealtimePartyEndingReason.HOST_REQUEST
+            }
+
+        assertEquals(false, party.isHostFarewellAvailable(endingStartedAt))
+    }
+
+    @Test
     fun `RealtimeParty - Party 종료가 LIVE_CLOSED보다 우선한다`() {
         val now = liveStart.plusDays(7)
         val party = realtimeParty().apply { liveEndingStartedAt = now.minusSeconds(60) }

--- a/src/test/kotlin/com/team2/server/party/infrastructure/event/RealtimePartyBurstGameEndedListenerTest.kt
+++ b/src/test/kotlin/com/team2/server/party/infrastructure/event/RealtimePartyBurstGameEndedListenerTest.kt
@@ -1,0 +1,22 @@
+package com.team2.server.party.infrastructure.event
+
+import com.team2.server.party.application.event.RealtimePartyBurstGameEndedEvent
+import com.team2.server.party.application.usecase.MarkRealtimePartyBurstGameEndedUseCase
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import java.time.LocalDateTime
+
+class RealtimePartyBurstGameEndedListenerTest {
+    private val useCase: MarkRealtimePartyBurstGameEndedUseCase = mock()
+    private val listener = RealtimePartyBurstGameEndedListener(useCase)
+
+    @Test
+    fun `박터뜨리기 종료 이벤트를 영속화한다`() {
+        val event = RealtimePartyBurstGameEndedEvent(1L, LocalDateTime.of(2026, 6, 8, 20, 0))
+
+        listener.onBurstGameEnded(event)
+
+        verify(useCase).invoke(event.partyId, event.endedAt)
+    }
+}

--- a/src/test/kotlin/com/team2/server/party/infrastructure/persistence/PartyRepositoryTest.kt
+++ b/src/test/kotlin/com/team2/server/party/infrastructure/persistence/PartyRepositoryTest.kt
@@ -35,6 +35,25 @@ class PartyRepositoryTest
         }
 
         @Test
+        fun `startAutomaticRealtimeEndings는 전달받은 종료 사유를 저장한다`() {
+            val party = partyRepository.save(realtimeParty(startedAt = BASE_TIME.minusMinutes(10)))
+
+            val updated =
+                partyRepository.startAutomaticRealtimeEndings(
+                    now = BASE_TIME,
+                    liveDurationMinutes = 10,
+                    partyEndedAfterDays = 7,
+                    endingReason = RealtimePartyEndingReason.TIME_LIMIT_REACHED.name,
+                )
+            entityManager.clear()
+
+            val found = partyRepository.findById(party.id).orElseThrow() as RealtimeParty
+            assertEquals(1, updated)
+            assertEquals(BASE_TIME, found.liveEndingStartedAt)
+            assertEquals(RealtimePartyEndingReason.TIME_LIMIT_REACHED, found.liveEndingReason)
+        }
+
+        @Test
         fun `markBurstGameEndedIfAbsent는 최초 박터뜨리기 종료 시각만 저장한다`() {
             val party = partyRepository.save(realtimeParty(startedAt = BASE_TIME.minusMinutes(1)))
             val firstEndedAt = BASE_TIME

--- a/src/test/kotlin/com/team2/server/party/infrastructure/persistence/PartyRepositoryTest.kt
+++ b/src/test/kotlin/com/team2/server/party/infrastructure/persistence/PartyRepositoryTest.kt
@@ -1,6 +1,7 @@
 package com.team2.server.party.infrastructure.persistence
 
 import com.team2.server.party.domain.entity.RealtimeParty
+import com.team2.server.party.domain.entity.RealtimePartyEndingReason
 import com.team2.server.support.JpaSliceTestSupport
 import jakarta.persistence.EntityManager
 import org.junit.jupiter.api.Test
@@ -14,6 +15,42 @@ class PartyRepositoryTest
         private val partyRepository: PartyRepository,
         private val entityManager: EntityManager,
     ) : JpaSliceTestSupport() {
+        @Test
+        fun `startRealtimeEndingIfNotStarted는 종료 시각과 사유를 함께 저장한다`() {
+            val party = partyRepository.save(realtimeParty(startedAt = BASE_TIME.minusMinutes(1)))
+
+            val updated =
+                partyRepository.startRealtimeEndingIfNotStarted(
+                    party.id,
+                    BASE_TIME,
+                    RealtimePartyEndingReason.HOST_LEFT,
+                )
+            entityManager.flush()
+            entityManager.clear()
+
+            val found = partyRepository.findById(party.id).orElseThrow() as RealtimeParty
+            assertEquals(1, updated)
+            assertEquals(BASE_TIME, found.liveEndingStartedAt)
+            assertEquals(RealtimePartyEndingReason.HOST_LEFT, found.liveEndingReason)
+        }
+
+        @Test
+        fun `markBurstGameEndedIfAbsent는 최초 박터뜨리기 종료 시각만 저장한다`() {
+            val party = partyRepository.save(realtimeParty(startedAt = BASE_TIME.minusMinutes(1)))
+            val firstEndedAt = BASE_TIME
+            val secondEndedAt = BASE_TIME.plusSeconds(1)
+
+            val firstUpdated = partyRepository.markBurstGameEndedIfAbsent(party.id, firstEndedAt)
+            val secondUpdated = partyRepository.markBurstGameEndedIfAbsent(party.id, secondEndedAt)
+            entityManager.flush()
+            entityManager.clear()
+
+            val found = partyRepository.findById(party.id).orElseThrow() as RealtimeParty
+            assertEquals(1, firstUpdated)
+            assertEquals(0, secondUpdated)
+            assertEquals(firstEndedAt, found.burstGameEndedAt)
+        }
+
         @Test
         fun `markHostEnteredIfAbsent는 hostEnteredAt을 한 번만 저장한다`() {
             val party = partyRepository.save(realtimeParty(startedAt = BASE_TIME.minusMinutes(1)))


### PR DESCRIPTION
## 🔗 Issue
- closes #218

## 💬 Context
주최자는 실시간 파티를 언제든 종료할 수 있지만, 종료 시점이 주최자 최초 입장 후 4분 이후이거나 박터뜨리기 종료 후인지에 따라 종료 사유를 구분해야 합니다. 또한 프론트가 종료 인사하기 버튼 상태를 복구할 수 있도록 상태 조회 계약을 확장합니다.

## 🛠 Changes
- 수동 종료 사유를 `HOST_REQUEST`, `HOST_LEFT`, `TIME_LIMIT_REACHED` 우선순위로 판정
- `live_ending_reason`, `burst_game_ended_at` 영속화 및 Flyway 백필 마이그레이션 추가
- 박터뜨리기 종료 이벤트 발생 시 최초 종료 시각 저장
- `realtime-state`, `party-state`에 `hostFarewellAvailable`, `hostFarewellAvailableAt`, `serverNow` 제공
- 종료 사유 경계 조건, 영속화, API 상태 복구, Flyway 마이그레이션 테스트 추가

## 👀 Review Focus
- 수동 종료 요청 시 `TIME_LIMIT_REACHED` → `HOST_REQUEST` → `HOST_LEFT` 판정 우선순위
- 종료 시작 시각과 종료 사유의 원자적 저장 및 박터뜨리기 최초 종료 시각 저장
- 프론트 타이머 복구용 `hostFarewellAvailableAt`, `serverNow` 응답 계약

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 호스트의 "종료 인사하기" 상태 및 호스트 종료 가능 시각 표시 추가
  * 실시간 상태 응답에 서버 기준 시각(serverNow) 및 관련 필드 포함

* **Bug Fixes / Behavior Changes**
  * 종료 사유에 HOST_LEFT 추가하고 카운트다운 화면에서 사유 구분 표시
  * 버스트(박터뜨리기) 최초 종료 시각을 한 번만 저장하도록 보장
  * 종료 시작 시각과 사유를 원자적으로 저장하도록 변경

* **Chores**
  * 기존 종료 사유 백필 규칙 정리(HOST_LEFT는 백필하지 않음)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->