### PR TITLE
[Feat] 파티 참여자 목록에 캐릭터 썸네일 이미지 추가

### DIFF
--- a/src/main/kotlin/com/team2/server/party/api/dto/PartyParticipantResponse.kt
+++ b/src/main/kotlin/com/team2/server/party/api/dto/PartyParticipantResponse.kt
@@ -15,6 +15,8 @@ data class PartyParticipantResponse(
     val characterId: Long?,
     @Schema(description = "캐릭터 메인 이미지 URL", nullable = true)
     val characterImageUrl: String?,
+    @Schema(description = "캐릭터 썸네일 이미지 URL", nullable = true)
+    val thumbnailImageUrl: String?,
     @Schema(description = "파티 주최자 여부", example = "true")
     val isOwner: Boolean,
     @Schema(description = "파티 주인공 여부", example = "true")
@@ -30,6 +32,7 @@ data class PartyParticipantResponse(
                 nickname = result.nickname,
                 characterId = result.characterId,
                 characterImageUrl = result.characterImageUrl,
+                thumbnailImageUrl = result.thumbnailImageUrl,
                 isOwner = result.isOwner,
                 isCelebrant = result.isCelebrant,
                 isMe = result.isMe,

--- a/src/main/kotlin/com/team2/server/party/application/dto/PartyParticipantResult.kt
+++ b/src/main/kotlin/com/team2/server/party/application/dto/PartyParticipantResult.kt
@@ -6,6 +6,7 @@ data class PartyParticipantResult(
     val nickname: String,
     val characterId: Long?,
     val characterImageUrl: String?,
+    val thumbnailImageUrl: String?,
     val isOwner: Boolean,
     val isCelebrant: Boolean,
     val isMe: Boolean,

--- a/src/main/kotlin/com/team2/server/party/application/usecase/GetPartyParticipantsUseCase.kt
+++ b/src/main/kotlin/com/team2/server/party/application/usecase/GetPartyParticipantsUseCase.kt
@@ -34,6 +34,7 @@ class GetPartyParticipantsUseCase(
                 .filter { it.participantToken in onlineParticipantTokens }
         val characterIds = profiles.mapNotNull { it.character?.id }.distinct()
         val defaultImageByCharacterId = findCharacterImageUrls(characterIds, DEFAULT_CHARACTER_IMAGE_SORT_ORDER)
+        val thumbnailImageByCharacterId = findCharacterImageUrls(characterIds, THUMBNAIL_CHARACTER_IMAGE_SORT_ORDER)
         val ownerImageByCharacterId = findCharacterImageUrls(characterIds, OWNER_CHARACTER_IMAGE_SORT_ORDER)
 
         val items =
@@ -48,6 +49,7 @@ class GetPartyParticipantsUseCase(
                     nickname = profile.nickname,
                     characterId = characterId,
                     characterImageUrl = ownerImageUrl ?: characterId?.let { defaultImageByCharacterId[it] },
+                    thumbnailImageUrl = characterId?.let { thumbnailImageByCharacterId[it] },
                     isOwner = isOwner,
                     isCelebrant = participant.isCelebrant,
                     isMe = participant.id == callerParticipantId,
@@ -69,6 +71,7 @@ class GetPartyParticipantsUseCase(
     private companion object {
         // CHARACTER 이미지 sort_order — V2 시드: 기본(Shape=Default)=0, 썸네일(Shape=Circle)=1 / V8 시드: 주최자 꼬깔모자=2
         private const val DEFAULT_CHARACTER_IMAGE_SORT_ORDER = 0
+        private const val THUMBNAIL_CHARACTER_IMAGE_SORT_ORDER = 1
         private const val OWNER_CHARACTER_IMAGE_SORT_ORDER = 2
     }
 }

--- a/src/test/kotlin/com/team2/server/party/api/ParticipantControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/party/api/ParticipantControllerTest.kt
@@ -83,22 +83,9 @@ class ParticipantControllerTest
                 )
 
             val character = characterRepository.save(Character(name = "octopus"))
-            imageRepository.save(
-                Image(
-                    imageUrl = "https://cdn/char.png",
-                    targetType = ImageTargetType.CHARACTER,
-                    targetId = character.id,
-                    sortOrder = 0,
-                ),
-            )
-            imageRepository.save(
-                Image(
-                    imageUrl = "https://cdn/char-owner.png",
-                    targetType = ImageTargetType.CHARACTER,
-                    targetId = character.id,
-                    sortOrder = 2,
-                ),
-            )
+            saveCharacterImage(character.id, "https://cdn/char.png", sortOrder = 0)
+            saveCharacterImage(character.id, "https://cdn/char-thumbnail.png", sortOrder = 1)
+            saveCharacterImage(character.id, "https://cdn/char-owner.png", sortOrder = 2)
 
             val ownerParticipant =
                 participantRepository.save(Participant(party = realtimeParty, user = owner, isCelebrant = true))
@@ -137,12 +124,14 @@ class ParticipantControllerTest
                     jsonPath("$.data.participants[0].isCelebrant") { value(true) }
                     jsonPath("$.data.participants[0].isMe") { value(true) }
                     jsonPath("$.data.participants[0].characterImageUrl") { value("https://cdn/char-owner.png") }
+                    jsonPath("$.data.participants[0].thumbnailImageUrl") { value("https://cdn/char-thumbnail.png") }
                     jsonPath("$.data.participants[1].joinOrder") { value(2) }
                     jsonPath("$.data.participants[1].nickname") { value("참가자A") }
                     jsonPath("$.data.participants[1].isOwner") { value(false) }
                     jsonPath("$.data.participants[1].isCelebrant") { value(false) }
                     jsonPath("$.data.participants[1].isMe") { value(false) }
                     jsonPath("$.data.participants[1].characterImageUrl") { value("https://cdn/char.png") }
+                    jsonPath("$.data.participants[1].thumbnailImageUrl") { value("https://cdn/char-thumbnail.png") }
                 }
         }
 
@@ -430,6 +419,21 @@ class ParticipantControllerTest
                     jsonPath("$.data.participants[0].isOwner") { value(true) }
                     jsonPath("$.data.participants[0].characterImageUrl") { value("https://cdn/fallback.png") }
                 }
+        }
+
+        private fun saveCharacterImage(
+            characterId: Long,
+            imageUrl: String,
+            sortOrder: Int,
+        ) {
+            imageRepository.save(
+                Image(
+                    imageUrl = imageUrl,
+                    targetType = ImageTargetType.CHARACTER,
+                    targetId = characterId,
+                    sortOrder = sortOrder,
+                ),
+            )
         }
 
         private fun connect(participant: Participant) {

--- a/src/test/kotlin/com/team2/server/party/api/ParticipantControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/party/api/ParticipantControllerTest.kt
@@ -379,6 +379,7 @@ class ParticipantControllerTest
                     jsonPath("$.data.participants[1].nickname") { value("익명") }
                     jsonPath("$.data.participants[1].characterId") { value(nullValue()) }
                     jsonPath("$.data.participants[1].characterImageUrl") { value(nullValue()) }
+                    jsonPath("$.data.participants[1].thumbnailImageUrl") { value(nullValue()) }
                     jsonPath("$.data.participants[1].isOwner") { value(false) }
                     jsonPath("$.data.participants[1].isMe") { value(false) }
                 }
