### PR TITLE
[Feat] 박터뜨리기 랭킹 프로필 이미지를 캐릭터 썸네일로 변경

### DIFF
--- a/docs/superpowers/specs/2026-05-14-realtime-burst-game-design.md
+++ b/docs/superpowers/specs/2026-05-14-realtime-burst-game-design.md
@@ -214,7 +214,7 @@ X-Participant-Token: {participantToken}
       "participantId": 37,
       "nickname": "토끼왕",
       "characterId": 2,
-      "characterImageUrl": "https://example.com/rabbit.png",
+      "characterThumbnailImageUrl": "https://example.com/rabbit.png",
       "role": "CELEBRANT",
       "tapCount": 11
     },
@@ -223,7 +223,7 @@ X-Participant-Token: {participantToken}
       "participantId": 38,
       "nickname": "곰돌이",
       "characterId": 1,
-      "characterImageUrl": "https://example.com/bear.png",
+      "characterThumbnailImageUrl": "https://example.com/bear.png",
       "role": "PARTICIPANT",
       "tapCount": 9
     },
@@ -232,7 +232,7 @@ X-Participant-Token: {participantToken}
       "participantId": 39,
       "nickname": "고양이",
       "characterId": 3,
-      "characterImageUrl": "https://example.com/cat.png",
+      "characterThumbnailImageUrl": "https://example.com/cat.png",
       "role": "PARTICIPANT",
       "tapCount": 8
     }
@@ -318,7 +318,7 @@ SSE 재연결, `burst-game-started` 이벤트 유실, 카운트다운 복구, �
       "participantId": 37,
       "nickname": "토끼왕",
       "characterId": 2,
-      "characterImageUrl": "https://example.com/rabbit.png",
+      "characterThumbnailImageUrl": "https://example.com/rabbit.png",
       "role": "CELEBRANT",
       "tapCount": 52
     },
@@ -327,7 +327,7 @@ SSE 재연결, `burst-game-started` 이벤트 유실, 카운트다운 복구, �
       "participantId": 38,
       "nickname": "곰돌이",
       "characterId": 1,
-      "characterImageUrl": "https://example.com/bear.png",
+      "characterThumbnailImageUrl": "https://example.com/bear.png",
       "role": "PARTICIPANT",
       "tapCount": 44
     },
@@ -336,7 +336,7 @@ SSE 재연결, `burst-game-started` 이벤트 유실, 카운트다운 복구, �
       "participantId": 39,
       "nickname": "고양이",
       "characterId": 3,
-      "characterImageUrl": "https://example.com/cat.png",
+      "characterThumbnailImageUrl": "https://example.com/cat.png",
       "role": "PARTICIPANT",
       "tapCount": 41
     }
@@ -413,7 +413,7 @@ tap batch 반영 후 해당 파티의 기존 SSE 구독자에게 전송한다.
       "participantId": 37,
       "nickname": "토끼왕",
       "characterId": 2,
-      "characterImageUrl": "https://example.com/rabbit.png",
+      "characterThumbnailImageUrl": "https://example.com/rabbit.png",
       "role": "CELEBRANT",
       "tapCount": 11
     },
@@ -422,7 +422,7 @@ tap batch 반영 후 해당 파티의 기존 SSE 구독자에게 전송한다.
       "participantId": 38,
       "nickname": "곰돌이",
       "characterId": 1,
-      "characterImageUrl": "https://example.com/bear.png",
+      "characterThumbnailImageUrl": "https://example.com/bear.png",
       "role": "PARTICIPANT",
       "tapCount": 9
     },
@@ -431,7 +431,7 @@ tap batch 반영 후 해당 파티의 기존 SSE 구독자에게 전송한다.
       "participantId": 39,
       "nickname": "고양이",
       "characterId": 3,
-      "characterImageUrl": "https://example.com/cat.png",
+      "characterThumbnailImageUrl": "https://example.com/cat.png",
       "role": "PARTICIPANT",
       "tapCount": 8
     }
@@ -472,7 +472,7 @@ tap batch 반영 후 해당 파티의 기존 SSE 구독자에게 전송한다.
       "participantId": 37,
       "nickname": "토끼왕",
       "characterId": 2,
-      "characterImageUrl": "https://example.com/rabbit.png",
+      "characterThumbnailImageUrl": "https://example.com/rabbit.png",
       "role": "CELEBRANT",
       "tapCount": 52
     },
