### PR TITLE
[Feat] 실시간 파티 온라인 참여자 목록 조회

### DIFF
--- a/docs/superpowers/specs/2026-05-14-party-participants-list-design.md
+++ b/docs/superpowers/specs/2026-05-14-party-participants-list-design.md
@@ -7,7 +7,7 @@
 
 ## 1. 배경 / 목표
 
-실시간 파티 시작 전에 입장한 참가자를 모아 보여주는 "파티 진행 기본화면"을 그리기 위한 서버 API. 클라이언트는 응답을 받아 다음을 수행한다.
+실시간 파티 시작 전에 현재 접속 중인 참가자를 모아 보여주는 "파티 진행 기본화면"을 그리기 위한 서버 API. 클라이언트는 응답을 받아 다음을 수행한다.
 
 - 입장 순서대로 1~13번 캐릭터 위치 고정 배치
 - 주최자 화면: 본인 외 가장 먼저 입장한 참가자를 상단 큰 캐릭터로 배치
@@ -15,6 +15,15 @@
 - 주최자(모자쓴 캐릭터)는 하단 고정
 
 서버는 정렬된 참가자 목록과 식별 정보를 반환하고, UI 배치는 클라이언트가 결정한다.
+
+### 온라인 참여자 기준
+
+- 온라인 참여자는 현재 SSE 연결이 존재하는 참가자다.
+- 주최자도 일반 참가자와 동일하게 SSE 연결이 존재할 때만 온라인 참여자다.
+- SSE 연결이 완료·타임아웃·오류·명시적 퇴장으로 종료되면 즉시 온라인 참여자에서 제외한다.
+- 즉시는 서버가 연결 종료를 감지한 시점을 의미한다. 별도 heartbeat가 없으면 네트워크 단절 감지는 다음 SSE 전송 또는 timeout까지 지연될 수 있다.
+- 새로고침이나 일시적인 네트워크 단절도 SSE 연결이 종료된 동안에는 오프라인으로 본다. 재연결되면 다시 포함한다.
+- 온라인 여부와 명시적 퇴장 여부는 서로 다른 상태다. SSE 연결 종료만으로 참가자를 명시적 퇴장 처리하지 않는다.
 
 ## 2. 비범위 (YAGNI)
 
@@ -36,6 +45,7 @@ X-Participant-Token: <token>     # 비로그인 참가자
 
 - 로그인 사용자는 `Authorization: Bearer <jwt>` 헤더를, 비로그인 참가자는 `X-Participant-Token: <participantToken>` 헤더를 사용한다. 둘 중 하나는 반드시 포함해야 한다.
 - 두 헤더가 모두 있으면 `Authorization` 헤더 우선.
+- 조회 권한은 기존 파티 참여 여부를 기준으로 검증한다. 호출자의 SSE 연결이 없더라도 조회할 수 있지만, 호출자는 응답 참여자 목록에 포함되지 않는다.
 
 ### Path Variable
 
@@ -81,9 +91,9 @@ X-Participant-Token: <token>     # 비로그인 참가자
 
 | 필드 | 타입 | 비고 |
 |---|---|---|
-| totalCount | Int | 현재 참가자 수 |
+| totalCount | Int | 현재 온라인 참여자 수 |
 | maxCount | Int | 상수 14 (`RealtimeParty.MAX_PARTICIPANTS`) |
-| participants | List | `joinOrder` 오름차순 |
+| participants | List | 현재 온라인 참여자 목록, `joinOrder` 오름차순 |
 | participants[].participantId | Long | 식별자 |
 | participants[].joinOrder | Int | 1..N, 서버가 `participant.id ASC` 기준으로 부여 |
 | participants[].nickname | String | `RealtimeParticipantProfile.nickname` |