@@ -418,6 +419,7 @@ class ParticipantControllerTest
                     status { isOk() }
                     jsonPath("$.data.participants[0].isOwner") { value(true) }
                     jsonPath("$.data.participants[0].characterImageUrl") { value("https://cdn/fallback.png") }
+                    jsonPath("$.data.participants[0].thumbnailImageUrl") { value(nullValue()) }
                 }
         }
 


### PR DESCRIPTION
## 🔗 Issue
- closes #232

## 💬 Context
실시간 파티 참여자 목록(`GET /api/v1/parties/{partyId}/participants`) 응답에는 기존에 캐릭터 메인 이미지(`characterImageUrl`)만 내려가고 있었습니다. 클라이언트에서 참여자를 작은 원형 아바타 형태로 표현하려면 캐릭터의 썸네일(원형) 이미지가 별도로 필요해, 응답에 썸네일 URL을 함께 내려주도록 추가했습니다.

CHARACTER 이미지는 `sort_order`로 종류를 구분합니다 — `0`=메인, `1`=썸네일(원형), `2`=주최자 꼬깔모자. 이번 변경은 기존 메인/주최자 이미지 로직은 그대로 두고 `sort_order=1`(썸네일)을 추가로 조회해 매핑합니다.

## 🛠 Changes
- 참여자 응답 DTO(`PartyParticipantResponse`)와 UseCase 출력 모델(`PartyParticipantResult`)에 `thumbnailImageUrl` 필드 추가
- `GetPartyParticipantsUseCase`에서 캐릭터별 썸네일(`sort_order=1`) 이미지 URL을 조회해 매핑 (주최자/일반 구분 없이 동일 썸네일, 캐릭터 미선택 시 `null`)
- `ParticipantControllerTest`에 썸네일 정상 응답 + null 케이스(익명 참여자, 썸네일 row 부재 시 폴백 없음) 검증 추가

## 👀 Review Focus
- `GetPartyParticipantsUseCase`에서 `thumbnailImageUrl`은 메인 이미지와 달리 주최자 여부와 무관하게 `sort_order=1` 하나로만 매핑됩니다. 이 동작이 기획 의도와 맞는지 확인 부탁드립니다.
- 캐릭터 이미지 조회가 `sort_order` 0/1/2로 총 3회 호출됩니다. 참여자 최대 14명으로 bounded라 현재 영향은 작지만(N+1 아님, 쿼리 3개), 추후 `sort_order` 변형이 늘어나면 1회 조회 후 그룹핑으로 묶는 최적화를 고려할 수 있습니다.

## ⚠️ Side Effects
- **DB 마이그레이션**: 없음 (기존 시드 `sort_order=1` 썸네일 이미지 그대로 사용)
- **환경변수/설정**: 없음
- **의존성 변경**: 없음
- **API 변경(Breaking)**: 없음 — 응답에 `thumbnailImageUrl` 필드를 **추가만** 함 (기존 필드/시그니처 변경 없음, 하위 호환)
- **외부 시스템 영향**: 프론트엔드에서 신규 `thumbnailImageUrl` 필드 사용 가능 — 참여자 원형 아바타 표시에 활용 가능하도록 공유 필요
- **운영 작업**: 없음

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견