### PR TITLE
[Feat] 보관함 응답에 조회자 역할 추가 및 파티명 필드 제거

### DIFF
--- a/src/main/kotlin/com/team2/server/party/api/ArchivePartyDetailController.kt
+++ b/src/main/kotlin/com/team2/server/party/api/ArchivePartyDetailController.kt
@@ -30,7 +30,7 @@ class ArchivePartyDetailController(
     private fun ArchivePartyDetailResult.toResponse(): ArchivePartyDetailResponse =
         ArchivePartyDetailResponse(
             partyId = partyId,
-            partyName = partyName,
+            celebrantNickname = celebrantNickname,
             partyOption = partyOption,
             role = role,
             partyStartedAt = partyStartedAt,

--- a/src/main/kotlin/com/team2/server/party/api/dto/ArchiveListItemResponse.kt
+++ b/src/main/kotlin/com/team2/server/party/api/dto/ArchiveListItemResponse.kt
@@ -1,6 +1,7 @@
 package com.team2.server.party.api.dto
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.team2.server.party.application.dto.ArchiveRole
 import com.team2.server.party.domain.entity.Participant
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.OffsetDateTime
@@ -15,8 +16,8 @@ data class ArchiveListItemResponse(
     val partyId: Long,
     @Schema(description = "항목 타입", allowableValues = ["PARTY", "PAPER"], example = "PARTY")
     val type: ArchiveItemType,
-    @Schema(description = "파티 이름. 없으면 빈 문자열", example = "김루카 생일 파티")
-    val title: String,
+    @Schema(description = "조회자 역할", allowableValues = ["HOST", "PARTICIPANT"], example = "HOST")
+    val role: ArchiveRole,
     @Schema(description = "파티 주인공 닉네임. 없으면 null", example = "김루카", nullable = true)
     val celebrantName: String?,
     @Schema(description = "파티 종료 시각 (KST 오프셋)", example = "2026-05-12T22:10:00+09:00")
@@ -25,13 +26,16 @@ data class ArchiveListItemResponse(
     companion object {
         private val KST: ZoneOffset = ZoneOffset.ofHours(9)
 
-        fun from(participant: Participant): ArchiveListItemResponse {
+        fun from(
+            participant: Participant,
+            userId: Long,
+        ): ArchiveListItemResponse {
             val party = participant.party
             return ArchiveListItemResponse(
                 id = participant.id.toString(),
                 partyId = party.id,
                 type = ArchiveItemType.from(party.partyOption),
-                title = party.name ?: "",
+                role = if (party.ownerId == userId) ArchiveRole.HOST else ArchiveRole.PARTICIPANT,
                 celebrantName = party.celebrantNickname,
                 date = party.endedAt().atOffset(KST),
             )

--- a/src/main/kotlin/com/team2/server/party/api/dto/ArchivePartyDetailResponse.kt
+++ b/src/main/kotlin/com/team2/server/party/api/dto/ArchivePartyDetailResponse.kt
@@ -9,8 +9,8 @@ import java.time.LocalDateTime
 data class ArchivePartyDetailResponse(
     @Schema(description = "파티 ID")
     val partyId: Long,
-    @Schema(description = "파티 이름. Party.name이 null이면 빈 문자열")
-    val partyName: String,
+    @Schema(description = "파티 주인공 닉네임. 없으면 null", nullable = true)
+    val celebrantNickname: String?,
     @Schema(description = "REALTIME 또는 PAPER_ONLY")
     val partyOption: PartyOption,
     @Schema(description = "조회자 역할")

--- a/src/main/kotlin/com/team2/server/party/application/dto/ArchivePartyDetailResult.kt
+++ b/src/main/kotlin/com/team2/server/party/application/dto/ArchivePartyDetailResult.kt
@@ -6,7 +6,7 @@ import java.time.LocalDateTime
 
 data class ArchivePartyDetailResult(
     val partyId: Long,
-    val partyName: String,
+    val celebrantNickname: String?,
     val partyOption: PartyOption,
     val role: ArchiveRole,
     val partyStartedAt: LocalDateTime,

--- a/src/main/kotlin/com/team2/server/party/application/usecase/GetArchivedPartyDetailUseCase.kt
+++ b/src/main/kotlin/com/team2/server/party/application/usecase/GetArchivedPartyDetailUseCase.kt
@@ -38,7 +38,7 @@ class GetArchivedPartyDetailUseCase(
         val chat = if (isRealtime) getArchiveChatSectionUseCase.invoke(party.id) else null
         return ArchivePartyDetailResult(
             partyId = party.id,
-            partyName = party.name.orEmpty(),
+            celebrantNickname = party.celebrantNickname,
             partyOption = party.partyOption,
             role = if (party.ownerId == userId) ArchiveRole.HOST else ArchiveRole.PARTICIPANT,
             partyStartedAt = party.startedAt,

--- a/src/main/kotlin/com/team2/server/party/application/usecase/GetMyArchiveUseCase.kt
+++ b/src/main/kotlin/com/team2/server/party/application/usecase/GetMyArchiveUseCase.kt
@@ -27,7 +27,7 @@ class GetMyArchiveUseCase(
             )
         val hasNext = rows.size > size
         val pageItems = rows.take(size)
-        val items = pageItems.map(ArchiveListItemResponse::from)
+        val items = pageItems.map { ArchiveListItemResponse.from(it, userId) }
         val nextCursor = if (hasNext) pageItems.last().id.toString() else null
         val totalCount = participantRepository.countArchiveByUserId(userId)
 

--- a/src/test/kotlin/com/team2/server/party/api/ArchiveControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/party/api/ArchiveControllerTest.kt
@@ -99,7 +99,7 @@ class ArchiveControllerTest
                     jsonPath("$.data.items[0].id") { value(participant.id.toString()) }
                     jsonPath("$.data.items[0].partyId") { value(party.id) }
                     jsonPath("$.data.items[0].type") { value("PARTY") }
-                    jsonPath("$.data.items[0].title") { value("김루카 생일 파티") }
+                    jsonPath("$.data.items[0].role") { value("HOST") }
                     jsonPath("$.data.items[0].celebrantName") { value("김루카") }
                     jsonPath("$.data.items[0].date") {
                         value(
@@ -136,32 +136,6 @@ class ArchiveControllerTest
                 }.andExpect {
                     status { isOk() }
                     jsonPath("$.data.items[0].type") { value("PAPER") }
-                }
-        }
-
-        @Test
-        fun `party name이 null이면 title은 빈 문자열로 응답한다`() {
-            val user = saveUser("kakao-archive-noname", "archive-noname@kakao.local")
-            val token = tokenProvider.issue(user)
-            val now = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS)
-            val party =
-                saveParty(
-                    RealtimeParty(
-                        ownerId = user.id,
-                        name = null,
-                        celebrantNickname = "이름없음",
-                        startedAt = now.plusHours(2),
-                    ),
-                    now.minusHours(1),
-                )
-            saveParticipant(party, user, now.minusHours(1))
-
-            mockMvc
-                .get("/api/v1/archive") {
-                    header("Authorization", "Bearer $token")
-                }.andExpect {
-                    status { isOk() }
-                    jsonPath("$.data.items[0].title") { value("") }
                 }
         }
 
@@ -215,9 +189,12 @@ class ArchiveControllerTest
                 }.andExpect {
                     status { isOk() }
                     jsonPath("$.data.items.length()") { value(3) }
-                    jsonPath("$.data.items[0].title") { value("친구 라이브") }
-                    jsonPath("$.data.items[1].title") { value("친구 파티") }
-                    jsonPath("$.data.items[2].title") { value("내 파티") }
+                    jsonPath("$.data.items[0].celebrantName") { value("친구2") }
+                    jsonPath("$.data.items[0].role") { value("PARTICIPANT") }
+                    jsonPath("$.data.items[1].celebrantName") { value("친구") }
+                    jsonPath("$.data.items[1].role") { value("PARTICIPANT") }
+                    jsonPath("$.data.items[2].celebrantName") { value("본인") }
+                    jsonPath("$.data.items[2].role") { value("HOST") }
                     jsonPath("$.data.totalCount") { value(3) }
                     jsonPath("$.data.nextCursor") { value(nullValue()) }
                 }

--- a/src/test/kotlin/com/team2/server/party/api/ArchivePartyDetailControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/party/api/ArchivePartyDetailControllerTest.kt
@@ -89,7 +89,7 @@ class ArchivePartyDetailControllerTest
                 }.andExpect {
                     status { isOk() }
                     jsonPath("$.data.partyId") { value(party.id) }
-                    jsonPath("$.data.partyName") { value("김유빈의 파티") }
+                    jsonPath("$.data.celebrantNickname") { value("김유빈") }
                     jsonPath("$.data.partyOption") { value("REALTIME") }
                     jsonPath("$.data.role") { value("PARTICIPANT") }
                     jsonPath("$.data.participantCount") { value(2) }


### PR DESCRIPTION
## 🔗 Issue
- closes #220

## 💬 Context
보관함 API 응답을 프론트 요구사항에 맞게 정비합니다.
- 리스트(`GET /api/v1/archive`)의 `title`과 상세(`GET /api/v1/archive/party/{partyId}`)의 `partyName`은 `party.name`을 노출하는데, 파티 생성 요청에 `name`이 없어 **항상 빈 값**으로 내려가고 있었습니다.
- 프론트는 주인공 닉네임으로 `"{주인공}의 파티"` 형태를 조합하므로, 빈 파티명 필드를 제거하고 상세에도 주인공 닉네임을 추가합니다.

## 🛠 Changes
- `GET /api/v1/archive` 리스트 항목에 `role: "HOST" | "PARTICIPANT"` 추가 (상세조회와 동일하게 `party.ownerId == userId` 기준)
- 리스트 응답에서 항상 빈 문자열이던 `title` 필드 제거
- `GET /api/v1/archive/party/{partyId}` 상세 응답에 `celebrantNickname: String?` 추가
- 상세 응답에서 항상 빈 문자열이던 `partyName` 필드 제거
- 두 컨트롤러 테스트 갱신 (role/celebrantName 단언 추가, 정렬 검증을 celebrantName 기준으로 전환)

## 👀 Review Focus
- ⚠️ `title`/`partyName` 제거는 **응답 필드 삭제(breaking change)** 입니다. 프론트 배포 타이밍과 맞춰야 합니다. (필드를 남기고 항상 `""`로 두는 대안도 가능)
- `role` 판정 기준이 상세조회(`GetArchivedPartyDetailUseCase`)와 일관적인지

## ✅ Check List
- [ ] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인 (로컬 ktlintCheck + build green, 컨테이너 누수 0)