@@ -481,7 +481,7 @@ tap batch 반영 후 해당 파티의 기존 SSE 구독자에게 전송한다.
       "participantId": 38,
       "nickname": "곰돌이",
       "characterId": 1,
-      "characterImageUrl": "https://example.com/bear.png",
+      "characterThumbnailImageUrl": "https://example.com/bear.png",
       "role": "PARTICIPANT",
       "tapCount": 52
     },
@@ -490,7 +490,7 @@ tap batch 반영 후 해당 파티의 기존 SSE 구독자에게 전송한다.
       "participantId": 39,
       "nickname": "고양이",
       "characterId": 3,
-      "characterImageUrl": "https://example.com/cat.png",
+      "characterThumbnailImageUrl": "https://example.com/cat.png",
       "role": "PARTICIPANT",
       "tapCount": 33
     }
@@ -539,7 +539,7 @@ batch 단위 전송 구조에서는 "특정 tap 수에 정확히 먼저 도달�
 | `participantId` | 랭킹 표시용 공개 식별자. 인증 수단인 `participantToken`은 전체 SSE에 노출하지 않는다 |
 | `nickname` | 실시간 프로필 닉네임 |
 | `characterId` | 선택 캐릭터 |
-| `characterImageUrl` | 캐릭터 이미지 URL |
+| `characterThumbnailImageUrl` | 캐릭터 썸네일 이미지 URL |
 | `role` | `CELEBRANT` 또는 `PARTICIPANT` |
 | `tapCount` | 참가자 누적 터치 수 |
 
@@ -560,7 +560,7 @@ batch 단위 전송 구조에서는 "특정 tap 수에 정확히 먼저 도달�
 | `participantId` | participant id |
 | `nickname` | 닉네임 |
 | `characterId` | 선택 캐릭터 |
-| `characterImageUrl` | 캐릭터 이미지 URL |
+| `characterThumbnailImageUrl` | 캐릭터 썸네일 이미지 URL |
 | `role` | 역할 |
 | `tapCount` | 누적 터치 수 |
 

