### PR TITLE
[Fix] 다가오는 파티 정렬 순서 개선

### DIFF
--- a/src/main/kotlin/com/team2/server/party/application/usecase/GetUpcomingPartiesUseCase.kt
+++ b/src/main/kotlin/com/team2/server/party/application/usecase/GetUpcomingPartiesUseCase.kt
@@ -23,6 +23,7 @@ class GetUpcomingPartiesUseCase(
             participantRepository.findNotEndedByUserId(
                 userId = userId,
                 startedAfter = now.minusDays(Party.ENDED_AFTER_DAYS),
+                now = now,
             )
         val inviteTokenByPartyId = findInviteTokenByPartyId(participants.map { it.party }, now)
 

--- a/src/main/kotlin/com/team2/server/party/infrastructure/persistence/ParticipantRepository.kt
+++ b/src/main/kotlin/com/team2/server/party/infrastructure/persistence/ParticipantRepository.kt
@@ -38,12 +38,16 @@ interface ParticipantRepository : JpaRepository<Participant, Long> {
         JOIN FETCH participant.party party
         WHERE participant.user.id = :userId
           AND party.startedAt > :startedAfter
-        ORDER BY party.startedAt ASC, participant.createdAt DESC, participant.id DESC
+        ORDER BY CASE WHEN party.startedAt > :now THEN 0 ELSE 1 END,
+                 CASE WHEN party.startedAt > :now THEN party.startedAt END ASC,
+                 CASE WHEN party.startedAt <= :now THEN party.startedAt END DESC,
+                 participant.id DESC
         """,
     )
     fun findNotEndedByUserId(
         userId: Long,
         startedAfter: LocalDateTime,
+        now: LocalDateTime,
     ): List<Participant>
 
     @Query(

--- a/src/test/kotlin/com/team2/server/party/api/MePartyControllerTest.kt
+++ b/src/test/kotlin/com/team2/server/party/api/MePartyControllerTest.kt
@@ -121,6 +121,45 @@ class MePartyControllerTest
         }
 
         @Test
+        fun `미시작 파티가 이미 시작한 파티보다 먼저 노출된다`() {
+            val user = saveUser("kakao-sort-order", "sort-order@kakao.local")
+            val token = tokenProvider.issue(user)
+            val now = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS)
+
+            val startedParty =
+                saveParty(
+                    PaperOnlyParty(
+                        ownerId = user.id,
+                        celebrantNickname = "이미시작",
+                        startedAt = now.minusDays(2),
+                    ),
+                    now.minusDays(3),
+                )
+            val futureParty =
+                saveParty(
+                    PaperOnlyParty(
+                        ownerId = user.id,
+                        celebrantNickname = "곧시작",
+                        startedAt = now.plusHours(1),
+                    ),
+                    now.minusHours(1),
+                )
+
+            saveParticipant(startedParty, user, createdAt = now.minusDays(3))
+            saveParticipant(futureParty, user, createdAt = now.minusHours(1))
+
+            mockMvc
+                .get("/api/v1/me/upcoming-parties") {
+                    header("Authorization", "Bearer $token")
+                }.andExpect {
+                    status { isOk() }
+                    jsonPath("$.data.length()") { value(2) }
+                    jsonPath("$.data[0].celebrantNickname") { value("곧시작") }
+                    jsonPath("$.data[1].celebrantNickname") { value("이미시작") }
+                }
+        }
+
+        @Test
         fun `유효한 초대 토큰이 없으면 inviteToken 은 null`() {
             val user = saveUser("kakao-upcoming-no-invite", "upcoming-no-invite@kakao.local")
             val token = tokenProvider.issue(user)


### PR DESCRIPTION
## 🔗 Issue
- closes #237

## 💬 Context
다가오는 파티 목록이 `startedAt ASC`로 정렬되어, 며칠 전에 시작한 파티가 맨 위에 노출되고 곧 시작할 파티가 아래로 밀리는 문제가 있었습니다.
미시작 파티를 우선 노출하고, 이미 시작한 파티는 후순위로 정렬하도록 개선합니다.

## 🛠 Changes
- `ParticipantRepository.findNotEndedByUserId` 쿼리에 CASE 기반 정렬 적용 (미시작 파티 ASC → 시작된 파티 DESC)
- `GetUpcomingPartiesUseCase`에서 `now` 파라미터 전달
- 미시작 파티가 시작된 파티보다 먼저 노출되는 테스트 추가

## 👀 Review Focus
- JPQL CASE 정렬 표현식이 의도대로 동작하는지

## ✅ Check List
- [x] Assignees 등록
- [x] Label 등록
- [x] CI 통과 확인

---
> **Comment prefix** — P1: 필수 반영 / P2: 적극 고려 / P3: 사소한 의견