@@ -116,6 +126,7 @@ GetPartyParticipantsUseCase        (application/usecase, @Transactional(readOnly
         │
         ├─ ParticipantService.requireCallerParticipantId(partyId, userId?, participantToken?) → Long  (인가 먼저)
         ├─ PartyService.requireRealtimeParty(partyId)        → RealtimeParty           (인가 후 파티 타입 검사)
+        ├─ RealtimePartyPresencePort.findOnlineParticipantTokens(partyId) → Set<String>
         ├─ ParticipantService.findOrderedProfiles(partyId)   → List<RealtimeParticipantProfile>
         └─ ImageRepository.findAllByTargetTypeAndTargetIdsOrderByTargetIdAndSortOrder(CHARACTER, ids)
 ```
@@ -124,6 +135,8 @@ GetPartyParticipantsUseCase        (application/usecase, @Transactional(readOnly
 
 - Controller → UseCase 만 호출
 - UseCase → 같은 feature 의 Service 조합 (`PartyService`, `ParticipantService`)
+- UseCase → `RealtimePartyPresencePort`를 통해 온라인 참여자 토큰 조회
+- 현재 단일 애플리케이션 인스턴스에서는 SSE emitter registry가 presence port를 구현한다.
 - Service → Service 호출 없음 (UseCase 가 조합)
 - UseCase 가 응답 DTO 변환 책임
 
@@ -140,6 +153,8 @@ GetPartyParticipantsUseCase        (application/usecase, @Transactional(readOnly
 | `party/application/dto/PartyParticipantsResult.kt` | 응답용 application DTO (envelope) |
 | `party/application/dto/PartyParticipantResult.kt` | 응답용 application DTO (item) |
 | `party/application/usecase/GetPartyParticipantsUseCase.kt` | 흐름 제어, @Transactional(readOnly) |
+| `party/application/port/RealtimePartyPresencePort.kt` | 현재 온라인 참여자 토큰 조회 경계 |
+| `chat/infrastructure/sse/SseRealtimePartyPresenceAdapter.kt` | SSE emitter registry 기반 presence 구현 |
 
 ### 수정
 
@@ -249,7 +264,11 @@ class GetPartyParticipantsUseCase(
         val callerParticipantId = participantService.requireCallerParticipantId(partyId, userId, participantToken)
         val party = partyService.requireRealtimeParty(partyId)
 
-        val profiles = participantService.findOrderedProfiles(partyId)
+        val onlineParticipantTokens = realtimePartyPresencePort.findOnlineParticipantTokens(partyId)
+        val profiles =
+            participantService
+                .findOrderedProfiles(partyId)
+                .filter { it.participantToken in onlineParticipantTokens }
         val characterIds = profiles.mapNotNull { it.character?.id }.distinct()
         val imageUrlByCharacterId =
             if (characterIds.isEmpty()) emptyMap()
@@ -294,12 +313,14 @@ class GetPartyParticipantsUseCase(
 
 | 케이스 | 기대 |
 |---|---|
-| 주최자 호출 (참가자 4명) | 200, `isOwner=true` 1건, 응답 순서 `joinOrder` 1..4 |
+| 주최자 포함 온라인 참가자 4명 | 200, `isOwner=true` 1건, 응답 순서 `joinOrder` 1..4 |
 | 일반 참가자 호출 | 200, 본인 `isMe=true` 1건만 |
 | `X-Participant-Token` 호출 (비로그인 참가자) | 200, 토큰 owner의 `isMe=true` |
 | 다른 파티의 `X-Participant-Token` 호출 | 403, PARTY_FORBIDDEN |
-| 참가자 1명만 (주최자 단독) | 200, totalCount=1 |
-| 참가자 14명 (가득) | 200, totalCount=14, maxCount=14 |
+| 주최자가 SSE 미연결 | 온라인 참가자 목록에서 주최자 제외 |
+| 호출자가 SSE 미연결 | 조회는 200, 온라인 참가자 목록에서 호출자 제외 |
+| 온라인 참가자 1명만 | 200, totalCount=1 |
+| 온라인 참가자 14명 (가득) | 200, totalCount=14, maxCount=14 |
 | 비참가자 호출 (JWT) | 403, PARTY_FORBIDDEN |
 | 비참가자가 PaperOnly 파티 호출 (JWT) | 403, PARTY_FORBIDDEN (인가 우선) |
 | 참가자가 PaperOnly 파티 호출 (JWT) | 400, PARTY_NOT_REALTIME |

--- a/src/main/kotlin/com/team2/server/chat/infrastructure/sse/SseEmitterRegistry.kt
+++ b/src/main/kotlin/com/team2/server/chat/infrastructure/sse/SseEmitterRegistry.kt
@@ -92,6 +92,12 @@ class SseEmitterRegistry {
 
     fun count(partyId: Long): Int = emitters[partyId]?.size ?: 0
 
+    fun findParticipantTokens(partyId: Long): Set<String> =
+        emitters[partyId]
+            .orEmpty()
+            .mapNotNull { emitterToToken[it] }
+            .toSet()
+
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     fun onBroadcast(event: SseBroadcastEvent) {
         broadcast(event.partyId, event.event, event.excludeToken)

--- a/src/main/kotlin/com/team2/server/chat/infrastructure/sse/SseRealtimePartyPresenceAdapter.kt
+++ b/src/main/kotlin/com/team2/server/chat/infrastructure/sse/SseRealtimePartyPresenceAdapter.kt
@@ -1,0 +1,12 @@
+package com.team2.server.chat.infrastructure.sse
+
+import com.team2.server.party.application.port.RealtimePartyPresencePort
+import org.springframework.stereotype.Component
+
+@Component
+class SseRealtimePartyPresenceAdapter(
+    private val sseEmitterRegistry: SseEmitterRegistry,
+) : RealtimePartyPresencePort {
+    override fun findOnlineParticipantTokens(partyId: Long): Set<String> =
+        sseEmitterRegistry.findParticipantTokens(partyId)
+}

--- a/src/main/kotlin/com/team2/server/party/api/ParticipantApi.kt
+++ b/src/main/kotlin/com/team2/server/party/api/ParticipantApi.kt
@@ -18,7 +18,7 @@ interface ParticipantApi {
     @Operation(
         summary = "파티 참여자 목록 조회",
         description = """
-실시간 파티 진행 기본화면용. 입장 순서로 정렬된 참여자 목록을 반환한다. RealtimeParty 전용, 참여자만 조회 가능.
+실시간 파티 진행 기본화면용. 현재 SSE에 연결된 참여자 목록을 입장 순서로 반환한다. RealtimeParty 전용, 참여자만 조회 가능.
 
 **인증**
 로그인 사용자는 `Authorization: Bearer {token}` 헤더를, 비로그인 참가자는 `X-Participant-Token: {participantToken}` 헤더를 사용한다. 둘 중 하나는 반드시 포함해야 한다.

--- a/src/main/kotlin/com/team2/server/party/api/dto/PartyParticipantsResponse.kt
+++ b/src/main/kotlin/com/team2/server/party/api/dto/PartyParticipantsResponse.kt
@@ -5,11 +5,11 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "파티 참여자 목록 응답")
 data class PartyParticipantsResponse(
-    @Schema(description = "현재 참여자 수", example = "4")
+    @Schema(description = "현재 온라인 참여자 수", example = "4")
     val totalCount: Int,
     @Schema(description = "최대 참여자 수", example = "14")
     val maxCount: Int,
-    @Schema(description = "입장 순서대로 정렬된 참여자 목록")
+    @Schema(description = "입장 순서대로 정렬된 온라인 참여자 목록")
     val participants: List<PartyParticipantResponse>,
 ) {
     companion object {

--- a/src/main/kotlin/com/team2/server/party/application/port/RealtimePartyPresencePort.kt
+++ b/src/main/kotlin/com/team2/server/party/application/port/RealtimePartyPresencePort.kt
@@ -1,0 +1,5 @@
+package com.team2.server.party.application.port
+
+interface RealtimePartyPresencePort {
+    fun findOnlineParticipantTokens(partyId: Long): Set<String>
+}

--- a/src/main/kotlin/com/team2/server/party/application/usecase/GetPartyParticipantsUseCase.kt
+++ b/src/main/kotlin/com/team2/server/party/application/usecase/GetPartyParticipantsUseCase.kt
@@ -4,6 +4,7 @@ import com.team2.server.common.image.application.port.ImageUrlPort
 import com.team2.server.common.image.entity.ImageTargetType
 import com.team2.server.party.application.dto.PartyParticipantResult
 import com.team2.server.party.application.dto.PartyParticipantsResult
+import com.team2.server.party.application.port.RealtimePartyPresencePort
 import com.team2.server.party.application.service.ParticipantService
 import com.team2.server.party.application.service.PartyService
 import com.team2.server.party.domain.entity.RealtimeParty
@@ -15,6 +16,7 @@ class GetPartyParticipantsUseCase(
     private val partyService: PartyService,
     private val participantService: ParticipantService,
     private val imageUrlPort: ImageUrlPort,
+    private val realtimePartyPresencePort: RealtimePartyPresencePort,
 ) {
     @Transactional(readOnly = true)
     fun invoke(
@@ -25,7 +27,11 @@ class GetPartyParticipantsUseCase(
         val callerParticipantId = participantService.requireCallerParticipant(partyId, userId, participantToken).id
         val party = partyService.requireRealtimeParty(partyId)
 
-        val profiles = participantService.findOrderedProfiles(partyId)
+        val onlineParticipantTokens = realtimePartyPresencePort.findOnlineParticipantTokens(partyId)
+        val profiles =
+            participantService
+                .findOrderedProfiles(partyId)
+                .filter { it.participantToken in onlineParticipantTokens }
         val characterIds = profiles.mapNotNull { it.character?.id }.distinct()
         val defaultImageByCharacterId = findCharacterImageUrls(characterIds, DEFAULT_CHARACTER_IMAGE_SORT_ORDER)
         val ownerImageByCharacterId = findCharacterImageUrls(characterIds, OWNER_CHARACTER_IMAGE_SORT_ORDER)

--- a/src/test/kotlin/com/team2/server/chat/infrastructure/sse/SseEmitterRegistryTest.kt
+++ b/src/test/kotlin/com/team2/server/chat/infrastructure/sse/SseEmitterRegistryTest.kt
@@ -34,6 +34,7 @@ class SseEmitterRegistryTest {
 
         registry.completeAll(1L)
         assertEquals(0, registry.count(1L))
+        assertEquals(emptySet(), registry.findParticipantTokens(1L))
     }
 
     @Test
@@ -53,6 +54,8 @@ class SseEmitterRegistryTest {
 
         assertEquals(1, registry.count(1L))
         assertEquals(1, registry.count(2L))
+        assertEquals(setOf("tok1"), registry.findParticipantTokens(1L))
+        assertEquals(setOf("tok2"), registry.findParticipantTokens(2L))
     }
 
     @Test
@@ -68,6 +71,7 @@ class SseEmitterRegistryTest {
 
         registry.unsubscribeByToken("tok")
         assertEquals(0, registry.count(1L))
+        assertEquals(emptySet(), registry.findParticipantTokens(1L))
     }
 
     @Test
@@ -86,6 +90,7 @@ class SseEmitterRegistryTest {
         registry.unsubscribeByToken("tok")
 
         assertEquals(0, registry.count(1L))
+        assertEquals(emptySet(), registry.findParticipantTokens(1L))
         assertEquals(0, emitter.completeCount)
     }
 

--- a/src/test/kotlin/com/team2/server/party/api/ParticipantControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/party/api/ParticipantControllerTest.kt
@@ -2,6 +2,7 @@ package com.team2.server.party.api
 
 import com.team2.server.auth.config.JwtProperties
 import com.team2.server.auth.jwt.JwtTokenProvider
+import com.team2.server.chat.infrastructure.sse.SseEmitterRegistry
 import com.team2.server.common.image.entity.Image
 import com.team2.server.common.image.entity.ImageTargetType
 import com.team2.server.common.image.persistence.ImageRepository
@@ -28,6 +29,7 @@ import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.context.annotation.Import
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 import java.time.LocalDateTime
 
 @SpringBootTest
@@ -44,6 +46,7 @@ class ParticipantControllerTest
         private val imageRepository: ImageRepository,
         private val userRepository: UserRepository,
         private val jwtProperties: JwtProperties,
+        private val sseEmitterRegistry: SseEmitterRegistry,
     ) {
         private val tokenProvider = JwtTokenProvider(jwtProperties)
 
@@ -56,12 +59,7 @@ class ParticipantControllerTest
 
         @BeforeEach
         fun setUp() {
-            realtimeParticipantProfileRepository.deleteAll()
-            participantRepository.deleteAll()
-            partyRepository.deleteAll()
-            imageRepository.deleteAll()
-            characterRepository.deleteAll()
-            userRepository.deleteAll()
+            clearData()
 
             owner = saveUser("participant-owner", "owner@e.com")
             member = saveUser("participant-member", "member@e.com")
@@ -117,6 +115,8 @@ class ParticipantControllerTest
                         character = character,
                     ),
                 )
+            connect(ownerParticipant)
+            connect(memberParticipant)
         }
 
         @Test
@@ -157,6 +157,61 @@ class ParticipantControllerTest
                     status { isOk() }
                     jsonPath("$.data.participants[0].isMe") { value(false) }
                     jsonPath("$.data.participants[1].isMe") { value(true) }
+                }
+        }
+
+        @Test
+        fun `주최자가 SSE에 연결되지 않았으면 온라인 참여자 목록에서 제외된다`() {
+            val ownerProfile =
+                realtimeParticipantProfileRepository.findByParticipantPartyIdAndParticipantIsCelebrantTrue(
+                    realtimeParty.id,
+                )!!
+            sseEmitterRegistry.unsubscribeByToken(ownerProfile.participantToken)
+            val token = tokenProvider.issue(member)
+
+            mockMvc
+                .get("/api/v1/parties/${realtimeParty.id}/participants") {
+                    header("Authorization", "Bearer $token")
+                }.andExpect {
+                    status { isOk() }
+                    jsonPath("$.data.totalCount") { value(1) }
+                    jsonPath("$.data.participants", hasSize<Any>(1))
+                    jsonPath("$.data.participants[0].nickname") { value("참가자A") }
+                    jsonPath("$.data.participants[0].isOwner") { value(false) }
+                    jsonPath("$.data.participants[0].isMe") { value(true) }
+                }
+        }
+
+        @Test
+        fun `호출자의 SSE 연결이 없어도 조회할 수 있지만 온라인 참여자 목록에서는 제외된다`() {
+            sseEmitterRegistry.unsubscribeByToken(memberProfile.participantToken)
+            val token = tokenProvider.issue(member)
+
+            mockMvc
+                .get("/api/v1/parties/${realtimeParty.id}/participants") {
+                    header("Authorization", "Bearer $token")
+                }.andExpect {
+                    status { isOk() }
+                    jsonPath("$.data.totalCount") { value(1) }
+                    jsonPath("$.data.participants", hasSize<Any>(1))
+                    jsonPath("$.data.participants[0].nickname") { value("주최자") }
+                    jsonPath("$.data.participants[0].isOwner") { value(true) }
+                    jsonPath("$.data.participants[0].isMe") { value(false) }
+                }
+        }
+
+        @Test
+        fun `온라인 참여자가 없어도 기존 참여자는 빈 목록을 조회할 수 있다`() {
+            sseEmitterRegistry.completeAll(realtimeParty.id)
+            val token = tokenProvider.issue(member)
+
+            mockMvc
+                .get("/api/v1/parties/${realtimeParty.id}/participants") {
+                    header("Authorization", "Bearer $token")
+                }.andExpect {
+                    status { isOk() }
+                    jsonPath("$.data.totalCount") { value(0) }
+                    jsonPath("$.data.participants", hasSize<Any>(0))
                 }
         }
 
@@ -283,6 +338,7 @@ class ParticipantControllerTest
             realtimeParticipantProfileRepository.save(
                 RealtimeParticipantProfile(participant = participant, nickname = "혼자", character = character),
             )
+            connect(participant)
             val token = tokenProvider.issue(soloOwner)
 
             mockMvc
@@ -321,6 +377,8 @@ class ParticipantControllerTest
             realtimeParticipantProfileRepository.save(
                 RealtimeParticipantProfile(participant = anonymousP, nickname = "익명", character = null),
             )
+            connect(ownerP)
+            connect(anonymousP)
             val token = tokenProvider.issue(owner)
 
             mockMvc
@@ -361,6 +419,7 @@ class ParticipantControllerTest
             realtimeParticipantProfileRepository.save(
                 RealtimeParticipantProfile(participant = ownerP, nickname = "주최자", character = character),
             )
+            connect(ownerP)
             val token = tokenProvider.issue(owner)
 
             mockMvc
@@ -371,6 +430,21 @@ class ParticipantControllerTest
                     jsonPath("$.data.participants[0].isOwner") { value(true) }
                     jsonPath("$.data.participants[0].characterImageUrl") { value("https://cdn/fallback.png") }
                 }
+        }
+
+        private fun connect(participant: Participant) {
+            val profile = realtimeParticipantProfileRepository.findByParticipant(participant)!!
+            sseEmitterRegistry.subscribe(participant.party.id, SseEmitter(5000L), profile.participantToken)
+        }
+
+        private fun clearData() {
+            partyRepository.findAll().forEach { sseEmitterRegistry.completeAll(it.id) }
+            realtimeParticipantProfileRepository.deleteAll()
+            participantRepository.deleteAll()
+            partyRepository.deleteAll()
+            imageRepository.deleteAll()
+            characterRepository.deleteAll()
+            userRepository.deleteAll()
         }
 
         private fun saveUser(


### PR DESCRIPTION
## 🔗 Issue
- closes #227

## 💬 Context
`GET /api/v1/parties/{partyId}/participants`가 현재 SSE 접속 여부와 무관하게 `hasLeft=false`인 전체 참여자를 반환해, 접속하지 않은 주최자도 온라인 참여자처럼 표시됐습니다.

온라인 상태와 명시적 퇴장 상태를 분리하고, 서버가 인지한 현재 SSE 연결을 온라인 참여자 기준으로 사용합니다. 별도 heartbeat는 이번 범위에 포함하지 않습니다.

## 🛠 Changes
- SSE emitter registry 기반 온라인 참여자 토큰 조회 port/adapter 추가
- 참여자 목록 응답을 현재 온라인 참여자만 포함하도록 필터링
- 주최자 미접속, 호출자 연결 종료, 온라인 참여자 0명 회귀 테스트 추가
- Swagger 및 참여자 목록 설계 문서의 온라인 참여자 계약 갱신

## 👀 Review Focus
- SSE 연결 상태를 `hasLeft`와 분리해 presence 기준으로 사용하는 구조가 적절한지
- SSE 연결이 없는 기존 참여자의 조회 권한은 유지하되 목록에서는 제외하는 정책이 적절한지
- 단일 애플리케이션 인스턴스 전제에서 in-memory registry 기반 구현이 적절한지

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 파티 참여자 목록 조회 API가 현재 온라인 상태인 참여자만 반환하도록 개선되었습니다.
  * 참여자 목록 응답의 `totalCount` 필드가 현재 온라인 참여자 수를 정확히 나타내도록 변경되었습니다.
  * 파티 입장 전 기본화면에서 실시간으로 활성 참여자를 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->