--- a/src/main/kotlin/com/team2/server/burstgame/application/dto/BurstGameRankingResponse.kt
+++ b/src/main/kotlin/com/team2/server/burstgame/application/dto/BurstGameRankingResponse.kt
@@ -12,8 +12,8 @@ data class BurstGameRankingResponse(
     val nickname: String,
     @Schema(description = "선택한 캐릭터 ID입니다.", example = "2", nullable = true)
     val characterId: Long?,
-    @Schema(description = "선택한 캐릭터 이미지 URL입니다.", example = "https://example.com/rabbit.png", nullable = true)
-    val characterImageUrl: String?,
+    @Schema(description = "선택한 캐릭터 썸네일 이미지 URL입니다.", example = "https://example.com/rabbit.png", nullable = true)
+    val characterThumbnailImageUrl: String?,
     @Schema(description = "실시간 파티 참여자 역할입니다.", example = "CELEBRANT", allowableValues = ["CELEBRANT", "PARTICIPANT"])
     val role: String,
     @Schema(description = "해당 참여자의 현재 라운드 누적 터치 수입니다.", example = "11")
@@ -26,7 +26,7 @@ data class BurstGameRankingResponse(
                 participantId = entry.participantId,
                 nickname = entry.nickname,
                 characterId = entry.characterId,
-                characterImageUrl = entry.characterImageUrl,
+                characterThumbnailImageUrl = entry.characterThumbnailImageUrl,
                 role = entry.role,
                 tapCount = entry.tapCount,
             )

--- a/src/main/kotlin/com/team2/server/burstgame/application/support/BurstGameParticipantResolver.kt
+++ b/src/main/kotlin/com/team2/server/burstgame/application/support/BurstGameParticipantResolver.kt
@@ -29,9 +29,13 @@ class BurstGameParticipantResolver(
         val party = resolveLiveOpenRealtimePartyUseCase.invoke(partyId)
         val profile = resolveRealtimeParticipantProfileUseCase.invoke(partyId, userId, participantToken)
         val characterId = profile.character?.id
-        val imageUrl =
+        val thumbnailImageUrl =
             characterId?.let {
-                imageUrlReader.findFirstImageUrlByTargetIds(ImageTargetType.CHARACTER, listOf(it))[it]
+                imageUrlReader.findImageUrlByTargetIdsAndSortOrder(
+                    ImageTargetType.CHARACTER,
+                    listOf(it),
+                    CHARACTER_THUMBNAIL_SORT_ORDER,
+                )[it]
             }
         return ResolvedRealtimeParticipant(
             party = party,
@@ -40,7 +44,7 @@ class BurstGameParticipantResolver(
                     participantId = profile.participant.id,
                     nickname = profile.nickname,
                     characterId = characterId,
-                    characterImageUrl = imageUrl,
+                    characterThumbnailImageUrl = thumbnailImageUrl,
                     role =
                         if (profile.participant.isCelebrant) {
                             ParticipantRole.CELEBRANT.name
@@ -49,6 +53,10 @@ class BurstGameParticipantResolver(
                         },
                 ),
         )
+    }
+
+    private companion object {
+        const val CHARACTER_THUMBNAIL_SORT_ORDER = 1
     }
 
     data class ResolvedRealtimeParticipant(

--- a/src/main/kotlin/com/team2/server/burstgame/domain/BurstGameParticipantInfo.kt
+++ b/src/main/kotlin/com/team2/server/burstgame/domain/BurstGameParticipantInfo.kt
@@ -4,6 +4,6 @@ data class BurstGameParticipantInfo(
     val participantId: Long,
     val nickname: String,
     val characterId: Long?,
-    val characterImageUrl: String?,
+    val characterThumbnailImageUrl: String?,
     val role: String,
 )

--- a/src/main/kotlin/com/team2/server/burstgame/domain/BurstGameRankingEntry.kt
+++ b/src/main/kotlin/com/team2/server/burstgame/domain/BurstGameRankingEntry.kt
@@ -5,7 +5,7 @@ data class BurstGameRankingEntry(
     val participantId: Long,
     val nickname: String,
     val characterId: Long?,
-    val characterImageUrl: String?,
+    val characterThumbnailImageUrl: String?,
     val role: String,
     val tapCount: Int,
 )

--- a/src/main/kotlin/com/team2/server/burstgame/domain/policy/BurstGameRankingPolicy.kt
+++ b/src/main/kotlin/com/team2/server/burstgame/domain/policy/BurstGameRankingPolicy.kt
@@ -39,7 +39,7 @@ object BurstGameRankingPolicy {
             participantId = score.participant.participantId,
             nickname = score.participant.nickname,
             characterId = score.participant.characterId,
-            characterImageUrl = score.participant.characterImageUrl,
+            characterThumbnailImageUrl = score.participant.characterThumbnailImageUrl,
             role = score.participant.role,
             tapCount = score.tapCount,
         )

--- a/src/main/kotlin/com/team2/server/burstgame/infrastructure/realtime/SseBurstGameEventBroadcaster.kt
+++ b/src/main/kotlin/com/team2/server/burstgame/infrastructure/realtime/SseBurstGameEventBroadcaster.kt
@@ -198,7 +198,7 @@ class SseBurstGameEventBroadcaster(
         val participantId: Long,
         val nickname: String,
         val characterId: Long?,
-        val characterImageUrl: String?,
+        val characterThumbnailImageUrl: String?,
         val role: String,
         val tapCount: Int,
     ) {
@@ -209,7 +209,7 @@ class SseBurstGameEventBroadcaster(
                     participantId = entry.participantId,
                     nickname = entry.nickname,
                     characterId = entry.characterId,
-                    characterImageUrl = entry.characterImageUrl,
+                    characterThumbnailImageUrl = entry.characterThumbnailImageUrl,
                     role = entry.role,
                     tapCount = entry.tapCount,
                 )

--- a/src/test/kotlin/com/team2/server/burstgame/application/service/BurstGameSessionServiceTest.kt
+++ b/src/test/kotlin/com/team2/server/burstgame/application/service/BurstGameSessionServiceTest.kt
@@ -306,7 +306,7 @@ class BurstGameSessionServiceTest {
             participantId = participantId,
             nickname = "p$participantId",
             characterId = null,
-            characterImageUrl = null,
+            characterThumbnailImageUrl = null,
             role = "PARTICIPANT",
         )
 

--- a/src/test/kotlin/com/team2/server/burstgame/application/usecase/GetCandleBlowStateUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/burstgame/application/usecase/GetCandleBlowStateUseCaseTest.kt
@@ -83,7 +83,7 @@ class GetCandleBlowStateUseCaseTest {
                     participantId = 10L,
                     nickname = "player",
                     characterId = null,
-                    characterImageUrl = null,
+                    characterThumbnailImageUrl = null,
                     role = "PARTICIPANT",
                 ),
         )

--- a/src/test/kotlin/com/team2/server/burstgame/application/usecase/StartBurstGameUseCaseTest.kt
+++ b/src/test/kotlin/com/team2/server/burstgame/application/usecase/StartBurstGameUseCaseTest.kt
@@ -96,7 +96,7 @@ class StartBurstGameUseCaseTest {
             participantId = participantId,
             nickname = "player",
             characterId = null,
-            characterImageUrl = null,
+            characterThumbnailImageUrl = null,
             role = "PARTICIPANT",
         )
 

--- a/src/test/kotlin/com/team2/server/burstgame/domain/BurstGameSessionTest.kt
+++ b/src/test/kotlin/com/team2/server/burstgame/domain/BurstGameSessionTest.kt
@@ -198,7 +198,7 @@ class BurstGameSessionTest {
             participantId = participantId,
             nickname = "p$participantId",
             characterId = null,
-            characterImageUrl = null,
+            characterThumbnailImageUrl = null,
             role = "PARTICIPANT",
         )
 }

--- a/src/test/kotlin/com/team2/server/burstgame/domain/policy/BurstGameRankingPolicyTest.kt
+++ b/src/test/kotlin/com/team2/server/burstgame/domain/policy/BurstGameRankingPolicyTest.kt
@@ -74,7 +74,7 @@ class BurstGameRankingPolicyTest {
                     participantId = participantId,
                     nickname = "p$participantId",
                     characterId = null,
-                    characterImageUrl = null,
+                    characterThumbnailImageUrl = null,
                     role = "PARTICIPANT",
                 ),
             tapCount = tapCount,

--- a/src/test/kotlin/com/team2/server/burstgame/infrastructure/realtime/SseBurstGameEventBroadcasterTest.kt
+++ b/src/test/kotlin/com/team2/server/burstgame/infrastructure/realtime/SseBurstGameEventBroadcasterTest.kt
@@ -128,7 +128,7 @@ class SseBurstGameEventBroadcasterTest {
                         participantId = 10L,
                         nickname = "player",
                         characterId = null,
-                        characterImageUrl = null,
+                        characterThumbnailImageUrl = null,
                         role = "PARTICIPANT",
                         tapCount = totalTapCount,
                     ),


### PR DESCRIPTION
## 🔗 Issue
- closes #225

## 💬 Context
박터뜨리기 실시간 3위 랭킹과 최종 전체 랭킹에서 캐릭터 원본 이미지(`sortOrder=0`)를 내려주고 있었는데, 썸네일 이미지(`sortOrder=1`)로 변경합니다.

## 🛠 Changes
- `BurstGameParticipantInfo`, `BurstGameRankingEntry` 도메인 모델 필드명 `characterImageUrl` → `characterThumbnailImageUrl` 변경
- `BurstGameParticipantResolver`에서 `findFirstImageUrlByTargetIds` → `findImageUrlByTargetIdsAndSortOrder(sortOrder=1)` 로 썸네일 조회
- `BurstGameRankingResponse` DTO, `SseBurstGameEventBroadcaster` SSE 페이로드 필드 반영
- 테스트 코드 6개 파일 + 버스트 게임 설계 문서 필드명 반영

## 👀 Review Focus
- `BurstGameParticipantResolver`의 이미지 조회 로직 변경이 기존 동작에 영향 없는지 확인
- API 응답 필드명 변경(`characterImageUrl` → `characterThumbnailImageUrl`)으로 클라이언트 영향 확인 필요

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [ ] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **개선사항**
  * 게임 중 실시간 순위 표시에 캐릭터 썸네일 이미지 적용
  * 게임 종료 후 최종 순위 화면에 캐릭터 썸네일 이미지 표시
  * 모든 순위 관련 알림에서 캐릭터 썸네일 이미지 일관 제공

* **문서화**
  * 버스트 게임 설계 명세서 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->